### PR TITLE
make audio-x-generic more generic

### DIFF
--- a/mimes/128/audio-x-generic.svg
+++ b/mimes/128/audio-x-generic.svg
@@ -9,246 +9,192 @@
    version="1.1"
    width="128"
    height="128"
-   id="svg3971">
+   id="svg3172">
   <defs
-     id="defs3973">
+     id="defs3174">
     <linearGradient
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615"
-       id="linearGradient3164"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2144204,0,0,3.4699564,10.750311,-67.821122)" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       id="linearGradient3977">
       <stop
-         id="stop2687-1-9"
+         id="stop3979"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.99999"
-       y1="5.6575165"
-       x2="23.99999"
-       y2="42.32058"
-       id="linearGradient3167"
-       xlink:href="#linearGradient3924"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135114,-62.513485)" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3928"
+         id="stop3981"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.00293467" />
+         offset="0" />
       <stop
-         id="stop3930"
+         id="stop3983"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99483037" />
+         offset="1" />
       <stop
-         id="stop3932"
+         id="stop3985"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3095-1-9"
-       xlink:href="#linearGradient3104-6-2-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0306977,0,0,2.2467814,153.04984,-60.977786)" />
-    <linearGradient
-       id="linearGradient3104-6-2-3">
+       id="linearGradient3600">
       <stop
-         id="stop3106-3-4-0"
-         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3108-9-9-2"
-         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749-737">
+      <stop
+         id="stop3088"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3090"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="5.6608582"
+       x2="23.99999"
+       y2="42.339119"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594559)" />
     <linearGradient
        x1="25.132275"
        y1="0.98520643"
        x2="25.132275"
        y2="47.013336"
-       id="linearGradient3101-2"
-       xlink:href="#linearGradient3600-9-9"
+       id="linearGradient3019"
+       xlink:href="#linearGradient3600"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4373971,0,0,2.3371711,5.5024661,-56.677922)" />
-    <linearGradient
-       id="linearGradient3600-9-9">
-      <stop
-         id="stop3602-3-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604-7-3"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient2455"
-       xlink:href="#linearGradient3688-166-749"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient2457"
-       xlink:href="#linearGradient3688-464-309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       gradientTransform="matrix(2.6571409,0,0,2.5422194,0.228619,-4.91283)" />
     <linearGradient
        x1="25.058096"
        y1="47.027729"
        x2="25.058096"
        y2="39.999443"
-       id="linearGradient2459"
-       xlink:href="#linearGradient3702-501-757"
-       gradientUnits="userSpaceOnUse" />
+       id="linearGradient3024"
+       xlink:href="#linearGradient3702-501-757-486"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1428572,0,0,1.2857143,-11.428573,61.571428)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3027"
+       xlink:href="#linearGradient3688-464-309-255"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,1.7999999,-32.014243,-195.8)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3030"
+       xlink:href="#linearGradient3688-166-749-737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,1.7999999,95.985757,39.200001)" />
     <linearGradient
-       id="linearGradient3702-501-757">
+       gradientTransform="matrix(2.0019317,0,0,2,10.971805,0.11407869)"
+       gradientUnits="userSpaceOnUse"
+       y2="59.1875"
+       x2="21.330717"
+       y1="0.69737434"
+       x1="21.330717"
+       id="linearGradient4179-5"
+       xlink:href="#linearGradient4417" />
+    <linearGradient
+       id="linearGradient4417">
       <stop
-         id="stop2895"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop4419" />
       <stop
-         id="stop2897"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#cc3b02;stop-opacity:1"
+         offset="1"
+         id="stop4421" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3976">
+     id="metadata3177">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     transform="translate(0,64)"
-     id="layer1">
-    <g
-       transform="matrix(2.9499988,0,0,1.2222234,-6.8000012,1.555538)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient2455);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient2457);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient2459);fill-opacity:1;stroke:none" />
-      </g>
-    </g>
-    <rect
-       width="102"
-       height="102"
-       x="13"
-       y="-48"
-       id="rect5505-21-8-4"
-       style="color:#000000;fill:url(#linearGradient3101-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="103"
-       height="103"
-       x="12.5"
-       y="-48.5"
-       id="rect5505-21"
-       style="color:#000000;fill:none;stroke:url(#linearGradient3095-1-9);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="101"
-       height="101"
-       x="13.5"
-       y="-47.5"
-       id="rect6741-7"
-       style="fill:none;stroke:url(#linearGradient3167);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-    <path
-       d="m 13,-47.999999 0.03394,64 C 15.968234,15.935552 112.7728,-7.591753 115,-8.723442 l 0,-39.276557 z"
-       id="path3333"
-       style="opacity:0.4;fill:url(#linearGradient3164);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="m 67.46875,-37.625315 c -3.07349,-0.242634 -2.375401,3.284773 -2.438582,5.322868 -0.02931,17.57529 0.01826,35.160623 -0.05906,52.729643 -1.245273,0.945953 -2.838741,0.101959 -4.545133,0.103108 -7.7338,0.404722 -15.594301,6.379596 -16.022366,14.492512 -0.394788,6.711785 7.007909,11.823965 13.278224,10.376525 7.660668,-1.22581 13.260651,-9.2276 12.193163,-16.837156 0.06611,-14.451712 -0.135918,-28.938286 0.09573,-43.368436 2.304856,-0.603545 4.473667,2.129086 6.466725,3.162794 5.810226,4.323062 9.982396,11.290287 9.459047,18.692978 -0.121483,4.5723 -1.347015,9.028022 -2.833998,13.325164 6.787346,-9.72715 7.731661,-23.794289 0.5501,-33.576885 -3.678586,-4.641827 -8.219736,-8.678912 -10.781331,-14.124984 -1.566564,-2.96771 -2.651123,-6.209963 -3.143769,-9.516881 -0.454821,-0.746753 -1.452291,-0.759655 -2.21875,-0.78125 z"
-       id="path3982-7"
-       style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none" />
-    <path
-       d="m 67.46875,-38.624663 c -3.07349,-0.242634 -2.375401,3.284773 -2.438582,5.322868 -0.02931,17.57529 0.01826,35.160623 -0.05906,52.729643 -1.245273,0.945953 -2.838741,0.101959 -4.545133,0.103108 -7.7338,0.404722 -15.594301,6.379596 -16.022366,14.492512 -0.394788,6.711783 7.007909,11.823973 13.278224,10.376533 7.660668,-1.22581 13.260651,-9.227604 12.193163,-16.837164 0.06611,-14.451712 -0.135918,-28.938286 0.09573,-43.368436 2.304856,-0.603545 4.473667,2.129086 6.466725,3.162794 5.810226,4.323061 9.982396,11.290287 9.459047,18.692978 -0.121483,4.5723 -1.347015,9.028022 -2.833998,13.325164 6.787346,-9.72715 7.731661,-23.794289 0.5501,-33.576885 -3.678586,-4.641827 -8.219736,-8.678912 -10.781331,-14.124984 -1.566564,-2.96771 -2.651123,-6.209963 -3.143769,-9.516881 -0.454821,-0.746753 -1.452291,-0.759655 -2.21875,-0.78125 z"
-       id="path3982"
-       style="opacity:0.2;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 67.46875,-37.624999 c -1.346474,0 -1.869098,0.376285 -2.15625,0.96875 -0.287152,0.592465 -0.28125,1.506966 -0.28125,2.46875 L 65,20.281251 a 0.37521267,0.37521267 0 0 1 -0.09375,0.25 c -0.217233,0.225998 -0.522926,0.348457 -0.78125,0.34375 -0.258324,-0.0047 -0.481731,-0.08132 -0.6875,-0.15625 -0.411537,-0.149864 -0.737268,-0.288539 -0.9375,-0.21875 a 0.37521267,0.37521267 0 0 1 -0.15625,0.03125 c -8.139139,-0.494041 -17.065023,5.40125 -17.875,13.84375 a 0.37521267,0.37521267 0 0 1 0,0.03125 c -0.470696,3.30959 1.053707,6.31927 3.5,8.40625 2.446293,2.08698 5.797465,3.20361 8.9375,2.6875 a 0.37521267,0.37521267 0 0 1 0.03125,0 c 8.004553,-0.84684 13.982654,-8.92232 12.9375,-16.875 a 0.37521267,0.37521267 0 0 1 0,-0.0625 c 0.02322,-14.379353 -0.05003,-28.782915 0.03125,-43.15625 a 0.37521267,0.37521267 0 0 1 0.09375,-0.25 c 0.225788,-0.257501 0.594326,-0.335442 0.875,-0.28125 0.280674,0.05419 0.517639,0.20085 0.75,0.34375 0.232361,0.1429 0.438145,0.288574 0.625,0.40625 0.186855,0.117676 0.354135,0.185141 0.375,0.1875 a 0.37521267,0.37521267 0 0 1 0.15625,0.0625 c 6.69292,3.943272 12.65864,10.441878 13.0625,18.625 0.379204,5.460852 -1.022455,10.792207 -2.78125,15.875 5.842631,-8.549713 7.472963,-20.050716 2.9375,-29.5 -2.492785,-5.894808 -8.220934,-9.605371 -11.5,-15.3125 -2.380965,-3.74992 -4.192388,-7.921864 -4.78125,-12.375 -0.0073,-0.01444 -0.02348,-0.01731 -0.03125,-0.03125 -0.179896,-0.322842 -0.476719,-0.504815 -0.875,-0.625 -0.415473,-0.125373 -0.908261,-0.161011 -1.34375,-0.15625 z"
-       id="path3982-9"
-       style="fill:none;stroke:none" />
-  </g>
+  <rect
+     width="6"
+     height="8.999999"
+     x="108"
+     y="113"
+     id="rect2801"
+     style="opacity:0.4;fill:url(#radialGradient3030);fill-opacity:1;stroke:none" />
+  <rect
+     width="6"
+     height="8.999999"
+     x="-20"
+     y="-122"
+     transform="scale(-1,-1)"
+     id="rect3696"
+     style="opacity:0.4;fill:url(#radialGradient3027);fill-opacity:1;stroke:none" />
+  <rect
+     width="88"
+     height="9"
+     x="20"
+     y="113"
+     id="rect3700"
+     style="opacity:0.4;fill:url(#linearGradient3024);fill-opacity:1;stroke:none" />
+  <path
+     d="m 17.499929,1.500412 c 21.311061,0 93.000031,0.007 93.000031,0.007 l 1.1e-4,116.992628 c 0,0 -62.0001,0 -93.00014,0 0,-39.000029 0,-78.000054 0,-117.000079 z"
+     id="path4160"
+     style="fill:url(#linearGradient3019);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 109.5,117.5 -91,0 0,-115.000003 91,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3016);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 17.499929,1.5004119 c 21.311061,0 93.000031,0.007 93.000031,0.007 l 1.1e-4,116.9926281 c 0,0 -62.0001,0 -93.00014,0 0,-39.000029 0,-78.000054 0,-117.0000791 z"
+     id="path4160-4"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4179-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path16590-0"
+     d="m 85.499147,28 -29.513339,7.621088 c -2.217019,0.593454 -4.001822,2.954324 -4.001822,5.247306 l 0,36.356339 c -2.248089,-1.176037 -5.135355,-1.651552 -8.128663,-0.874553 -5.401492,1.402123 -8.7863,5.933557 -7.628461,10.119806 1.157838,4.186253 6.478892,6.524492 11.880384,5.122371 4.309258,-1.118587 7.279765,-4.2836 7.753501,-7.621088 l 0.124921,-34.357365 28.012651,-7.496151 0,27.111083 C 81.75023,68.0528 78.862963,67.577285 75.869655,68.354287 c -5.401492,1.402119 -8.786299,5.933554 -7.628461,10.119803 1.157858,4.186253 6.478892,6.524493 11.880384,5.122373 C 84.430836,82.477877 87.526264,79.31286 88,75.975374 l 10e-7,-44.727042 c 0,-1.719758 -1.063848,-3.006416 -2.501134,-3.248332 z" />
 </svg>

