### PR TITLE
Match 48px color batteries with symbolic

### DIFF
--- a/status/48/battery-full-charged.svg
+++ b/status/48/battery-full-charged.svg
@@ -196,52 +196,6 @@
          style="stop-color:#1d7e0d;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3846-7">
-      <stop
-         offset="0"
-         style="stop-color:#fff3cb;stop-opacity:1"
-         id="stop3848-7" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fdde76;stop-opacity:1"
-         id="stop3850-5" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#f9c440;stop-opacity:1"
-         id="stop3852-9" />
-      <stop
-         offset="1"
-         style="stop-color:#e48b20;stop-opacity:1"
-         id="stop3854-2" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-0.25003053,6.0175179)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5126"
-       id="linearGradient3089"
-       y2="16.787233"
-       x2="27"
-       y1="9"
-       x1="27" />
-    <linearGradient
-       gradientTransform="matrix(0.50704097,0,0,0.50651113,78.588569,13.480075)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3846-7"
-       id="linearGradient3133-5"
-       y2="55.341991"
-       x2="-109.56079"
-       y1="-13.931436"
-       x1="-109.56079" />
-    <linearGradient
-       gradientTransform="translate(0.90741738,5.9834753)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5126"
-       id="linearGradient3089-4"
-       y2="28.377226"
-       x2="27"
-       y1="17.058283"
-       x1="27" />
   </defs>
   <path
      d="M 40,42.5 A 16,4.5 0 0 1 7.9999998,42.5 16,4.5 0 1 1 40,42.5 z"
@@ -278,9 +232,9 @@
      style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate" />
   <path
      d="m 24,6.5 c -3.709888,0 -7.052717,0.1725241 -9.4375,0.4375 -1.192392,0.132488 -2.155165,0.2807189 -2.75,0.4375 -0.16358,0.043115 -0.213184,0.056865 -0.3125,0.09375 l 0,35.0625 c 0.09932,0.03688 0.14892,0.05063 0.3125,0.09375 0.594835,0.156781 1.557608,0.305012 2.75,0.4375 C 16.947283,43.327476 20.290112,43.5 24,43.5 c 3.709888,0 7.052717,-0.172524 9.4375,-0.4375 1.192392,-0.132488 2.155165,-0.280719 2.75,-0.4375 0.16358,-0.04312 0.213184,-0.05687 0.3125,-0.09375 l 0,-35.0625 C 36.400684,7.4318648 36.35108,7.4181148 36.1875,7.375 35.592665,7.2182189 34.629892,7.069988 33.4375,6.9375 31.052717,6.6725241 27.709888,6.5 24,6.5 z"
+     transform="matrix(0.92,0,0,1,1.92,0)"
      id="path4752"
-     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient4760);stroke-width:1.04257202;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate"
-     transform="matrix(0.92,0,0,1,1.92,0)" />
+     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient4760);stroke-width:1.04257202;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate" />
   <rect
      width="25"
      height="39"
@@ -307,25 +261,4 @@
      d="M 35.969003,9.564443 C 34.420917,8.947168 29.661637,8.5 24,8.5 18.35733,8.5 13.61098,8.944177 12.046663,9.558245"
      id="rect3268-0-7"
      style="opacity:0.2;color:#000000;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.05;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path4370"
