### PR TITLE
dialog-warning-symbolic: filled instead of outline

### DIFF
--- a/status/symbolic/dialog-warning-symbolic.svg
+++ b/status/symbolic/dialog-warning-symbolic.svg
@@ -1,6 +1,31 @@
-<svg height='16.002' width='16.002' xmlns='http://www.w3.org/2000/svg'>
-    <g transform='translate(-892.998 271.002)'>
-        <path class='warning' color='#000' d='M900.961-271.002a1.499 1.499 0 0 0-1.277.785l-6.502 12c-.542 1 .18 2.217 1.316 2.217h13c1.136 0 1.859-1.216 1.317-2.217l-6.498-12a1.496 1.496 0 0 0-1.356-.785zm.026 1a.494.494 0 0 1 .45.262l6.499 12c.203.374-.016.74-.438.74h-13c-.422 0-.64-.366-.437-.74l6.502-12a.493.493 0 0 1 .424-.262zM900-267v4l.5 2h1l.5-2v-4zm1 7a1 1 0 1 0 0 2 1 1 0 0 0 0-2z' fill='#f9c440' font-family='sans-serif' font-weight='400' overflow='visible' style='line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal' white-space='normal'/>
-        
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   height="16.002"
+   width="16.002"
+   version="1.1"
+   id="svg6">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#f9c440"
+     d="M 7.9628906 0 A 1.499 1.499 0 0 0 6.6855469 0.78515625 L 0.18359375 12.785156 C -0.35840625 13.785156 0.364 15.001953 1.5 15.001953 L 14.5 15.001953 C 15.636 15.001953 16.358406 13.786156 15.816406 12.785156 L 9.3183594 0.78515625 A 1.496 1.496 0 0 0 7.9628906 0 z M 7.0019531 4.0019531 L 9.0019531 4.0019531 L 9.0019531 8.0019531 L 8.5019531 10.001953 L 7.5019531 10.001953 L 7.0019531 8.0019531 L 7.0019531 4.0019531 z M 8.0019531 11.001953 A 1 1 0 0 1 8.0019531 13.001953 A 1 1 0 0 1 8.0019531 11.001953 z "
+     class="warning"
+     id="path829" />
 </svg>


### PR DESCRIPTION
The outline is just too hard to see for yellow. Filled seems to look nicer

![screenshot from 2017-11-16 10 51 31](https://user-images.githubusercontent.com/7277719/32909764-3fe64312-cabc-11e7-9b7f-9d3eeefa5757.png)