--- a/mimes/16/audio-x-generic.svg
+++ b/mimes/16/audio-x-generic.svg
@@ -9,85 +9,45 @@
    version="1.1"
    width="16"
    height="16"
-   id="svg3917">
+   id="svg3810">
   <defs
-     id="defs3919">
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3863"
-       xlink:href="#linearGradient3104-6-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.25630299,0,0,0.28357583,19.23936,-0.0749084)" />
-    <linearGradient
-       id="linearGradient3104-6-2">
-      <stop
-         id="stop3106-3-4"
-         style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
-      <stop
-         id="stop3108-9-9"
-         style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
-    </linearGradient>
+     id="defs3812">
     <linearGradient
        x1="23.99999"
-       y1="7.13907"
+       y1="6.9230647"
        x2="23.99999"
-       y2="40.861012"
-       id="linearGradient3128"
-       xlink:href="#linearGradient3924-4-8"
+       y2="41.076912"
+       id="linearGradient3988"
+       xlink:href="#linearGradient3977"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486647,0.86486755)" />
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)" />
     <linearGradient
-       id="linearGradient3924-4-8">
+       id="linearGradient3977">
       <stop
-         id="stop3926-0-4"
+         id="stop3979"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3928-6-8"
+         id="stop3981"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.00677974" />
+         offset="0" />
       <stop
-         id="stop3930-2-1"
+         id="stop3983"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99050254" />
+         offset="1" />
       <stop
-         id="stop3932-9-0"
+         id="stop3985"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615"
-       id="linearGradient3137"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2605204,0,0,0.43374453,1.7353306,-0.4776389)" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       id="linearGradient3600">
       <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600-9-9">
-      <stop
-         id="stop3602-3-7"
+         id="stop3602"
          style="stop-color:#f4f4f4;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3604-7-3"
+         id="stop3604"
          style="stop-color:#dbdbdb;stop-opacity:1"
          offset="1" />
     </linearGradient>
@@ -96,57 +56,77 @@
        y1="0.98520643"
        x2="25.132275"
        y2="47.013336"
-       id="linearGradient3915"
-       xlink:href="#linearGradient3600-9-9"
+       id="linearGradient3806"
+       xlink:href="#linearGradient3600"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2867526,0,0,0.27496131,1.1179376,0.97906881)" />
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         id="stop3106-5"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         offset="0" />
+      <stop
+         id="stop3108-5"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3019"
+       xlink:href="#linearGradient3104-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
+    <linearGradient
+       id="linearGradient4417">
+      <stop
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop4419" />
+      <stop
+         style="stop-color:#cc3b02;stop-opacity:1"
+         offset="1"
+         id="stop4421" />
+    </linearGradient>
+    <linearGradient
+       y2="79.212646"
+       x2="21.736967"
+       y1="3.4214787"
+       x1="43.141579"
+       gradientTransform="matrix(0.2529987,-0.06188599,0.07145079,0.18134844,-4.1592307,2.5785007)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4236"
+       xlink:href="#linearGradient4417" />
   </defs>
   <metadata
-     id="metadata3922">
+     id="metadata3815">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <rect
-       width="12"
-       height="12"
-       x="2"
-       y="2"
-       id="rect5505-21-8-5"
-       style="color:#000000;fill:url(#linearGradient3915);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="M 2,2.0000005 2.00398,10 C 2.3491899,9.9919004 13.737978,7.0510311 14,6.9095702 l 0,-4.9095698 z"
-       id="path3333"
-       style="opacity:0.4;fill:url(#linearGradient3137);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="M 8.4460576,3.0009021 C 8.0205197,2.976884 7.9550899,3.4376629 8,3.7436676 L 8,9.7577102 C 7.7389486,9.7028553 7.3983308,9.7263068 7.1040162,9.8131512 6.2197099,10.048414 5.4335562,10.847877 5.5064711,11.768817 c 0.1021941,0.862408 1.1239334,1.425071 1.9662982,1.168943 0.9542645,-0.225906 1.5075441,-1.055033 1.5075441,-2.125189 l 0,-4.7611269 c 0.7927638,0.4191605 1.5066556,1.2024363 1.4903426,2.1252211 0.0086,0.6670359 -0.178415,1.3340719 -0.442652,1.9412628 -0.035555,0.0733 0.04188,0.14513 0.09903,0.172957 0.153015,0.04274 0.232515,-0.15786 0.318996,-0.25231 C 11.366989,8.8037934 11.426564,6.9891585 10.432523,5.7760095 10.079747,5.3452118 9.620324,4.9783104 9.379728,4.4779387 9.1388655,4.0930845 8.9862187,3.6576738 8.9120504,3.2185275 8.8148902,3.0597989 8.6296399,2.999443 8.4460576,3.0009021 z"
-       id="path3926-0"
-       style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="M 8.4460576,2.0009026 C 8.0205197,1.9768845 7.9550899,2.4376634 8,2.7436681 L 8,8.7577107 C 7.7389486,8.7028558 7.3983308,8.7263073 7.1040162,8.8131517 6.2197099,9.0484143 5.4335562,9.8478773 5.5064711,10.768818 c 0.1021941,0.862407 1.1239334,1.42507 1.9662982,1.168942 0.9542645,-0.225906 1.5075441,-1.055032 1.5075441,-2.1251887 l 0,-4.7611267 c 0.7927638,0.4191605 1.5066556,1.2024363 1.4903426,2.1252211 0.0086,0.6670359 -0.178415,1.3340719 -0.442652,1.9412626 -0.035555,0.0733 0.04188,0.14513 0.09903,0.172957 0.153015,0.04274 0.232515,-0.15786 0.318996,-0.25231 C 11.366989,7.8037939 11.426564,5.989159 10.432523,4.77601 10.079747,4.3452123 9.620324,3.9783109 9.379728,3.4779392 9.1388655,3.093085 8.9862187,2.6576743 8.9120504,2.218528 8.8148902,2.0597994 8.6296399,1.9994435 8.4460576,2.0009026 z"
-       id="path3926"
-       style="opacity:0.2;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="11"
-       height="11"
-       x="2.5"
-       y="2.5"
-       id="rect6741-0-3"
-       style="fill:none;stroke:url(#linearGradient3128);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-    <rect
-       width="13.000078"
-       height="13.000078"
-       x="1.4999609"
-       y="1.4999609"
-       id="rect5505-21-8-6"
-       style="color:#000000;fill:none;stroke:url(#linearGradient3863);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  </g>
+  <path
+     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none"
+     id="path4160"
+     d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1"
+     d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 Z" />
+  <path
+     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-8"
+     d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z" />
+  <path
+     id="path4192"
+     d="M 10.722656 4.0058594 C 10.668132 3.995603 10.608 3.9982973 10.544922 4.015625 L 6.4550781 5.1386719 C 6.2027663 5.2079828 6 5.4866719 6 5.7636719 L 6 6.3261719 L 6 6.609375 L 6 11.025391 A 0.98817231 1.5078181 82.261693 0 0 5.1308594 11.064453 A 0.98817231 1.5078181 82.261693 0 0 4.046875 12.355469 A 0.98817231 1.5078181 82.261693 0 0 5.8691406 12.935547 A 0.98817231 1.5078181 82.261693 0 0 6.9980469 11.849609 L 7 11.849609 L 7 6.8339844 L 10 6.0117188 L 10 10.025391 A 0.98817231 1.5078181 82.261693 0 0 9.1308594 10.064453 A 0.98817231 1.5078181 82.261693 0 0 8.046875 11.355469 A 0.98817231 1.5078181 82.261693 0 0 9.8691406 11.935547 A 0.98817231 1.5078181 82.261693 0 0 10.998047 10.882812 L 11 10.882812 L 11 5.2363281 L 11 4.390625 C 11 4.182875 10.886229 4.0366285 10.722656 4.0058594 z "
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4236);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0022527;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/24/audio-x-generic.svg
+++ b/mimes/24/audio-x-generic.svg
@@ -6,245 +6,177 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="24"
+   id="svg3828"
    height="24"