-     d="m 20.707031,14.996094 a 1.0045446,1.0045446 0 0 0 -0.951172,0.683594 l -3.707031,11 A 1.0045446,1.0045446 0 0 0 17,28.003906 l 5.644531,0 -2.40625,9.75586 a 1.0045446,1.0045446 0 0 0 1.796875,0.816406 l 9.78711,-14 A 1.0045446,1.0045446 0 0 0 31,22.996094 l -5.035156,0 3.679687,-6.501953 a 1.0045446,1.0045446 0 0 0 -0.875,-1.498047 l -8.0625,0 z" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-     id="path4370-5"
-     d="m 20.707031,14.996094 a 1.0045446,1.0045446 0 0 0 -0.951172,0.683594 l -3.707031,11 A 1.0045446,1.0045446 0 0 0 17,28.003906 l 5.644531,0 -2.40625,9.75586 a 1.0045446,1.0045446 0 0 0 1.796875,0.816406 l 9.78711,-14 A 1.0045446,1.0045446 0 0 0 31,22.996094 l -5.035156,0 3.679687,-6.501953 a 1.0045446,1.0045446 0 0 0 -0.875,-1.498047 l -8.0625,0 z"
-     transform="translate(0,-1.0014822)" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3133-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="path2911"
-     d="m 28.769428,14.999999 -4.526732,8 6.757304,0 L 21.212031,37 23.925983,26 17,26 l 3.706427,-11.000001 8.063001,0 0,0 z" />
-  <path
-     style="display:inline;opacity:0.6;fill:none;stroke:url(#linearGradient3089);stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-     id="path4162"
-     d="M 23.70596,22.902883 27.912108,15.5 l -6.830638,0 -3.473618,10.179342" />
-  <path
-     style="display:inline;opacity:0.6;fill:none;stroke:url(#linearGradient3089-4);stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-     id="path4162-0"
-     d="M 22.656631,34.097447 30.026292,23.50743 24.201806,23.49257" />
 </svg>

--- a/status/48/battery-full-charging.svg
+++ b/status/48/battery-full-charging.svg
@@ -66,31 +66,12 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-1">
-      <stop
-         id="stop3750-8-9-7"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-2-4"
-         style="stop-color:#42baea;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-7-2-4"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-9-3-7"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        x1="-5.0010252"
        y1="35"
        x2="46.68"
        y2="35"
        id="linearGradient4393"
-       xlink:href="#linearGradient4223"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-1"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.92592593,0,0,1.9473684,1.7777778,-42.157895)" />
     <linearGradient
@@ -154,153 +135,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1,0,0,0.42857143,0,4.2857143)" />
     <linearGradient
-       id="linearGradient3957-2">
-      <stop
-         id="stop3959-62"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3961-5"
-         style="stop-color:#c1c1c1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="21.013996"
-       y1="25.433903"
-       x2="22.805599"
-       y2="27.343702"
-       id="linearGradient3963-7"
-       xlink:href="#linearGradient3957-2"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       x1="24"
-       y1="22"
-       x2="24"
-       y2="26"
-       id="linearGradient3963"
-       xlink:href="#linearGradient3957"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       x1="27.92535"
-       y1="15.149301"
-       x2="33.447899"
-       y2="22.986004"
-       id="linearGradient3951"
-       xlink:href="#linearGradient4168"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3018"
-       xlink:href="#linearGradient3820-7-2-1-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27083381,0,0,0.08762273,52.308147,25.428863)" />
-    <radialGradient
-       cx="3.9722471"
-       cy="8.4497671"
-       r="19.99999"
-       fx="3.9722471"
-       fy="8.4497671"
-       id="radialGradient3015"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,2.4988347,-2.6434689,-6.8014435e-8,46.336814,-12.180468)" />
-    <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3012"
-       xlink:href="#linearGradient4011-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.7279009)" />
-    <linearGradient
-       id="linearGradient3820-7-2-1-2">
-      <stop
-         id="stop3822-2-6-3-3"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-7-9"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-5-0"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-5">
-      <stop
-         id="stop3750-8-9-6"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-2-5"
-         style="stop-color:#42baea;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-7-2-5"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-9-3-4"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4011-8">
-      <stop
-         id="stop4013-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4015-1"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
-      <stop
-         id="stop4017-0"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456558" />
-      <stop
-         id="stop4019-7"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3957">
-      <stop
-         id="stop3959"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3961"
-         style="stop-color:#c1c1c1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4168">
-      <stop
-         id="stop4170"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4172"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.23208089" />
-      <stop
-         id="stop4174"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.5908742" />
-      <stop
-         id="stop4176"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient3820-7-2-1-2-6">
       <stop
          id="stop3822-2-6-3-3-7"
@@ -344,317 +178,22 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.4666658,0,0,2.0811612,-6.0666553,-30.333874)" />
     <linearGradient
