### PR TITLE
drop dialog-close/cancel/no

### DIFF
--- a/actions/16/dialog-cancel.svg
+++ b/actions/16/dialog-cancel.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/actions/16/dialog-close.svg
+++ b/actions/16/dialog-close.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/actions/16/dialog-no.svg
+++ b/actions/16/dialog-no.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/actions/48/dialog-cancel.svg
+++ b/actions/48/dialog-cancel.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/actions/48/dialog-close.svg
+++ b/actions/48/dialog-close.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/actions/48/dialog-no.svg
+++ b/actions/48/dialog-no.svg
@@ -1,1 +1,0 @@
-window-close.svg


### PR DESCRIPTION
As far as I know, these are basically vestiges from the days when dialog buttons had icons. Pretty sure it's safe to drop them