-   id="svg3979">
+   width="24"
+   version="1.1">
   <defs
-     id="defs3981">
+     id="defs3830">
     <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3114"
-       xlink:href="#linearGradient3104-6-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.37459597,0,0,0.4144562,28.426726,8.1982324)" />
-    <linearGradient
-       id="linearGradient3104-6-2">
+       id="linearGradient3977">
       <stop
-         id="stop3106-3-4"
-         style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
-      <stop
-         id="stop3108-9-9"
-         style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615"
-       id="linearGradient3135"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39077928,0,0,0.59639877,2.6029975,7.5932432)" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7-8">
-      <stop
-         id="stop2687-1-9-6"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3979" />
       <stop
-         id="stop2689-5-4-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.99999"
-       y1="6.6499596"
-       x2="23.99999"
-       y2="41.441586"
-       id="linearGradient3138"
-       xlink:href="#linearGradient3917"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,8.9717327)" />
-    <linearGradient
-       id="linearGradient3917">
-      <stop
-         id="stop3919"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3921"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.01020449" />
+         id="stop3981" />
       <stop
-         id="stop3923"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99008638" />
+         id="stop3983" />
       <stop
-         id="stop3925"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop3985" />
     </linearGradient>
     <linearGradient
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336"
-       id="linearGradient3125"
-       xlink:href="#linearGradient3600-9-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4301289,0,0,0.41244197,1.6769074,9.4686024)" />
-    <linearGradient
-       id="linearGradient3600-9-9">
+       id="linearGradient3600-4">
       <stop
-         id="stop3602-3-7"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-7" />
       <stop
-         id="stop3604-7-3"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-6" />
     </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3082"
-       xlink:href="#linearGradient3688-166-749"
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.526306"
+       x2="23.99999"
+       y1="6.4736748"
+       x1="23.99999" />
     <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3084"
-       xlink:href="#linearGradient3688-464-309"
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
-       id="linearGradient3688-464-309">
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient4417">
       <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop4419" />
       <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#cc3b02;stop-opacity:1"
+         offset="1"
+         id="stop4421" />
     </linearGradient>
     <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient3086"
-       xlink:href="#linearGradient3702-501-757"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3702-501-757">
-      <stop
-         id="stop2895"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       y2="84.235909"
+       x2="17.238106"
+       y1="25.439518"
+       x1="36.948124"
+       gradientTransform="matrix(0.33469959,-0.0946529,0.11219966,0.32923278,-5.7488173,-3.4071265)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4252"
+       xlink:href="#linearGradient4417" />
   </defs>
   <metadata
-     id="metadata3984">
+     id="metadata3833">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     transform="translate(0,-8)"
-     id="layer1">
-    <g
-       transform="matrix(0.55,0,0,0.3333336,-1.2000011,15.33331)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3082);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3084);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3086);fill-opacity:1;stroke:none" />
-      </g>
-    </g>
-    <rect
-       width="18"
-       height="18"
-       x="3.000001"
-       y="10.999999"
-       id="rect5505-21-8-5"
-       style="color:#000000;fill:url(#linearGradient3125);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="17"
-       height="17"
-       x="3.5012455"
-       y="11.498756"
-       id="rect6741-9"
-       style="fill:none;stroke:url(#linearGradient3138);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-    <path
-       d="M 3.5764341,11 C 3.2547127,11 3,11.418213 3,11.824999 L 3.00603,22 C 3.5238425,21.988917 20.606966,17.945168 21,17.750658 l 0,-5.925659 C 21,11.514064 20.748387,11 20.46981,11 L 3.576473,11 z"
-       id="path3333"
-       style="opacity:0.4;fill:url(#linearGradient3135);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="m 12.419632,14.004925 c -0.452724,-0.05278 -0.515415,0.329409 -0.468254,0.633497 -0.0043,3.025975 0.0086,6.054726 -0.0064,9.078969 -0.110572,0.10409 -0.322761,-0.0671 -0.463635,-0.02267 -1.5347133,-0.08429 -3.2115233,0.918377 -3.3649513,2.365375 -0.180821,1.15045 1.168324,2.097014 2.3714223,1.918082 1.515988,-0.144968 2.700362,-1.523417 2.502717,-2.884223 0.0043,-2.395978 -0.0086,-4.794731 0.0064,-7.188977 0.103332,-0.106629 0.257461,0.120399 0.366317,0.131537 1.219106,0.649916 2.297503,1.721652 2.370301,3.056315 0.08005,1.042897 -0.270433,2.063392 -0.664755,3.030213 1.321308,-1.465442 1.744289,-3.603233 0.826124,-5.334141 -0.469578,-1.004767 -1.528881,-1.623965 -2.121477,-2.557221 -0.437627,-0.623661 -0.770691,-1.319897 -0.874898,-2.05618 -0.0858,-0.153536 -0.311793,-0.172231 -0.478911,-0.170577 z"
-       id="path7249-8-0-4"
-       style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 12.419632,13.004924 c -0.452724,-0.05278 -0.515415,0.329409 -0.468254,0.633498 -0.0043,3.025974 0.0086,6.054724 -0.0064,9.078969 -0.110572,0.104088 -0.322761,-0.06711 -0.463635,-0.02267 -1.5347133,-0.08429 -3.2115233,0.918375 -3.3649513,2.365374 -0.180821,1.15045 1.168324,2.097014 2.3714223,1.918083 1.515988,-0.144969 2.700362,-1.523417 2.502717,-2.884224 0.0043,-2.395978 -0.0086,-4.79473 0.0064,-7.188976 0.103332,-0.106628 0.257461,0.120399 0.366317,0.131537 1.219106,0.649917 2.297503,1.721652 2.370301,3.056314 0.08005,1.042898 -0.270433,2.063392 -0.664755,3.030215 1.321308,-1.465445 1.744289,-3.603234 0.826124,-5.334142 -0.469578,-1.004766 -1.528881,-1.623966 -2.121477,-2.55722 -0.437627,-0.623662 -0.770691,-1.319898 -0.874898,-2.05618 -0.0858,-0.153536 -0.311793,-0.172232 -0.478911,-0.170578 z"
-       id="path7249-8-0"
-       style="opacity:0.2;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="19.000078"
-       height="19.000078"
-       x="2.4999619"
-       y="10.49996"
-       id="rect5505-21-8-6"
-       style="color:#000000;fill:none;stroke:url(#linearGradient3114);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  </g>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="22"
+     x="3.5000007"
+     height="2"
+     width="16.999998" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none"
+     id="path4160-3"
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
+  <path
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-3-1"
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
+  <path
+     id="path4192"
+     d="M 15.722656 7.0058594 C 15.668041 6.9952844 15.606152 6.9986658 15.542969 7.015625 L 10.457031 8.3808594 C 10.204297 8.4486961 10 8.7269063 10 9.0039062 L 10 10.607422 L 10 15.044922 A 1.5171451 2.0185373 78.171094 0 0 8.5097656 15.017578 A 1.5171451 2.0185373 78.171094 0 0 7.0605469 17.005859 A 1.5171451 2.0185373 78.171094 0 0 9.4902344 17.898438 A 1.5171451 2.0185373 78.171094 0 0 10.998047 16.291016 L 11 16.291016 L 11 10.837891 L 15 9.765625 L 15 14.044922 A 1.5171451 2.0185373 78.171094 0 0 13.509766 14.017578 A 1.5171451 2.0185373 78.171094 0 0 12.060547 16.005859 A 1.5171451 2.0185373 78.171094 0 0 14.490234 16.898438 A 1.5171451 2.0185373 78.171094 0 0 15.998047 15.291016 L 16 15.291016 L 16 8.9960938 L 16 7.3925781 C 16 7.1848281 15.886503 7.0375842 15.722656 7.0058594 z "
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4252);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00069865;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0" />
 </svg>

--- a/mimes/32/audio-x-generic.svg
+++ b/mimes/32/audio-x-generic.svg
@@ -8,10 +8,10 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   width="32"
+   id="svg3182"
    height="32"
-   id="svg3951"
+   width="32"
+   version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="audio-x-generic.svg">
   <sodipodi:namedview
@@ -23,251 +23,346 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="712"
-     id="namedview48"
+     inkscape:window-width="3200"
+     inkscape:window-height="1674"
+     id="namedview35"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="-0.48600775"
-     inkscape:cy="18.422574"
+     inkscape:zoom="2"
+     inkscape:cx="16"
+     inkscape:cy="16"
      inkscape:window-x="0"
-     inkscape:window-y="30"
+     inkscape:window-y="60"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3951" />
+     inkscape:current-layer="svg3182">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4190" />
+  </sodipodi:namedview>
   <defs
-     id="defs3953">
+     id="defs3184">
     <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3116"
-       xlink:href="#linearGradient3104-6-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.53231992,0,0,0.58896333,39.343211,-0.77091136)" />
-    <linearGradient
-       id="linearGradient3104-6-2">
+       id="linearGradient3977">
       <stop
-         id="stop3106-3-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="0.99999994"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.814808"
+       x2="23.99999"
+       y1="6.1851754"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
          style="stop-color:#000000;stop-opacity:0.31782946"
          offset="0" />
       <stop
-         id="stop3108-9-9"
+         id="stop3108-9"
          style="stop-color:#000000;stop-opacity:0.24031007"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615"
-       id="linearGradient3154"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.56446029,0,0,0.88104367,2.3718811,-1.9538595)" />
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6" />
     <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       id="linearGradient4417"
+       inkscape:collect="always">
       <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop4419"