-       x1="30.271185"
-       y1="10.028973"
-       x2="30.271185"
-       y2="55.052982"
-       id="linearGradient3060"
-       xlink:href="#linearGradient27416-1-2-0-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1155865,0,0,3.8509774,61.40076,-219.77227)" />
-    <linearGradient
-       x1="30.271185"
-       y1="10.028973"
-       x2="30.271185"
-       y2="55.052982"
-       id="linearGradient3052"
-       xlink:href="#linearGradient27416-1-2-0-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1155865,0,0,3.8509774,61.40076,-219.77227)" />
-    <linearGradient
-       id="linearGradient27416-1-2-0-1">
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-1">
       <stop
-         id="stop27420-2-0-8-7"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop27422-3-5-3-3"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="30.271185"
-       y1="10.028973"
-       x2="30.271185"
-       y2="55.052982"
-       id="linearGradient2995"
-       xlink:href="#linearGradient27416-1-2-0-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1155865,0,0,3.8509774,177.06178,-159.44552)" />
-    <linearGradient
-       id="linearGradient3957-2-4">
-      <stop
-         id="stop3959-62-0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3961-5-9"
-         style="stop-color:#c1c1c1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="21.013996"
-       y1="25.433903"
-       x2="22.805599"
-       y2="27.343702"
-       id="linearGradient3963-7-3"
-       xlink:href="#linearGradient3957-2-4"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       x1="24"
-       y1="22"
-       x2="24"
-       y2="26"
-       id="linearGradient3963-2"
-       xlink:href="#linearGradient3957-9"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       x1="27.92535"
-       y1="15.149301"
-       x2="33.447899"
-       y2="22.986004"
-       id="linearGradient3951-6"
-       xlink:href="#linearGradient4168-2"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3018-4"
-       xlink:href="#linearGradient3820-7-2-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27083381,0,0,0.08762273,-2.855072,25.187228)" />
-    <radialGradient
-       cx="3.9722471"
-       cy="8.4497671"
-       r="19.99999"
-       fx="3.9722471"
-       fy="8.4497671"
-       id="radialGradient3015-0"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,2.4988347,-2.6434689,-6.8014435e-8,46.336814,-12.180468)" />
-    <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3012-5"
-       xlink:href="#linearGradient4011"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.7279009)" />
-    <linearGradient
-       id="linearGradient3820-7-2-1">
-      <stop
-         id="stop3822-2-6-3"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-7"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-5"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
-      <stop
-         id="stop3750-8-9"
+         id="stop3750-8-9-7"
          style="stop-color:#90dbec;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3752-3-2"
+         id="stop3752-3-2-4"
          style="stop-color:#42baea;stop-opacity:1"
          offset="0.26238" />
       <stop
-         id="stop3754-7-2"
+         id="stop3754-7-2-4"
          style="stop-color:#3689e6;stop-opacity:1"
          offset="0.704952" />
       <stop
-         id="stop3756-9-3"
+         id="stop3756-9-3-7"
          style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4011">
-      <stop
-         id="stop4013"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4015"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
-      <stop
-         id="stop4017"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456558" />
-      <stop
-         id="stop4019"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3957-9">
-      <stop
-         id="stop3959-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3961-7"
-         style="stop-color:#c1c1c1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4168-2">
-      <stop
-         id="stop4170-7"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4172-7"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.23208089" />
-      <stop
-         id="stop4174-1"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.5908742" />
-      <stop
-         id="stop4176-9"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4526">
-      <stop
-         id="stop4528"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4223">
-      <stop
-         id="stop4225"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4227"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop4229"
-         style="stop-color:#68b723;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop4231"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="6.7304144"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.2001843"
-       fy="9.9571075"
-       id="radialGradient4144"
-       xlink:href="#linearGradient4223"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,9.4975523,-11.65996,0,140.93055,-79.160972)" />
-    <linearGradient
-       x1="23.99999"
-       y1="6.1111298"
-       x2="23.99999"
-       y2="41.890972"
-       id="linearGradient3153"
-       xlink:href="#linearGradient4187"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(1.17e-5,1.00001)" />
-    <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient4395"
-       xlink:href="#linearGradient3702-501-757-6-946"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3702-501-757-6-946">
-      <stop
-         id="stop3228"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop3230"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3232"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3688-464-309-8-331">
-      <stop
-         id="stop3222"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3224"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3015-826"
-       xlink:href="#linearGradient3688-464-309-8-331"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749-2-324">
-      <stop
-         id="stop3216"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3218"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3013-896"
-       xlink:href="#linearGradient3688-166-749-2-324"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient4187">
-      <stop
-         id="stop4189"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4191"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.02099473" />
-      <stop
-         id="stop4193"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.97696" />
-      <stop
-         id="stop4195"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
   </defs>
