### PR TITLE
Add an autotools system to enable easier packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+Makefile.in
+aclocal.m4
+autom4te.cache/
+configure
+install-sh
+missing
+Makefile
+config.log
+config.status

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,33 @@
+ICON_DIRS = \
+	actions \
+	mimes \
+	categories \
+	devices \
+	emotes \
+	cursors \
+	places \
+	status \
+	emblems \
+	apps
+
+EXTRA_DIST = \
+	$(ICON_DIRS) \
+	AUTHORS \
+	COPYING \
+	index.theme \
+	cursor.theme \
+	README.md
+
+themedir = $(datadir)/icons/elementary
+theme_DATA = \
+	index.theme \
+	cursor.theme
+
+install-data-hook:
+	test -d $(DESTDIR)$(themedir) || $(MKDIR_P) $(DESTDIR)$(themedir) ;
+	for iconset in $(ICON_DIRS) ; do \
+		cp -Rv $$iconset $(DESTDIR)$(themedir)/. ; \
+		ln -sv $$iconset $(DESTDIR)$(themedir)/$$iconset@2x ; \
+	done;
+uninstall-hook:
+	test -d $(DESTDIR)$(themedir) && rm -rvf $(DESTDIR)$(themedir)

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+autoreconf --force --install --symlink --warnings=all
+
+if test -z "${NOCONFIGURE}"; then
+    set -x
+    ./configure --prefix=/usr "$@"
+    make clean
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,17 @@
+AC_INIT([elementary-icon-theme], 3.2.2, [https://github.com/elementary/icons/issues], [elementary-icon-theme], [https://elementary.io//])
+AM_INIT_AUTOMAKE([-Wno-portability no-dist-gzip dist-xz foreign subdir-objects 1.9 tar-pax])
+AC_PREFIX_DEFAULT(/usr/local)
+AM_SILENT_RULES([yes])
+
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT
+
+AC_MSG_RESULT([
+        Elementary Icon Theme $VERSION
+        ========
+
+        prefix:                 ${prefix}
+        exec_prefix:            ${exec_prefix}
+        datarootdir:            ${datarootdir}
+])


### PR DESCRIPTION
This makes it far easier for us to manage and distribute the icon theme, as it's appearing in quite a few repos :)

If/when this is merged, remember to edit the version number in `configure.ac` to reflect the current version of the package, then git add/git commit that change, and pop a git tag in for this version.

With that done, you can actually generate distributable source tarballs for elementary-icon-theme as follows:

```
./autogen.sh
make distcheck
```

GitHub allows you to edit the tags after pushing them, so you can actually upload this `elementary-icon-theme-$VERSION.tar.xz` for people to use as the formally distributed tarball. This ensures its complete, and usable in building packages.

Cheers :)

N.B I decided to recreate the `@2x` symlinks during the autotools install, much cleaner this way, and doesn't bork tarballs.