+         offset="0"
+         style="stop-color:#ffa154;stop-opacity:1" />
       <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop4421"
+         offset="1"
+         style="stop-color:#cc3b02;stop-opacity:1" />
     </linearGradient>
+    <filter
+       id="filter7554"
+       color-interpolation-filters="sRGB">
+      <feBlend
+         mode="darken"
+         in2="BackgroundImage"
+         id="feBlend7556" />
+    </filter>
     <linearGradient
-       x1="23.99999"
-       y1="6.2929444"
-       x2="23.99999"
-       y2="41.851887"
-       id="linearGradient3157"
-       xlink:href="#linearGradient3924"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4419"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.67567568,0,0,0.67567568,-0.2162134,-0.21620953)" />
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
+       x1="38.299992"
+       y1="14.922255"
+       x2="38.299992"
+       y2="76.811172" />
     <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.00837224" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.98752147" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336"
-       id="linearGradient3124"
-       xlink:href="#linearGradient3600-9-9"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4421"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.61938547,0,0,0.59391629,1.1347482,0.83479223)" />
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
+       x1="38.299992"
+       y1="14.922255"
+       x2="38.299992"
+       y2="76.811172" />
     <linearGradient
-       id="linearGradient3600-9-9">
-      <stop
-         id="stop3602-3-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604-7-3"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient2976"
-       xlink:href="#linearGradient3688-166-749"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4423"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
+       x1="38.299992"
+       y1="14.922255"
+       x2="38.299992"
+       y2="76.811172" />
     <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient2978"
-       xlink:href="#linearGradient3688-464-309"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4425"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
+       x1="38.299992"
+       y1="14.922255"
+       x2="38.299992"
+       y2="76.811172" />
     <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4429"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
+       x1="38.299992"
+       y1="14.922255"
+       x2="38.299992"
+       y2="76.811172" />
     <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient2980"
-       xlink:href="#linearGradient3702-501-757"
-       gradientUnits="userSpaceOnUse" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4431"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
+       x1="38.299992"
+       y1="14.922255"
+       x2="38.299992"
+       y2="76.811172" />
     <linearGradient
-       id="linearGradient3702-501-757">
-      <stop
-         id="stop2895"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4433"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
+       x1="38.299992"
+       y1="14.922255"
+       x2="38.299992"
+       y2="76.811172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
+       x1="38.299992"
+       y1="14.922255"
+       x2="38.299992"
+       y2="76.811172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4179-5"
+       x1="1558.0084"
+       y1="-978.039"
+       x2="1558.0084"
+       y2="-916.15015"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-14.77563,-14.536001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-14.77563,-14.536001)"
+       x1="1555.844"
+       y1="-1002.4898"
+       x2="1555.844"
+       y2="-940.50317" />
   </defs>
   <metadata
-     id="metadata3956">
+     id="metadata3187">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="29"
+     x="4.9499893"
+     height="2"
+     width="22.100021" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z" />
+  <path
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline"
+     id="path4160-3"
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z" />
+  <path
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z"
+     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   <g
-     style="display:inline"
-     id="g2036"
-     transform="matrix(0.6999997,0,0,0.3333336,-0.8000003,15.33333)">
-    <g
-       style="opacity:0.4"
-       id="g3712"
-       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-      <rect
-         style="fill:url(#radialGradient2976);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient2978);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient2980);fill-opacity:1;stroke:none"
-         id="rect3700"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     id="layer9"
+     style="display:inline;fill:url(#linearGradient4419)"
+     transform="translate(-685.0002,484.99179)" />
+  <g
+     id="layer10"
+     style="display:inline;fill:url(#linearGradient4421)"
+     transform="translate(-685.0002,484.99179)" />
+  <g
+     style="fill:url(#linearGradient4423)"
+     id="layer11"
+     transform="translate(-685.0002,484.99179)" />
+  <g
+     id="layer13"
+     style="display:inline;fill:url(#linearGradient4425)"
+     transform="translate(-685.0002,484.99179)" />
+  <g
+     style="fill:url(#linearGradient4179-5);color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="layer14"
+     transform="translate(-685.0002,484.99179)">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 706.36939,-478 -7.375,1.90625 c -0.554,0.14844 -1,0.73896 -1,1.3125 l 0,9.09375 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34976,0.35071 -2.19558,1.48415 -1.90625,2.53125 0.28933,1.0471 1.61899,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07145 1.9375,-1.90625 l 0.0312,-8.59375 7,-1.875 0,6.78125 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34976,0.35071 -2.19558,1.48415 -1.90625,2.53125 0.28933,1.0471 1.61899,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07145 1.9375,-1.90625 l 0.0312,-11.1875 c 0,-0.43016 -0.26584,-0.75199 -0.625,-0.8125 z"
+       id="path16590"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4470);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
   </g>
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3124);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     id="rect5505-21-8-5"
-     y="3.0400031"
-     x="3.0400031"
-     height="25.919994"
-     width="25.919994" />
-  <rect
-     style="fill:none;stroke:url(#linearGradient3157);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect6741-7"
-     y="3.4999998"
-     x="3.5"
-     height="25"
-     width="25" />
-  <path
-     inkscape:connector-curvature="0"
-     style="opacity:0.4;fill:url(#linearGradient3154);fill-opacity:1;fill-rule:evenodd;stroke:none"
-     id="path3333"
-     d="m 2.9453323,3.0788478 0.00865,16.2500002 C 3.7019354,19.312476 28.377615,13.338754 28.945332,13.051412 l 0,-9.9725642 z" />
-  <path
-     inkscape:connector-curvature="0"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     id="path7249-8-0-0"
-     d="m 16.467121,7.0001419 c -0.539306,-0.077588 -0.453358,0.4219277 -0.444835,0.7731003 -0.0059,4.1691958 0.01172,8.3406718 -0.0088,12.5084438 -0.145,0.324522 -0.552117,0.0099 -0.801117,0.07215 -1.734176,-0.05405 -3.601662,1.194576 -3.847003,3.03023 -0.253255,1.378856 1.032041,2.593171 2.32157,2.614885 1.917831,0.05257 3.577865,-1.878734 3.334262,-3.814617 0.0065,-3.328297 -0.01298,-6.659269 0.0097,-9.985901 0.131388,-0.316182 0.485595,-0.01847 0.650972,0.09458 1.521163,0.920301 2.850472,2.446294 2.944681,4.327944 0.0815,1.08847 -0.146638,2.173024 -0.460318,3.207202 1.398377,-2.300702 1.322661,-5.50375 -0.405142,-7.605355 C 18.430598,10.834423 17.18144,9.177685 16.927563,7.191724 16.878603,7.0050567 16.621013,7.0074936 16.467121,7.0001419 Z" />
-  <path
-     inkscape:connector-curvature="0"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     id="path7249-8-0"
-     d="m 16.467121,6.0001425 c -0.539306,-0.077588 -0.453358,0.4219277 -0.444835,0.7731003 -0.0059,4.1691952 0.01172,8.3406712 -0.0088,12.5084432 -0.145,0.324522 -0.552117,0.0099 -0.801117,0.07215 -1.734176,-0.05405 -3.601662,1.194576 -3.847003,3.03023 -0.253255,1.378856 1.032041,2.593171 2.32157,2.614885 1.917831,0.05257 3.577865,-1.878734 3.334262,-3.814617 0.0065,-3.328297 -0.01298,-6.659269 0.0097,-9.985901 0.131388,-0.316182 0.485595,-0.01847 0.650972,0.09458 1.521163,0.920301 2.850472,2.446294 2.944681,4.327944 0.0815,1.08847 -0.146638,2.173024 -0.460318,3.207202 1.398377,-2.300702 1.322661,-5.50375 -0.405142,-7.605355 C 18.430598,9.834423 17.18144,8.1776853 16.927563,6.1917246 16.878598,6.0050573 16.621013,6.0074942 16.467121,6.0001425 Z" />
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3116);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect5505-21-8-6"
-     y="2.4999607"
-     x="2.4999609"
-     height="27.000076"
-     width="27.000076" />
+  <g
+     id="layer15"
+     style="display:inline;fill:url(#linearGradient4429)"
+     transform="translate(-685.0002,484.99179)" />
+  <g
+     id="g71291"
+     style="display:inline;fill:url(#linearGradient4431)"
+     transform="translate(-685.0002,484.99179)" />
+  <g
+     id="g4953"
+     style="display:inline;fill:url(#linearGradient4433)"
+     transform="translate(-685.0002,484.99179)" />
+  <g
+     id="layer12"
+     style="display:inline;fill:url(#linearGradient4435)"
+     transform="translate(-685.0002,484.99179)" />
 </svg>

--- a/mimes/48/audio-x-generic.svg
+++ b/mimes/48/audio-x-generic.svg
@@ -6,239 +6,197 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg3931"
+   id="svg3901"
    height="48"
    width="48"
    version="1.1">
   <defs
-     id="defs3933">
+     id="defs3903">
     <linearGradient
-       gradientTransform="matrix(0.7689059,0,0,0.85072409,57.717948,0.7753716)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-6-2"
-       id="linearGradient3095-1"
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404" />
-    <linearGradient
-       id="linearGradient3104-6-2">
+       id="linearGradient3403">
       <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-4" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-9" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.82498024,0,0,1.3012336,4.16188,-1.4329212)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3154"
-       y2="24.627615"
-       x2="20.054544"
-       y1="15.298182"
-       x1="16.626165" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
+         id="stop3405"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         offset="0" />
       <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(1.17e-5,1.00001)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4640"
-       id="linearGradient3157"
-       y2="41.714962"
-       x2="23.99999"
-       y1="6.0582566"
-       x1="23.99999" />
-    <linearGradient
-       id="linearGradient4640">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4642" />
-      <stop
-         offset="0.00856149"
+         id="stop3407"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4644" />
+         offset="0" />
       <stop