@@ -670,11 +209,7 @@
      x="11.5"
      y="7.5"
      id="rect3268-0-1"
-     style="color:#000000;fill:url(#linearGradient4393);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     d="M 36.5,9 C 36.5,8.169 30.925,7.5 24,7.5 17.075,7.5 11.5,8.169 11.5,9"
-     id="rect3268-0"
-     style="opacity:0.5;color:#000000;fill:none;stroke:#0f7d00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:url(#linearGradient4393);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
      d="M 24,5.5 C 17.075,5.5 11.5,6.169 11.5,7 l 0,2 c 0,-0.831 5.575,-1.5 12.5,-1.5 6.925,0 12.5,0.669 12.5,1.5 l 0,-2 C 36.5,6.169 30.925,5.5 24,5.5 z"
      id="rect3268-6-4"
@@ -682,7 +217,7 @@
   <path
      d="M 11.5,9 C 11.5,8.169 17.075,7.5 24,7.5 30.925,7.5 36.5,8.169 36.5,9"
      id="rect3268-6"
-     style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate" />
+     style="opacity:0.5;color:#000000;fill:#000000;stroke:#00537d;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:0;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
   <path
      d="m 27.5,5.5625 0,-1.21875 C 27.5,3.8749017 25.939,3.5 24,3.5 c -1.939,0 -3.5,0.3749017 -3.5,0.84375 l 0,1.21875"
      id="rect3268-3-9"
@@ -693,9 +228,9 @@
      style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate" />
   <path
      d="m 24,6.5 c -3.709888,0 -7.052717,0.1725241 -9.4375,0.4375 -1.192392,0.132488 -2.155165,0.2807189 -2.75,0.4375 -0.16358,0.043115 -0.213184,0.056865 -0.3125,0.09375 l 0,35.0625 c 0.09932,0.03688 0.14892,0.05063 0.3125,0.09375 0.594835,0.156781 1.557608,0.305012 2.75,0.4375 C 16.947283,43.327476 20.290112,43.5 24,43.5 c 3.709888,0 7.052717,-0.172524 9.4375,-0.4375 1.192392,-0.132488 2.155165,-0.280719 2.75,-0.4375 0.16358,-0.04312 0.213184,-0.05687 0.3125,-0.09375 l 0,-35.0625 C 36.400684,7.4318648 36.35108,7.4181148 36.1875,7.375 35.592665,7.2182189 34.629892,7.069988 33.4375,6.9375 31.052717,6.6725241 27.709888,6.5 24,6.5 z"
-     transform="matrix(0.92,0,0,1,1.92,0)"
      id="path4752"
-     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient4760);stroke-width:1.04257202;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate" />
+     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient4760);stroke-width:1.04257202;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate"
+     transform="matrix(0.92,0,0,1,1.92,0)" />
   <rect
      width="25"
      height="39"
@@ -728,10 +263,10 @@
     <path
        d="m 28.769428,15.999999 -4.526732,8 6.757304,0 L 21.212031,38 23.925983,27 17,27 l 3.706427,-11.000001 8.063001,0 0,0 z"
        id="path3419"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;enable-background:new" />
     <path
        d="m 28.769428,14.999999 -4.526732,8 6.757304,0 L 21.212031,37 23.925983,26 17,26 l 3.706427,-11.000001 8.063001,0 0,0 z"
        id="path2911"
-       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
   </g>
 </svg>

--- a/status/48/battery-full.svg
+++ b/status/48/battery-full.svg
@@ -71,7 +71,7 @@
        x2="46.68"
        y2="35"
        id="linearGradient4393"