-         offset="0.9902752"
+         id="stop3409"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4646" />
+         offset="1" />
       <stop
-         offset="1"
+         id="stop3411"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4648" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.9080499,0,0,0.87071082,2.2068021,2.767049)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-9-9"
-       id="linearGradient3101-2"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
-    <linearGradient
-       id="linearGradient3600-9-9">
+       id="linearGradient3600">
       <stop
          offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-3-7" />
+         id="stop3602" />
       <stop
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-7-3" />
+         id="stop3604" />
     </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-166-749-2-324"
-       id="radialGradient3013-896"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
     <linearGradient
-       id="linearGradient3688-166-749-2-324">
+       id="linearGradient5060">
       <stop
          offset="0"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop3216" />
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
       <stop
          offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3218" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-8-331"
-       id="radialGradient3015-826"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
-    <linearGradient
-       id="linearGradient3688-464-309-8-331">
-      <stop
-         offset="0"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop3222" />
-      <stop
-         offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3224" />
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3702-501-757-6-946">
+       id="linearGradient5048">
       <stop
          offset="0"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3228" />
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
       <stop
          offset="0.5"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop3230" />
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
       <stop
          offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3232" />
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
     </linearGradient>
     <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.110645"
+       x2="23.99999"
+       y1="5.9404659"
+       x1="23.99999"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3702-501-757-6-946"
-       id="linearGradient3929"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096" />
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3112"
+       xlink:href="#linearGradient5060" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3115"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3118"
+       xlink:href="#linearGradient5048" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       id="linearGradient4417">
+      <stop
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop4419" />
+      <stop
+         style="stop-color:#cc3b02;stop-opacity:1"
+         offset="1"
+         id="stop4421" />
+    </linearGradient>
+    <linearGradient
+       y2="75.923912"
+       x2="23.504675"
+       y1="21.421766"
+       x1="38.172356"
+       gradientTransform="matrix(0.74314615,-0.2014786,0.19999636,0.75521721,-12.079371,-8.0110727)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4321"
+       xlink:href="#linearGradient4417" />
   </defs>
   <metadata
-     id="metadata3936">
+     id="metadata3906">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <g
-       style="opacity:0.4"
-       id="g3712-0"
-       transform="matrix(1.1578952,0,0,0.57142859,-3.789476,19.142856)">
-      <rect
-         style="fill:url(#radialGradient3013-896);fill-opacity:1;stroke:none"
-         id="rect2801-4"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3015-826);fill-opacity:1;stroke:none"
-         id="rect3696-8"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3929);fill-opacity:1;stroke:none"
-         id="rect3700-7"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
-    <rect
-       style="color:#000000;fill:url(#linearGradient3101-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21-8-3"
-       y="6"
-       x="4.9999976"
-       height="38"
-       width="38" />
-    <rect
-       style="fill:none;stroke:url(#linearGradient3157);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-1"
-       y="6.5"
-       x="5.5000081"
-       height="37"
-       width="37" />
-    <path
-       style="opacity:0.4;fill:url(#linearGradient3154);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 5,6 5.01264,30 C 6.105807,29.97583 42.170256,21.153092 42.999995,20.728709 L 42.999995,6 C 42.999995,6 17.633272,6.0236831 5,6 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path7249-8-0-4"
-       d="m 24.854681,9.0010319 c -0.929275,-0.1207252 -1.057957,0.7534127 -0.961152,1.4489101 -0.0088,6.920886 0.01757,13.848121 -0.01317,20.76505 -0.226965,0.238066 -0.662511,-0.153464 -0.951672,-0.05185 -3.1502,-0.19279 -6.592075,2.100471 -6.907005,5.409988 -0.371159,2.631262 2.398139,4.796204 4.867655,4.38696 3.111766,-0.331566 5.542848,-3.484297 5.137157,-6.596679 0.0088,-5.479983 -0.01757,-10.966312 0.01317,-16.442334 0.212101,-0.243876 0.528471,0.275372 0.751913,0.300846 2.502375,1.486463 4.715927,3.937692 4.865355,6.990278 0.164321,2.385273 -0.555099,4.719306 -1.364498,6.930582 2.712159,-3.351702 3.580383,-8.241169 1.695728,-12.20003 -0.96387,-2.298062 -3.138229,-3.714267 -4.354609,-5.848771 C 26.735266,12.667568 26.051608,11.075165 25.837709,9.3911706 25.661598,9.0400097 25.197713,8.9972487 24.854681,9.0010319 z" />
-    <path
-       style="opacity:0.2;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path7249-8-0"
-       d="m 24.854681,8.0010319 c -0.929275,-0.1207252 -1.057957,0.7534127 -0.961152,1.4489099 -0.0088,6.9208862 0.01757,13.8481212 -0.01317,20.7650502 -0.226965,0.238066 -0.662511,-0.153464 -0.951672,-0.05185 -3.1502,-0.19279 -6.592075,2.100471 -6.907005,5.409988 -0.371159,2.631262 2.398139,4.796204 4.867655,4.38696 3.111766,-0.331566 5.542848,-3.484297 5.137157,-6.596679 0.0088,-5.479983 -0.01757,-10.966312 0.01317,-16.442334 0.212101,-0.243876 0.528471,0.275372 0.751913,0.300846 2.502375,1.486463 4.715927,3.937692 4.865355,6.990278 0.164321,2.385273 -0.555099,4.719306 -1.364498,6.930582 2.712159,-3.351702 3.580383,-8.241169 1.695728,-12.20003 -0.96387,-2.298062 -3.138229,-3.714267 -4.354609,-5.848771 C 26.735266,11.667568 26.051608,10.075165 25.837709,8.3911706 25.661598,8.0400097 25.197713,7.9972487 24.854681,8.0010319 z" />
-    <rect
-       style="color:#000000;fill:none;stroke:url(#linearGradient3095-1);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21-8-6"
-       y="5.4999619"
-       x="4.4999595"
-       height="39.000076"
-       width="39.000076" />
-  </g>
+  <rect
+     width="32.508301"
+     height="3.5700529"
+     x="7.7378473"
+     y="42.429947"
+     id="rect2879"
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
+     id="path2881"
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
+     id="path2883"
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z"
+     id="path4160"
+     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z"
+     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     id="path4201"
+     d="M 32.445312,10.009766 C 32.336477,9.990812 32.217707,9.998697 32.091797,10.035156 L 19.908203,13.5625 C 19.404564,13.708337 19,14.272172 19,14.826172 l 0,13.511719 c -0.870948,-0.376328 -1.900382,-0.438401 -2.882812,-0.173829 -2.154814,0.584184 -3.505906,2.551792 -3.017579,4.394532 0.488754,1.841328 2.62967,2.860645 4.783203,2.277344 1.774251,-0.483156 3.052032,-1.929487 3.109376,-3.519532 l 0.0078,-0.273438 0,-12.39453 10,-2.894532 0,9.583985 c -0.870948,-0.376328 -1.900382,-0.438401 -2.882812,-0.173829 -2.154814,0.584184 -3.505906,2.551792 -3.017579,4.394532 0.488754,1.841328 2.62967,2.860645 4.783203,2.277344 1.774251,-0.483156 3.052032,-1.929487 3.109376,-3.519532 l 0.0078,-0.105469 0,-17.439453 c 0,-0.4155 -0.22818,-0.704858 -0.554688,-0.761718 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4321);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/64/audio-x-generic.svg
+++ b/mimes/64/audio-x-generic.svg
@@ -6,236 +6,493 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg6534"
+   id="svg3130"
    height="64"
    width="64"
    version="1.1">
   <defs
-     id="defs6536">
+     id="defs3132">
     <linearGradient
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.3783747,-2.4707828)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3924-45"
-       id="linearGradient5522"
-       y2="42.157932"
-       x2="23.99999"
-       y1="6.0525746"
-       x1="23.99999" />
-    <linearGradient
-       id="linearGradient3924-45">
+       id="linearGradient5792">
       <stop
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3124" />
-      <stop
-         offset="0.01292247"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3126" />
+         style="stop-color:#e29ffc;stop-opacity:1"
+         id="stop5794" />
       <stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3128" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3130" />
+         style="stop-color:#7a36b1;stop-opacity:1"
+         id="stop5800" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550855,-2.16287)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-6-2"
-       id="linearGradient3095-1"
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404" />
+       id="linearGradient5778">
+      <stop
+         offset="0"
+         style="stop-color:#f37329;stop-opacity:1"
+         id="stop5780" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         id="stop5782" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         id="stop5784" />
+      <stop
+         offset="1"
+         style="stop-color:#ac441f;stop-opacity:1"
+         id="stop5786" />
+    </linearGradient>
     <linearGradient
-       id="linearGradient3104-6-2">
+       id="linearGradient4338">
+      <stop
+         id="stop4340"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4342"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4344"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4346"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
       <stop
          offset="0"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-4" />
+         id="stop3106-3" />
       <stop
          offset="1"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-9" />
+         id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.1723404,0,0,1.8434143,3.8089875,-5.5299721)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient5519"
-       y2="24.627615"
-       x2="20.054544"
-       y1="15.298182"
-       x1="16.626165" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.2903867,0,0,1.2373259,1.0307192,0.405807)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-9-9"
-       id="linearGradient3101-2"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
-    <linearGradient
-       id="linearGradient3600-9-9">
+       id="linearGradient3600-9">
       <stop
          offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-3-7" />
+         id="stop3602-3" />
       <stop
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-7-3" />
+         id="stop3604-7" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-166-749-654"
-       id="radialGradient2873-966-168-714"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
+       xlink:href="#linearGradient5060"
+       id="radialGradient3057"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
-       id="linearGradient3688-166-749-654">
+       id="linearGradient5060">
       <stop
          offset="0"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop3088" />
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
       <stop
          offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3090" />
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-604"
-       id="radialGradient2875-742-326-419"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
+       xlink:href="#linearGradient5060"
+       id="radialGradient3060"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
-       id="linearGradient3688-464-309-604">
+       id="linearGradient5048">
       <stop
          offset="0"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop3094" />
-      <stop
-         offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3096" />
-    </linearGradient>
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3702-501-757-795"
-       id="linearGradient2877-634-617-908"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096" />
-    <linearGradient
-       id="linearGradient3702-501-757-795">
-      <stop
-         offset="0"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3100" />
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
       <stop
          offset="0.5"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop3102" />
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
       <stop
          offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3104" />
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
     </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3128"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
+      <stop
+         id="stop3750-1-0-7"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7-4"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8-5"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6-2"
+         style="stop-color:#ac441f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4322"
+       xlink:href="#linearGradient3600-9" />
+    <linearGradient
+       y2="42.175503"
+       x2="23.99999"
+       y1="5.8245578"
+       x1="23.99999"
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4324"
+       xlink:href="#linearGradient4338" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4326"
+       xlink:href="#linearGradient3104-6" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,10.877624,-7.0637189,0,139.33678,-239.06405)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,8.885821,-11.172671,0,197.34473,-210.06077)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-5"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,13.308038,-7.0637189,0,147.82206,-298.85162)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,8.885821,-7.0637189,0,130.23278,-188.88398)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-0"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,3.2947378,3.7477225,0,-35.505623,-52.475041)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2-7"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,17.099485,-5.0375394,0,122.02275,-392.14616)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2-75"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,4.233405,2.6727139,0,-8.7186373,-75.577183)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2-7-9"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,19.627118,7.0637189,0,-77.11192,-454.23439)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-6"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,10.877624,-7.0637189,0,165.05778,-239.06405)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-9"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,10.877624,-7.0637189,0,139.33678,-239.06405)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-03"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,8.885821,-7.0637189,0,147.5569,-189.41432)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-03-2"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,3.2947378,3.7477225,0,-34.74306,-52.475041)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2-7-4"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,3.2947378,-3.7477225,0,76.307792,-52.475041)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2-7-4-3"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,3.2947378,-3.7477225,0,78.163947,-52.475041)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2-7-4-3-4"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,3.2947378,3.7477225,0,-14.502129,-52.475041)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2-7-4-3-4-7"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,3.2947378,3.7477225,0,-14.502129,-52.475041)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2-7-4-3-4-7-3"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <radialGradient
+       r="12.671875"
+       fy="16.231987"
+       fx="18.1481"
+       cy="16.231987"
+       cx="18.1481"
+       gradientTransform="matrix(0,1.739277,3.7477225,0,-12.469197,-14.150505)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4873-2-7-4-3-4-7-3-6"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.8641062"
+       x2="23.99999"
+       y2="42.175503"
+       id="linearGradient3093"
+       xlink:href="#linearGradient4338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,-504.68918,31.027079)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3153"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,-472.27914,87.451449)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3156"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,-478.72086,87.451449)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3842"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-508.58462,87.451449)" />
+    <radialGradient
+       cx="10.413292"
+       cy="10.163567"
+       r="12.671875"
+       fx="9.8830614"
+       fy="10.163567"
+       id="radialGradient3029"
+       xlink:href="#linearGradient5778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.586615e-7,4.599873,-10.376613,3.3044537e-7,136.30664,-39.283015)" />
+    <radialGradient
+       cx="6.5633106"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
+       id="radialGradient3029-7"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,137.65609,-105.47417)" />
+    <radialGradient
+       cx="6.5633106"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
+       id="radialGradient3029-1"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,97.65609,-88.47414)" />
+    <radialGradient
+       cx="10.413292"
+       cy="10.163567"
+       r="12.671875"
+       fx="9.8830614"
+       fy="10.163567"
+       id="radialGradient3029-9"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.586615e-7,4.599873,-10.376613,3.3044537e-7,136.30664,-40.283015)" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.2729746e-8,2.5434783,-4.6521739,-4.1574064e-8,-57.720517,-80.391303)"
+       r="23"
+       fy="-19.285719"
+       fx="32"
+       cy="-19.285719"
+       cx="32"
+       id="radialGradient5802"
+       xlink:href="#linearGradient5792" />
+    <linearGradient
+       y2="42.175503"
+       x2="23.99999"
+       y1="5.8245578"
+       x1="23.99999"
+       gradientTransform="matrix(0,1.2162162,-1.5405376,0,98.972949,0.810819)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4324-8"
+       xlink:href="#linearGradient4338" />
   </defs>
   <metadata
-     id="metadata6539">
+     id="metadata3135">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     style="opacity:0.15"
-     id="g3712"
-     transform="matrix(1.5789502,0,0,0.7142857,-5.8947511,28.428574)">
-    <rect
-       style="fill:url(#radialGradient2873-966-168-714);fill-opacity:1;stroke:none"
-       id="rect2801"
-       y="40"
-       x="38"
-       height="7"
-       width="5" />
-    <rect
-       style="fill:url(#radialGradient2875-742-326-419);fill-opacity:1;stroke:none"
-       id="rect3696"
-       transform="scale(-1,-1)"
-       y="-47"
-       x="-10"
-       height="7"
-       width="5" />
-    <rect
-       style="fill:url(#linearGradient2877-634-617-908);fill-opacity:1;stroke:none"
-       id="rect3700"
-       y="40"
-       x="10"
-       height="7.0000005"
-       width="28" />
-  </g>
   <rect
-     width="54"
-     height="54"
-     x="5"
-     y="5"
-     id="rect5505-21-8"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3101-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+     width="44.199997"
+     height="5"
+     x="9.8999996"
+     y="57.000004"
+     id="rect2879"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3128);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="M 5,4.9999999 5.017966,39 C 6.5714146,38.965765 57.820897,26.466881 59,25.865671 L 59,4.9999999 Z"
-     id="path3333"
-     style="opacity:0.4;fill:url(#linearGradient5519);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z"
+     id="path2881"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3060);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 33.500729,9.9873841 c -1.310996,-0.1696929 -1.49383,1.0583119 -1.356921,2.0360749 -0.01241,9.732985 0.0248,19.474893 -0.01859,29.202307 -0.320421,0.33478 -0.935311,-0.215808 -1.343538,-0.07291 -4.44734,-0.27111 -9.306459,2.953788 -9.751065,7.607796 -0.52399,3.700212 3.385608,6.744662 6.871983,6.169162 4.392618,-0.466712 7.66086,-4.899351 7.088107,-9.276245 0.01241,-7.706335 -0.0248,-15.421598 0.01859,-23.122367 0.299436,-0.342951 0.910426,0.387242 1.225874,0.423064 3.532765,2.090339 6.657779,5.53738 6.868736,9.830079 0.23193,3.354326 -0.783586,6.636476 -1.926349,9.746131 3.828929,-4.713331 5.054657,-11.589144 2.393968,-17.156292 -1.360758,-3.23165 -4.430441,-5.223189 -6.147683,-8.224835 C 36.155672,15.143454 35.190508,12.904138 34.888532,10.53602 34.639906,10.0422 33.985009,9.9820672 33.500729,9.9873841 Z"
-     id="path7249-8-0-3-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate" />
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z"
+     id="path2883"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3057);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 33.500729,9.0015205 c -1.525356,0 -1.491434,1.0085275 -1.491434,2.0360745 l -0.01859,29.202307 c -0.320421,0.33478 -0.800798,-0.215808 -1.209025,-0.07291 -4.44734,-0.27111 -9.306459,2.953788 -9.751065,7.607796 -0.52399,3.700212 3.385608,6.744662 6.871983,6.169162 4.392618,-0.466712 7.66086,-4.899351 7.088107,-9.276245 0.01241,-7.706335 -0.0248,-15.421598 0.01859,-23.122367 0.299436,-0.342951 0.910426,0.387242 1.225874,0.423064 3.532765,2.090339 6.657779,5.53738 6.868736,9.830079 0.23193,3.354326 -0.783586,6.636476 -1.926349,9.746131 C 45.006485,36.831281 46.232213,29.955468 43.571524,24.38832 42.210766,21.15667 39.141083,19.165131 37.423841,16.163485 36.155672,14.15759 35.190508,11.918274 34.888532,9.5501565 34.639906,9.0563365 33.985009,8.996204 33.500729,9.0015205 Z"
-     id="path7249-8-0-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate" />
-  <rect
-     width="55"
-     height="55"
-     x="4.5"
-     y="4.5"
-     id="rect5505-21-8-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3095-1);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-  <rect
-     width="53"
-     height="53.142479"
-     x="5.5"
-     y="5.428761"
-     id="rect6741"
-     style="fill:none;stroke:url(#linearGradient5522);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
+     id="path4160-6"
+     style="display:inline;fill:url(#linearGradient4322);fill-opacity:1;stroke:none" />
+  <path
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient4326);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z"
+     id="rect6741-1-8"
+     style="fill:none;stroke:url(#linearGradient4324);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     id="rect4842-3"
+     d="m 42,17.000004 -1,1.261126 0,6.25496 -1,-0.930831 0,6.110456 -1,-0.480429 0,1.032171 -1,0.540482 0,-1.782841 -1,0.690617 0,-2.175067 -1,1.41126 0,-4.472118 -1,-0.750671 0,-2.143163 -1,-2.672386 0,8.993029 -1,-2.011796 0,-1.968633 -1,1.231099 0,4.473995 -1,-0.75067 0,1.837265 -1,-0.450402 0,-1.086595 -1,0.75067 0,-1.150402 -1,0.570509 0,-2.642359 -1,0.84075 0,-5.549329 -1,1.261126 0,4.08177 -1,-0.600536 0,-2.293298 -1,-1.110992 0,6.249329 -1,-0.870777 0,1.809116 -1,-0.300268 0,-1.028419 -1,0.390348 0,-1.694638 -1,0.420376 0,-3.274799 -1,0.600536 0,-2.404021 -1,0.960858 0,-4.398928 -1,-2.522252 0,8.831635 -1,-0.600536 0,4.592225 -1,-0.810724 0,0.874531 -1,0.360322 0,-1.174799 -1,0.75067 0,-0.89142 -1,-0.630563 0,1.521983 -1,-0.240214 0,0.861394 -1,-0.240214 0,-0.981502 -1,0.600536 0,0.913941 0,0.01501 0,0.913941 1,0.600536 0,-0.981501 1,-0.240214 0,0.861393 1,-0.240214 0,1.521983 1,-0.630563 0,-0.89142 1,0.75067 0,-1.174799 1,0.360322 0,0.874531 1,-0.810724 0,4.592225 1,-0.600536 0,8.831635 1,-2.522252 0,-4.398928 1,0.960858 0,-2.404021 1,0.600536 0,-3.274799 1,0.420376 0,-1.694638 1,0.390348 0,-1.028419 1,-0.300268 0,1.809116 1,-0.870777 0,6.249329 1,-1.110992 0,-2.293298 1,-0.600536 0,4.08177 1,1.261126 0,-5.549329 1,0.84075 0,-2.642359 1,0.570509 0,-1.150402 1,0.75067 0,-1.086595 1,-0.450402 0,1.837265 1,-0.75067 0,4.473995 1,1.231099 0,-1.968633 1,-2.011796 0,8.993029 1,-2.672386 0,-2.143163 1,-0.750671 0,-4.472118 1,1.41126 0,-2.175067 1,0.690617 0,-1.782841 1,0.540482 0,1.032171 1,-0.480429 0,6.110456 1,-0.930831 0,6.25496 L 42,45 l 0,-4.543432 1,0.450402 0,-2.621715 1,0.600536 0,-3.075871 1,1.080965 0,-1.912333 1,-0.480429 0,1.401877 1,0.900804 0,-4.342627 1,0.780697 0,1.600804 1,-1.801609 0,-1.747184 1,1.41126 0,-1.109116 1,-0.18016 0,1.486327 1,-1.050939 0,1.289277 1,-0.840751 0,-1.126005 1,0.75067 0,-0.771313 1,0.390348 0,-0.532976 0,-0.01501 0,-0.532975 -1,0.390348 0,-0.771314 -1,0.75067 0,-1.126005 -1,-0.840751 0,1.289277 -1,-1.050939 0,1.486327 -1,-0.18016 0,-1.109116 -1,1.41126 0,-1.747184 -1,-1.801609 0,1.600804 -1,0.780697 0,-4.342627 -1,0.900804 0,1.401876 -1,-0.480429 0,-1.912332 -1,1.080965 0,-3.075871 -1,0.600536 0,-2.621715 -1,0.450402 0,-4.543432 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5802);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/64/audio-x-generic.svg
+++ b/mimes/64/audio-x-generic.svg
@@ -6,12 +6,49 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3844"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="audio-x-generic.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3200"
+     inkscape:window-height="1674"
+     id="namedview43"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="2"
+     inkscape:cx="155.75"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="60"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3844" />
   <defs
      id="defs3846">