-       xlink:href="#linearGradient4223"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-1"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.92592593,0,0,1.9473684,1.7777778,-42.157895)" />
     <linearGradient
@@ -178,22 +178,22 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.4666658,0,0,2.0811612,-6.0666553,-30.333874)" />
     <linearGradient
-       id="linearGradient4223">
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-1">
       <stop
-         id="stop4225"
-         style="stop-color:#cdf87e;stop-opacity:1"
+         id="stop3750-8-9-7"
+         style="stop-color:#90dbec;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4227"
-         style="stop-color:#a2e34f;stop-opacity:1"
+         id="stop3752-3-2-4"
+         style="stop-color:#42baea;stop-opacity:1"
          offset="0.26238" />
       <stop
-         id="stop4229"
-         style="stop-color:#68b723;stop-opacity:1"
-         offset="0.66093999" />
+         id="stop3754-7-2-4"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0.704952" />
       <stop
-         id="stop4231"
-         style="stop-color:#1d7e0d;stop-opacity:1"
+         id="stop3756-9-3-7"
+         style="stop-color:#2b63a0;stop-opacity:1"
          offset="1" />
     </linearGradient>
   </defs>
@@ -209,11 +209,7 @@
      x="11.5"
      y="7.5"
      id="rect3268-0-1"
-     style="color:#000000;fill:url(#linearGradient4393);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     d="M 36.5,9 C 36.5,8.169 30.925,7.5 24,7.5 17.075,7.5 11.5,8.169 11.5,9"
-     id="rect3268-0"
-     style="opacity:0.5;color:#000000;fill:none;stroke:#0f7d00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:url(#linearGradient4393);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
      d="M 24,5.5 C 17.075,5.5 11.5,6.169 11.5,7 l 0,2 c 0,-0.831 5.575,-1.5 12.5,-1.5 6.925,0 12.5,0.669 12.5,1.5 l 0,-2 C 36.5,6.169 30.925,5.5 24,5.5 z"
      id="rect3268-6-4"
@@ -221,7 +217,7 @@
   <path
      d="M 11.5,9 C 11.5,8.169 17.075,7.5 24,7.5 30.925,7.5 36.5,8.169 36.5,9"
      id="rect3268-6"
-     style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate" />
+     style="opacity:0.5;color:#000000;fill:#000000;stroke:#00537d;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:0;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
   <path
      d="m 27.5,5.5625 0,-1.21875 C 27.5,3.8749017 25.939,3.5 24,3.5 c -1.939,0 -3.5,0.3749017 -3.5,0.84375 l 0,1.21875"
      id="rect3268-3-9"
@@ -232,9 +228,9 @@
      style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate" />
   <path
      d="m 24,6.5 c -3.709888,0 -7.052717,0.1725241 -9.4375,0.4375 -1.192392,0.132488 -2.155165,0.2807189 -2.75,0.4375 -0.16358,0.043115 -0.213184,0.056865 -0.3125,0.09375 l 0,35.0625 c 0.09932,0.03688 0.14892,0.05063 0.3125,0.09375 0.594835,0.156781 1.557608,0.305012 2.75,0.4375 C 16.947283,43.327476 20.290112,43.5 24,43.5 c 3.709888,0 7.052717,-0.172524 9.4375,-0.4375 1.192392,-0.132488 2.155165,-0.280719 2.75,-0.4375 0.16358,-0.04312 0.213184,-0.05687 0.3125,-0.09375 l 0,-35.0625 C 36.400684,7.4318648 36.35108,7.4181148 36.1875,7.375 35.592665,7.2182189 34.629892,7.069988 33.4375,6.9375 31.052717,6.6725241 27.709888,6.5 24,6.5 z"
-     transform="matrix(0.92,0,0,1,1.92,0)"
      id="path4752"
-     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient4760);stroke-width:1.04257202;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate" />
+     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient4760);stroke-width:1.04257202;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:accumulate"
+     transform="matrix(0.92,0,0,1,1.92,0)" />
   <rect
      width="25"
      height="39"


### PR DESCRIPTION
This updates the icons to match with the symbolic variants:
* No lightning on the full-charged state
* Don't change hue for the full and full-charging states