+    <linearGradient
+       id="linearGradient4417"
+       inkscape:collect="always">
+      <stop
+         id="stop4419"
+         offset="0"
+         style="stop-color:#ffa154;stop-opacity:1" />
+      <stop
+         id="stop4421"
+         offset="1"
+         style="stop-color:#cc3b02;stop-opacity:1" />
+    </linearGradient>
     <linearGradient
        gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
        gradientUnits="userSpaceOnUse"
@@ -135,45 +172,16 @@
        x2="302.85715"
        y1="366.64789"
        x1="302.85715" />
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
-       id="radialGradient4873"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,8.885821,-11.172671,0,205.34514,-189.06077)"
-       cx="18.1481"
-       cy="16.231987"
-       fx="18.1481"
-       fy="16.231987"
-       r="12.671875" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
-      <stop
-         offset="0"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5" />
-      <stop
-         offset="1"
-         style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
-       id="radialGradient4873-7"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4179-5"
+       x1="21.330717"
+       y1="0.44737434"
+       x2="21.330717"
+       y2="59.5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,8.885821,-11.172671,0,180.89297,-206.06074)"
-       cx="18.1481"
-       cy="16.231987"
-       fx="18.1481"
-       fy="16.231987"
-       r="12.671875" />
+       gradientTransform="translate(5.5109472,0.05698564)" />
   </defs>
   <metadata
      id="metadata3849">
@@ -215,7 +223,8 @@
      id="path4160-6-1"
      style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="M 42.738688,13.999946 27.996256,17.81049 c -1.107432,0.296727 -1.998974,1.477162 -1.998974,2.623653 l 0,18.178169 c -1.122964,-0.588018 -2.565203,-0.825776 -4.060416,-0.437276 -2.698135,0.701061 -4.388907,2.966778 -3.810544,5.059903 0.578363,2.093126 3.236319,3.262246 5.934454,2.561185 2.152555,-0.559293 3.636373,-2.1418 3.873012,-3.810544 l 0.06237,-17.178682 13.992817,-3.748076 0,13.555542 c -1.122963,-0.588018 -2.565203,-0.825776 -4.060416,-0.437275 -2.698135,0.70106 -4.388907,2.966777 -3.810544,5.059902 0.578364,2.093126 3.236319,3.262246 5.934454,2.561186 2.152555,-0.559293 3.636374,-2.141801 3.873012,-3.810544 l 0.06237,-22.363521 c 0,-0.859879 -0.531407,-1.503208 -1.249359,-1.624166 z"
-     id="path16590"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4873);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     inkscape:connector-curvature="0"
+     d="m 42.738661,13.999946 -14.74243,3.810544 c -1.10744,0.296727 -1.99898,1.477162 -1.99898,2.623653 l 0,18.178169 c -1.12296,-0.588018 -2.5652,-0.825776 -4.06041,-0.437276 -2.69814,0.701061 -4.388911,2.966778 -3.81055,5.059903 0.57836,2.093126 3.23632,3.262246 5.93446,2.561185 2.15255,-0.559293 3.63637,-2.1418 3.87301,-3.810544 l 0.0624,-17.178682 13.99281,-3.748076 0,13.555542 c -1.12296,-0.588018 -2.5652,-0.825776 -4.06041,-0.437275 -2.69814,0.70106 -4.38891,2.966777 -3.81055,5.059902 0.57837,2.093126 3.23632,3.262246 5.93446,2.561186 2.15255,-0.559293 3.63637,-2.141801 3.87301,-3.810544 l 0.0624,-22.363521 c 0,-0.859879 -0.53141,-1.503208 -1.24936,-1.624166 z"
+     id="path16590-0"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4179-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/64/audio-x-generic.svg
+++ b/mimes/64/audio-x-generic.svg
@@ -6,61 +6,21 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg3130"
+   id="svg3844"
    height="64"
    width="64"
    version="1.1">
   <defs
-     id="defs3132">
+     id="defs3846">
     <linearGradient
-       id="linearGradient5792">
-      <stop
-         offset="0"
-         style="stop-color:#e29ffc;stop-opacity:1"
-         id="stop5794" />
-      <stop
-         offset="1"
-         style="stop-color:#7a36b1;stop-opacity:1"
-         id="stop5800" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5778">
-      <stop
-         offset="0"
-         style="stop-color:#f37329;stop-opacity:1"
-         id="stop5780" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop5782" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop5784" />
-      <stop
-         offset="1"
-         style="stop-color:#ac441f;stop-opacity:1"
-         id="stop5786" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4338">
-      <stop
-         id="stop4340"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4342"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
-      <stop
-         id="stop4344"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
-      <stop
-         id="stop4346"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3033"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
     <linearGradient
        id="linearGradient3104-6">
       <stop
@@ -72,6 +32,43 @@
          style="stop-color:#000000;stop-opacity:0.24031007"
          id="stop3108-9" />
     </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4"
+       id="linearGradient3093"
+       y2="42.175503"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9"
+       id="linearGradient3096"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
     <linearGradient
        id="linearGradient3600-9">
       <stop
@@ -87,7 +84,7 @@
        gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5060"
-       id="radialGradient3057"
+       id="radialGradient3153"
        fy="486.64789"
        fx="605.71429"
        r="117.14286"
@@ -108,7 +105,7 @@
        gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5060"
-       id="radialGradient3060"
+       id="radialGradient3156"
        fy="486.64789"
        fx="605.71429"
        r="117.14286"
@@ -133,327 +130,53 @@
        gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5048"
-       id="linearGradient3128"
+       id="linearGradient3842"
        y2="609.50507"
        x2="302.85715"
        y1="366.64789"
        x1="302.85715" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       id="radialGradient4873"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,8.885821,-11.172671,0,205.34514,-189.06077)"
+       cx="18.1481"
+       cy="16.231987"
+       fx="18.1481"
+       fy="16.231987"
+       r="12.671875" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
       <stop
-         id="stop3750-1-0-7"
+         offset="0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop3750-1-0-7" />
       <stop
-         id="stop3752-3-7-4"
+         offset="0.26238"
          style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
+         id="stop3752-3-7-4" />
       <stop
-         id="stop3754-1-8-5"
+         offset="0.704952"
          style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
+         id="stop3754-1-8-5" />
       <stop
-         id="stop3756-1-6-2"
+         offset="1"
          style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3756-1-6-2" />
     </linearGradient>
-    <linearGradient
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275"
-       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4322"
-       xlink:href="#linearGradient3600-9" />
-    <linearGradient
-       y2="42.175503"
-       x2="23.99999"
-       y1="5.8245578"
-       x1="23.99999"
-       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4324"
-       xlink:href="#linearGradient4338" />
-    <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4326"
-       xlink:href="#linearGradient3104-6" />
     <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,10.877624,-7.0637189,0,139.33678,-239.06405)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,8.885821,-11.172671,0,197.34473,-210.06077)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-5"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,13.308038,-7.0637189,0,147.82206,-298.85162)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,8.885821,-7.0637189,0,130.23278,-188.88398)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-0"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,3.2947378,3.7477225,0,-35.505623,-52.475041)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2-7"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,17.099485,-5.0375394,0,122.02275,-392.14616)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2-75"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,4.233405,2.6727139,0,-8.7186373,-75.577183)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2-7-9"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,19.627118,7.0637189,0,-77.11192,-454.23439)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-6"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,10.877624,-7.0637189,0,165.05778,-239.06405)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-9"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,10.877624,-7.0637189,0,139.33678,-239.06405)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-03"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,8.885821,-7.0637189,0,147.5569,-189.41432)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-03-2"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,3.2947378,3.7477225,0,-34.74306,-52.475041)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2-7-4"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,3.2947378,-3.7477225,0,76.307792,-52.475041)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2-7-4-3"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,3.2947378,-3.7477225,0,78.163947,-52.475041)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2-7-4-3-4"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,3.2947378,3.7477225,0,-14.502129,-52.475041)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2-7-4-3-4-7"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,3.2947378,3.7477225,0,-14.502129,-52.475041)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2-7-4-3-4-7-3"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="18.1481"
-       cy="16.231987"
-       cx="18.1481"
-       gradientTransform="matrix(0,1.739277,3.7477225,0,-12.469197,-14.150505)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4873-2-7-4-3-4-7-3-6"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3" />
-    <linearGradient
-       x1="23.99999"
-       y1="5.8641062"
-       x2="23.99999"
-       y2="42.175503"
-       id="linearGradient3093"
-       xlink:href="#linearGradient4338"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2162162,0,0,1.5405376,-504.68918,31.027079)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3153"
-       xlink:href="#linearGradient3104-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.03132633,0,0,0.02058823,-472.27914,87.451449)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3156"
-       xlink:href="#linearGradient3104-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.03132632,0,0,0.02058823,-478.72086,87.451449)" />
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient3842"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.09153846,0,0,0.02058823,-508.58462,87.451449)" />
-    <radialGradient
-       cx="10.413292"
-       cy="10.163567"
-       r="12.671875"
-       fx="9.8830614"
-       fy="10.163567"
-       id="radialGradient3029"
-       xlink:href="#linearGradient5778"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.586615e-7,4.599873,-10.376613,3.3044537e-7,136.30664,-39.283015)" />
-    <radialGradient
-       cx="6.5633106"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.0330806"
-       fy="9.9571075"
-       id="radialGradient3029-7"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       id="radialGradient4873-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,10.035098,-12.319893,0,137.65609,-105.47417)" />
-    <radialGradient
-       cx="6.5633106"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.0330806"
-       fy="9.9571075"
-       id="radialGradient3029-1"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,10.035098,-12.319893,0,97.65609,-88.47414)" />
-    <radialGradient
-       cx="10.413292"
-       cy="10.163567"
-       r="12.671875"
-       fx="9.8830614"
-       fy="10.163567"
-       id="radialGradient3029-9"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.586615e-7,4.599873,-10.376613,3.3044537e-7,136.30664,-40.283015)" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.2729746e-8,2.5434783,-4.6521739,-4.1574064e-8,-57.720517,-80.391303)"
-       r="23"
-       fy="-19.285719"
-       fx="32"
-       cy="-19.285719"
-       cx="32"
-       id="radialGradient5802"
-       xlink:href="#linearGradient5792" />
-    <linearGradient
-       y2="42.175503"
-       x2="23.99999"
-       y1="5.8245578"
-       x1="23.99999"
-       gradientTransform="matrix(0,1.2162162,-1.5405376,0,98.972949,0.810819)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4324-8"
-       xlink:href="#linearGradient4338" />
+       gradientTransform="matrix(0,8.885821,-11.172671,0,180.89297,-206.06074)"
+       cx="18.1481"
+       cy="16.231987"
+       fx="18.1481"
+       fy="16.231987"
+       r="12.671875" />
   </defs>
   <metadata
-     id="metadata3135">
+     id="metadata3849">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -470,29 +193,29 @@
      x="9.8999996"
      y="57.000004"
      id="rect2879"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3128);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
      d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z"
      id="path2881"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3060);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
      d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z"
      id="path2883"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3057);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
      d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
      id="path4160-6"
-     style="display:inline;fill:url(#linearGradient4322);fill-opacity:1;stroke:none" />
-  <path
-     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
-     id="path4160-6-1"
-     style="display:inline;fill:none;stroke:url(#linearGradient4326);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none" />
   <path
      d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z"
      id="rect6741-1-8"
-     style="fill:none;stroke:url(#linearGradient4324);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     id="rect4842-3"
-     d="m 42,17.000004 -1,1.261126 0,6.25496 -1,-0.930831 0,6.110456 -1,-0.480429 0,1.032171 -1,0.540482 0,-1.782841 -1,0.690617 0,-2.175067 -1,1.41126 0,-4.472118 -1,-0.750671 0,-2.143163 -1,-2.672386 0,8.993029 -1,-2.011796 0,-1.968633 -1,1.231099 0,4.473995 -1,-0.75067 0,1.837265 -1,-0.450402 0,-1.086595 -1,0.75067 0,-1.150402 -1,0.570509 0,-2.642359 -1,0.84075 0,-5.549329 -1,1.261126 0,4.08177 -1,-0.600536 0,-2.293298 -1,-1.110992 0,6.249329 -1,-0.870777 0,1.809116 -1,-0.300268 0,-1.028419 -1,0.390348 0,-1.694638 -1,0.420376 0,-3.274799 -1,0.600536 0,-2.404021 -1,0.960858 0,-4.398928 -1,-2.522252 0,8.831635 -1,-0.600536 0,4.592225 -1,-0.810724 0,0.874531 -1,0.360322 0,-1.174799 -1,0.75067 0,-0.89142 -1,-0.630563 0,1.521983 -1,-0.240214 0,0.861394 -1,-0.240214 0,-0.981502 -1,0.600536 0,0.913941 0,0.01501 0,0.913941 1,0.600536 0,-0.981501 1,-0.240214 0,0.861393 1,-0.240214 0,1.521983 1,-0.630563 0,-0.89142 1,0.75067 0,-1.174799 1,0.360322 0,0.874531 1,-0.810724 0,4.592225 1,-0.600536 0,8.831635 1,-2.522252 0,-4.398928 1,0.960858 0,-2.404021 1,0.600536 0,-3.274799 1,0.420376 0,-1.694638 1,0.390348 0,-1.028419 1,-0.300268 0,1.809116 1,-0.870777 0,6.249329 1,-1.110992 0,-2.293298 1,-0.600536 0,4.08177 1,1.261126 0,-5.549329 1,0.84075 0,-2.642359 1,0.570509 0,-1.150402 1,0.75067 0,-1.086595 1,-0.450402 0,1.837265 1,-0.75067 0,4.473995 1,1.231099 0,-1.968633 1,-2.011796 0,8.993029 1,-2.672386 0,-2.143163 1,-0.750671 0,-4.472118 1,1.41126 0,-2.175067 1,0.690617 0,-1.782841 1,0.540482 0,1.032171 1,-0.480429 0,6.110456 1,-0.930831 0,6.25496 L 42,45 l 0,-4.543432 1,0.450402 0,-2.621715 1,0.600536 0,-3.075871 1,1.080965 0,-1.912333 1,-0.480429 0,1.401877 1,0.900804 0,-4.342627 1,0.780697 0,1.600804 1,-1.801609 0,-1.747184 1,1.41126 0,-1.109116 1,-0.18016 0,1.486327 1,-1.050939 0,1.289277 1,-0.840751 0,-1.126005 1,0.75067 0,-0.771313 1,0.390348 0,-0.532976 0,-0.01501 0,-0.532975 -1,0.390348 0,-0.771314 -1,0.75067 0,-1.126005 -1,-0.840751 0,1.289277 -1,-1.050939 0,1.486327 -1,-0.18016 0,-1.109116 -1,1.41126 0,-1.747184 -1,-1.801609 0,1.600804 -1,0.780697 0,-4.342627 -1,0.900804 0,1.401876 -1,-0.480429 0,-1.912332 -1,1.080965 0,-3.075871 -1,0.600536 0,-2.621715 -1,0.450402 0,-4.543432 z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5802);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 42.738688,13.999946 27.996256,17.81049 c -1.107432,0.296727 -1.998974,1.477162 -1.998974,2.623653 l 0,18.178169 c -1.122964,-0.588018 -2.565203,-0.825776 -4.060416,-0.437276 -2.698135,0.701061 -4.388907,2.966778 -3.810544,5.059903 0.578363,2.093126 3.236319,3.262246 5.934454,2.561185 2.152555,-0.559293 3.636373,-2.1418 3.873012,-3.810544 l 0.06237,-17.178682 13.992817,-3.748076 0,13.555542 c -1.122963,-0.588018 -2.565203,-0.825776 -4.060416,-0.437275 -2.698135,0.70106 -4.388907,2.966777 -3.810544,5.059902 0.578364,2.093126 3.236319,3.262246 5.934454,2.561186 2.152555,-0.559293 3.636374,-2.141801 3.873012,-3.810544 l 0.06237,-22.363521 c 0,-0.859879 -0.531407,-1.503208 -1.249359,-1.624166 z"
+     id="path16590"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4873);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>


### PR DESCRIPTION
Proposing for feedback

![sound1](https://user-images.githubusercontent.com/7277719/27193385-79bd1fb6-51b3-11e7-8268-4feb3543f499.png)


My thinking is that the current audio mime leans heavily towards music, but we can't know the contents of the audio file. So it might be better to use a mime that more conveys raw audio than music specifically