### PR TITLE
Fix baselines and clean up presentation mimes

### DIFF
--- a/mimes/128/x-office-presentation-rtl.svg
+++ b/mimes/128/x-office-presentation-rtl.svg
@@ -6,419 +6,419 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4954"
-   height="128"
+   version="1.1"
    width="128"
-   version="1.1">
+   height="128"
+   id="svg4954">
   <defs
      id="defs4956">
     <linearGradient
        id="linearGradient4356">
       <stop
-         offset="0"
+         id="stop4358"
          style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop4358" />
+         offset="0" />
       <stop
-         id="stop4360"
+         offset="0.01283212"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.01283212" />
+         id="stop4360" />
       <stop
-         offset="0.98265791"
+         id="stop4362"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop4362" />
+         offset="0.98265791" />
       <stop
-         offset="1"
+         id="stop4364"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop4364" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2">
       <stop
-         offset="0"
+         id="stop3602-1-25-9"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-6-5-6"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-6-5-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-4-2-1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-4-2-1" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-1-7-1"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-1-7-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-2-4-5"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-2-4-5" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-8-1-1"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-8-1-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-0-6-4"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-0-6-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-2"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-4"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-3"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-3" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-9"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-5">
       <stop
-         offset="0"
+         id="stop3106-9"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,146.70866,219.72585)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5"
-       id="linearGradient3091"
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084" />
-    <linearGradient
-       xlink:href="#linearGradient4356"
-       id="linearGradient3076"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,17.90543)"
-       x1="23.999994"
-       y1="5.2628093"
-       x2="23.99999"
-       y2="41.754993" />
-    <linearGradient
-       y2="37.546188"
-       x2="25.132275"
-       y1="15.284525"
-       x1="25.132275"
-       gradientTransform="matrix(2.9136939,0,0,2.9573295,-2.3848139,-1.0517271)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3917"
-       xlink:href="#linearGradient3600-3-2-2" />
-    <linearGradient
-       y2="35.721317"
-       x2="24"
-       y1="14.203104"
-       x1="24"
-       gradientTransform="matrix(4.2341648,0,0,2.3350645,-20.70947,0.56392794)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3928"
-       xlink:href="#linearGradient3211-8-8-9" />
-    <linearGradient
-       y2="37.267109"
-       x2="25.132275"
-       y1="10.060704"
-       x1="25.132275"
-       gradientTransform="matrix(4.0656632,0,0,2.2421191,-19.37221,-0.55729706)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3931"
-       xlink:href="#linearGradient3600-3-2-2-6-8" />
-    <linearGradient
-       y2="11.941198"
-       x2="-51.833466"
-       y1="41.012497"
-       x1="-51.833466"
-       gradientTransform="matrix(3.2830096,0,0,2.0982895,222.16977,-3.0560921)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3933"
-       xlink:href="#linearGradient3104-9-7-3-9-6" />
-    <linearGradient
-       y2="36.481995"
-       x2="24"
-       y1="4.9902573"
-       x1="24"
-       gradientTransform="matrix(5.9859991,0,0,0.22228053,-55.820217,14.890763)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3936"
-       xlink:href="#linearGradient3211-8-8-0-0-9" />
-    <linearGradient
-       y2="35.416233"
-       x2="25.132275"
-       y1="12.629268"
-       x1="25.132275"
-       gradientTransform="matrix(5.3695381,0,0,0.30719318,-46.335455,12.120375)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3939"
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7" />
-    <linearGradient
-       y2="14.685826"
-       x2="-51.816425"
-       y1="38.70771"
-       x1="-51.816425"
-       gradientTransform="matrix(4.3358848,0,0,0.28748705,272.67005,11.778015)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3941"
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,146.70866,251.72585)"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791"
+       id="linearGradient3091"
+       xlink:href="#linearGradient3104-5"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,146.70866,228.72585)" />
+    <linearGradient
+       y2="41.754993"
+       x2="23.99999"
+       y1="5.2628093"
+       x1="23.999994"
+       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,26.90543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4356" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2"
+       id="linearGradient3917"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9136939,0,0,2.9573295,-2.3848139,7.9482731)"
+       x1="25.132275"
+       y1="15.284525"
+       x2="25.132275"
+       y2="37.546188" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-9"
+       id="linearGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.2341648,0,0,2.3350645,-20.70947,9.5639281)"
+       x1="24"
+       y1="14.203104"
+       x2="24"
+       y2="35.721317" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-8"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.0656632,0,0,2.2421191,-19.37221,8.4427031)"
+       x1="25.132275"
+       y1="10.060704"
+       x2="25.132275"
+       y2="37.267109" />
+    <linearGradient
+       xlink:href="#linearGradient3104-9-7-3-9-6"
+       id="linearGradient3933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.2830096,0,0,2.0982895,222.16977,5.9439081)"
+       x1="-51.833466"
+       y1="41.012497"
+       x2="-51.833466"
+       y2="11.941198" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       id="linearGradient3936"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.9859991,0,0,0.22228053,-55.820217,23.890763)"
+       x1="24"
+       y1="4.9902573"
+       x2="24"
+       y2="36.481995" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.3695381,0,0,0.30719318,-46.335455,21.120375)"
+       x1="25.132275"
+       y1="12.629268"
+       x2="25.132275"
+       y2="35.416233" />
+    <linearGradient
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
+       id="linearGradient3941"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.3358848,0,0,0.28748705,272.67005,20.778015)"
+       x1="-51.816425"
+       y1="38.70771"
+       x2="-51.816425"
+       y2="14.685826" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient3968"
-       xlink:href="#linearGradient3104-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,146.70866,260.72585)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
     <linearGradient
        id="linearGradient3702-501-757-795">
       <stop
-         id="stop3100"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop3100" />
       <stop
-         id="stop3102"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop3102" />
       <stop
-         id="stop3104"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3104" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309-604">
       <stop
-         id="stop3094"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop3094" />
       <stop
-         id="stop3096"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3096" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-166-749-654">
       <stop
-         id="stop3088"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop3088" />
       <stop
-         id="stop3090"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3090" />
     </linearGradient>
     <radialGradient
-       r="2.5"
-       fy="43.5"
-       fx="4.9929786"
-       cy="43.5"
-       cx="4.9929786"
-       gradientTransform="matrix(1.9035948,0,0,1.2599994,28.738724,-10.959975)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-654"
        id="radialGradient4172"
-       xlink:href="#linearGradient3688-166-749-654" />
-    <radialGradient
-       r="2.5"
-       fy="43.5"
-       fx="4.9929786"
-       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.2599994,28.738724,-10.959975)"
        cx="4.9929786"
-       gradientTransform="matrix(1.9035948,0,0,1.2599994,-19.261277,-98.659973)"
-       gradientUnits="userSpaceOnUse"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309-604"
        id="radialGradient4174"
-       xlink:href="#linearGradient3688-464-309-604" />
-    <linearGradient
-       gradientTransform="matrix(1.0178572,0,0,0.89999962,-0.42857159,4.7000205)"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.2599994,-19.261277,-98.659973)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757-795"
        id="linearGradient4176"
-       xlink:href="#linearGradient3702-501-757-795" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084"
-       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,124.39616,219.72585)"
        gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       gradientTransform="matrix(1.0178572,0,0,0.89999962,-0.42857159,4.7000205)" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient4180"
-       xlink:href="#linearGradient3104-5" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084"
-       gradientTransform="matrix(-2.6788351,0,0,3.9652608,122.77116,-69.725859)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,124.39616,228.72585)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient4185"
-       xlink:href="#linearGradient3104-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.6788351,0,0,3.9652608,122.77116,-60.725859)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9"
+         offset="0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop3750-1-0-7-6-6-1-3-9" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0"
+         offset="0.26238"
          style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
+         id="stop3752-3-7-4-0-32-8-923-0" />
       <stop
-         id="stop3754-1-8-5-2-7-6-7-1"
+         offset="0.704952"
          style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
+         id="stop3754-1-8-5-2-7-6-7-1" />
       <stop
-         id="stop3756-1-6-2-6-6-1-96-6"
+         offset="1"
          style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3756-1-6-2-6-6-1-96-6" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8"
-       id="radialGradient4173-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,20.456265,-25.113759,0,302.02937,-159.84671)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
+       r="12.671875"
        fy="9.9571075"
-       r="12.671875" />
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,20.456265,-25.113759,0,302.02937,-150.84671)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4173-5"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9-9-0"
+         offset="0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop3750-1-0-7-6-6-1-3-9-9-0" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7-8"
+         offset="0.26238"
          style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
+         id="stop3752-3-7-4-0-32-8-923-0-7-8" />
       <stop
-         id="stop3754-1-8-5-2-7-6-7-1-8-0"
+         offset="0.704952"
          style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
+         id="stop3754-1-8-5-2-7-6-7-1-8-0" />
       <stop
-         id="stop3756-1-6-2-6-6-1-96-6-1-1"
+         offset="1"
          style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3756-1-6-2-6-6-1-96-6-1-1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4356-5"
-       id="linearGradient3076-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,17.90543)"
-       x1="23.999994"
-       y1="5.2628093"
+       y2="41.754993"
        x2="23.99999"
-       y2="41.754993" />
+       y1="5.2628093"
+       x1="23.999994"
+       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,26.90543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3076-9"
+       xlink:href="#linearGradient4356-5" />
     <linearGradient
        id="linearGradient4356-5">
       <stop
-         offset="0"
+         id="stop4358-6"
          style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop4358-6" />
+         offset="0" />
       <stop
-         id="stop4360-9"
+         offset="0.01283212"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.01283212" />
+         id="stop4360-9" />
       <stop
-         offset="0.98265791"
+         id="stop4362-4"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop4362-4" />
+         offset="0.98265791" />
       <stop
-         offset="1"
+         id="stop4364-6"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop4364-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         id="stop3106-3-2"
+         offset="0"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
+         id="stop3106-3-2" />
       <stop
-         id="stop3108-9-8-3"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
+         id="stop3108-9-8-3" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3104-6-6-1"
-       id="linearGradient4420"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6301305,0,0,1.6674276,179.33609,21.019469)"
-       x1="-51.786404"
-       y1="50.786446"
+       y2="2.9062471"
        x2="-51.786404"
-       y2="2.9062471" />
-    <radialGradient
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.62513)"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(2.6301305,0,0,1.6674276,179.33609,30.019469)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       id="linearGradient4420"
+       xlink:href="#linearGradient3104-6-6-1" />
+    <radialGradient
+       cx="6.5633106"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
        id="radialGradient3029"
-       fy="9.9571075"
-       fx="6.0330806"
-       r="12.671875"
-       cy="9.9571075"
-       cx="6.5633106" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
-       cx="6.5633106"
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.63209)"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.62513)" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4341"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
-       cx="6.5633106"
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.6342)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.63209)"
+       cx="6.5633106"
+       cy="9.9571075"
+       fx="6.0330806"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4343"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.6342)"
+       cx="6.5633106"
+       cy="9.9571075"
+       fx="6.0330806"
+       fy="9.9571075"
+       r="12.671875" />
   </defs>
   <metadata
      id="metadata4959">
@@ -433,116 +433,116 @@
     </rdf:RDF>
   </metadata>
   <g
-     style="opacity:0.15"
+     transform="matrix(3.368421,0,0,1.4285713,-16.842106,55.857146)"
      id="g3712"
-     transform="matrix(3.368421,0,0,1.4285713,-16.842106,46.857146)">
+     style="opacity:0.15">
     <rect
-       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none"
-       id="rect2801"
-       y="40.700001"
+       width="4.75"
+       height="6.2999973"
        x="38.25"
-       height="6.2999973"
-       width="4.75" />
+       y="40.700001"
+       id="rect2801"
+       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none" />
     <rect
-       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none"
-       id="rect3696"
-       transform="scale(-1,-1)"
-       y="-47"
+       width="4.75"
+       height="6.2999973"
        x="-9.75"
-       height="6.2999973"
-       width="4.75" />
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none" />
     <rect
-       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none"
-       id="rect3700"
-       y="40.700005"
-       x="9.75"
+       width="28.5"
        height="6.2999973"
-       width="28.5" />
+       x="9.75"
+       y="40.700005"
+       id="rect3700"
+       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none" />
   </g>
   <path
-     d="m 28.5,15.499926 71,0 0,8.000155 -71,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-4-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 28.5,24.499926 71,0 0,8.000155 -71,0 z" />
   <path
-     d="m 29.499921,16.5 69.000079,0 0,6.000081 -69.000079,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-6-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 29.499921,25.5 69.000079,0 0,6.000081 -69.000079,0 z" />
   <path
-     d="M 16.499961,21.499925 111.5,21.5 l 0,61.000084 -94.999961,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="M 16.499961,30.499925 111.5,30.5 l 0,61.000084 -94.999961,0 z" />
   <path
-     d="m 17.5,22.5 93,0 0,58.000078 -93,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 17.5,31.5 93,0 0,58.000078 -93,0 z" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
-     id="rect4964"
-     y="28"
-     x="18"
+     width="103"
      height="81"
-     width="103" />
+     x="18"
+     y="37"
+     id="rect4964"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4964-1"
-     y="28.5"
-     x="7.5"
+     width="113"
      height="80"
-     width="113" />
+     x="7.5"
+     y="37.5"
+     id="rect4964-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 18,109.5 -11.5,0 c 0,-28 0.026032,-57.676631 0,-82 l 11.5,-3e-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+     d="m 18,118.5 -11.5,0 c 0,-28 0.026032,-57.676631 0,-82 l 11.5,-3e-6" />
   <path
-     id="rect6741-1-5"
-     d="m 17.5,108.5 -10,0 0,-80 10,0"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 17.5,117.5 -10,0 0,-80 10,0"
+     id="rect6741-1-5" />
   <path
-     d="m 18,109.5 -11.5,0 c 0,-28.5 0.025903,-57.678098 0,-82 l 11.5,-3e-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path4530-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 18,118.5 -11.5,0 c 0,-28.5 0.025903,-57.678098 0,-82 l 11.5,-3e-6" />
   <path
-     id="path4160-6-1"
-     d="m 18,109.5 103.5,0 0,-81.999997 -103.5,0"
-     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 18,118.5 103.5,0 0,-81.999997 -103.5,0"
+     id="path4160-6-1" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     d="m 110,88.999999 0,-2 -4,0 0,2 z m -5,0 0,-2 -12.999998,0 0,2 z m 5,-8 L 110,79 l -6,0 0,1.999999 z m -7,0 L 103,79 l -5,0 0,1.999999 z m -6,0 L 97,79 l -3,0 0,1.999999 z m -4,0 L 93,79 l -4,0 0,1.999999 z M 110,73 l 0,-2 -7,0 0,2 z m -8,0 0,-2 -3,0 0,2 z m -4,0 0,-2 -8,0 0,2 z m 12,-8 0,-2 -7,0 0,2 z m -8,0 0,-2 -5,0 0,2 z m -6,0 0,-2 -7,0 0,2 z"
      id="path3475-4"
-     d="m 110,79.999999 0,-2 -4,0 0,2 z m -5,0 0,-2 -12.999998,0 0,2 z m 5,-8 L 110,70 l -6,0 0,1.999999 z m -7,0 L 103,70 l -5,0 0,1.999999 z m -6,0 L 97,70 l -3,0 0,1.999999 z m -4,0 L 93,70 l -4,0 0,1.999999 z M 110,64 l 0,-2 -7,0 0,2 z m -8,0 0,-2 -3,0 0,2 z m -4,0 0,-2 -8,0 0,2 z m 12,-8 0,-2 -7,0 0,2 z m -8,0 0,-2 -5,0 0,2 z m -6,0 0,-2 -7,0 0,2 z" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     d="m 64.000001,38 0,2 -2.000001,-2e-6 0,-2 z M 61,37.999998 l 0,2 -5,0 0,-2 z m -6.999998,0 0,2 -6,2e-6 0,-2 z m 39.999998,0 0,2 -12,0 0,-2 z m -13,0 0,2 -6,0 0,-2 z m -6.999999,0 0,2 -8.000001,0 0,-2 z"
+     id="path3925"
      style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="path3925" />
+     d="m 64.000001,47 0,2 -2.000001,-2e-6 0,-2 z M 61,46.999998 l 0,2 -5,0 0,-2 z m -6.999998,0 0,2 -6,2e-6 0,-2 z m 39.999998,0 0,2 -12,0 0,-2 z m -13,0 0,2 -6,0 0,-2 z m -6.999999,0 0,2 -8.000001,0 0,-2 z" />
   <path
-     d="m 110,95.999998 0,-2 -7,0 0,2 z m -8,0 0,-2 -3,0 0,2 z m -4,0 0,-2 -7,0 0,2 z m 12,-7.999999 0,-2 -6,0 0,2 z m -7,0 0,-2 -5,0 0,2 z m -6,0 0,-2 -8,0 0,2 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path3966"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+     d="m 110,105 0,-2 -7,0 0,2 z m -8,0 0,-2 -3,0 0,2 z m -4,0 0,-2 -7,0 0,2 z m 12,-8.000001 0,-2 -6,0 0,2 z m -7,0 0,-2 -5,0 0,2 z m -6,0 0,-2 -8,0 0,2 z" />
   <path
-     d="m 88,80.000001 0,-2 -5,0 0,2 z m 0,-8 0,-2 -6,0 0,2 z m 1,-7.999999 0,-2 -5,0 0,2 z m -2,-8 0,-2 -5,0 0,2 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path4178"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+     d="m 88,89.000001 0,-2 -5,0 0,2 z m 0,-8 0,-2 -6,0 0,2 z m 1,-7.999999 0,-2 -5,0 0,2 z m -2,-8 0,-2 -5,0 0,2 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     d="m 88,95.000001 0,2 -7,0 0,-2 z m -8,0 0,2 -3,0 0,-2 z M 89,103 l 0,2 -7,0 0,-2 z m -8,0 0,2 -5,0 0,-2 z m -6,0 0,2 -7,0 0,-2 z"
      id="path4183"
-     d="m 88,86.000001 0,2 -7,0 0,-2 z m -8,0 0,2 -3,0 0,-2 z M 89,94 l 0,2 -7,0 0,-2 z m -8,0 0,2 -5,0 0,-2 z m -6,0 0,2 -7,0 0,-2 z" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     d="M 67.999998,74.999995 A 19.999999,19.999999 0 1 1 57.420232,57.357462 l -9.420236,17.642533 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
      id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+     d="M 67.999998,83.999995 A 19.999999,19.999999 0 1 1 57.420232,66.357462 l -9.420236,17.642533 z" />
   <g
-     transform="translate(-42.000002,-0.00199978)"
-     id="g4387">
+     id="g4387"
+     transform="translate(-42.000002,8.9980004)">
     <path
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4341);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 110,73.999995 A 19.999999,19.999999 0 1 1 99.420234,56.357462 l -9.420236,17.642533 z"
        id="path3035"
-       d="M 110,73.999995 A 19.999999,19.999999 0 1 1 99.420234,56.357462 l -9.420236,17.642533 z" />
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4341);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       d="M 110,73.997889 C 110,83 104,90.874324 95.33681,93.27249 86.68495,95.66752 77.5,92.035573 72.850413,84.282045 72.815033,84.314125 89.999998,73.997889 89.999998,73.997889 Z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="path3964"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       d="M 110,73.997889 C 110,83 104,90.874324 95.33681,93.27249 86.68495,95.66752 77.5,92.035573 72.850413,84.282045 72.815033,84.314125 89.999998,73.997889 89.999998,73.997889 Z" />
     <path
-       d="m 110,74.006966 c 0,8.671378 -5.804,16.822178 -14.66319,19.274601 -0.19524,-0.0339 -5.336812,-19.274601 -5.336812,-19.274601 z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="path3962"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       d="m 110,74.006966 c 0,8.671378 -5.804,16.822178 -14.66319,19.274601 -0.19524,-0.0339 -5.336812,-19.274601 -5.336812,-19.274601 z" />
   </g>
 </svg>

--- a/mimes/128/x-office-presentation-template-rtl.svg
+++ b/mimes/128/x-office-presentation-template-rtl.svg
@@ -6,492 +6,492 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4954"
-   height="128"
+   version="1.1"
    width="128"
-   version="1.1">
+   height="128"
+   id="svg4954">
   <defs
      id="defs4956">
     <linearGradient
        id="linearGradient4356">
       <stop
-         offset="0"
+         id="stop4358"
          style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop4358" />
+         offset="0" />
       <stop
-         id="stop4360"
+         offset="0.01283212"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.01283212" />
+         id="stop4360" />
       <stop
-         offset="0.98265791"
+         id="stop4362"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop4362" />
+         offset="0.98265791" />
       <stop
-         offset="1"
+         id="stop4364"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop4364" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2">
       <stop
-         offset="0"
+         id="stop3602-1-25-9"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-6-5-6"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-6-5-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-4-2-1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-4-2-1" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-1-7-1"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-1-7-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-2-4-5"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-2-4-5" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-8-1-1"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-8-1-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-0-6-4"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-0-6-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-2"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-4"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-3"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-3" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-9"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-5">
       <stop
-         offset="0"
+         id="stop3106-9"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,146.70866,219.72585)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5"
-       id="linearGradient3091"
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084" />
-    <linearGradient
-       xlink:href="#linearGradient4356"
-       id="linearGradient3076"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,17.90543)"
-       x1="23.999994"
-       y1="5.2628093"
-       x2="23.99999"
-       y2="41.754993" />
-    <linearGradient
-       y2="37.546188"
-       x2="25.132275"
-       y1="15.284525"
-       x1="25.132275"
-       gradientTransform="matrix(2.9136939,0,0,2.9573295,-2.3848139,-1.0517271)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3917"
-       xlink:href="#linearGradient3600-3-2-2" />
-    <linearGradient
-       y2="35.721317"
-       x2="24"
-       y1="14.203104"
-       x1="24"
-       gradientTransform="matrix(4.2341648,0,0,2.3350645,-20.70947,0.56392794)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3928"
-       xlink:href="#linearGradient3211-8-8-9" />
-    <linearGradient
-       y2="37.267109"
-       x2="25.132275"
-       y1="10.060704"
-       x1="25.132275"
-       gradientTransform="matrix(4.0656632,0,0,2.2421191,-19.37221,-0.55729706)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3931"
-       xlink:href="#linearGradient3600-3-2-2-6-8" />
-    <linearGradient
-       y2="11.941198"
-       x2="-51.833466"
-       y1="41.012497"
-       x1="-51.833466"
-       gradientTransform="matrix(3.2830096,0,0,2.0982895,222.16977,-3.0560921)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3933"
-       xlink:href="#linearGradient3104-9-7-3-9-6" />
-    <linearGradient
-       y2="36.481995"
-       x2="24"
-       y1="4.9902573"
-       x1="24"
-       gradientTransform="matrix(5.9859991,0,0,0.22228053,-55.820217,14.890763)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3936"
-       xlink:href="#linearGradient3211-8-8-0-0-9" />
-    <linearGradient
-       y2="35.416233"
-       x2="25.132275"
-       y1="12.629268"
-       x1="25.132275"
-       gradientTransform="matrix(5.3695381,0,0,0.30719318,-46.335455,12.120375)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3939"
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7" />
-    <linearGradient
-       y2="14.685826"
-       x2="-51.816425"
-       y1="38.70771"
-       x1="-51.816425"
-       gradientTransform="matrix(4.3358848,0,0,0.28748705,272.67005,11.778015)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3941"
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,146.70866,251.72585)"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791"
+       id="linearGradient3091"
+       xlink:href="#linearGradient3104-5"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,146.70866,228.72585)" />
+    <linearGradient
+       y2="41.754993"
+       x2="23.99999"
+       y1="5.2628093"
+       x1="23.999994"
+       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,26.90543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4356" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2"
+       id="linearGradient3917"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9136939,0,0,2.9573295,-2.3848139,7.9482731)"
+       x1="25.132275"
+       y1="15.284525"
+       x2="25.132275"
+       y2="37.546188" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-9"
+       id="linearGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.2341648,0,0,2.3350645,-20.70947,9.5639281)"
+       x1="24"
+       y1="14.203104"
+       x2="24"
+       y2="35.721317" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-8"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.0656632,0,0,2.2421191,-19.37221,8.4427031)"
+       x1="25.132275"
+       y1="10.060704"
+       x2="25.132275"
+       y2="37.267109" />
+    <linearGradient
+       xlink:href="#linearGradient3104-9-7-3-9-6"
+       id="linearGradient3933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.2830096,0,0,2.0982895,222.16977,5.9439081)"
+       x1="-51.833466"
+       y1="41.012497"
+       x2="-51.833466"
+       y2="11.941198" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       id="linearGradient3936"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.9859991,0,0,0.22228053,-55.820217,23.890763)"
+       x1="24"
+       y1="4.9902573"
+       x2="24"
+       y2="36.481995" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.3695381,0,0,0.30719318,-46.335455,21.120375)"
+       x1="25.132275"
+       y1="12.629268"
+       x2="25.132275"
+       y2="35.416233" />
+    <linearGradient
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
+       id="linearGradient3941"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.3358848,0,0,0.28748705,272.67005,20.778015)"
+       x1="-51.816425"
+       y1="38.70771"
+       x2="-51.816425"
+       y2="14.685826" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient3968"
-       xlink:href="#linearGradient3104-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,146.70866,260.72585)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
     <linearGradient
        id="linearGradient3702-501-757-795">
       <stop
-         id="stop3100"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop3100" />
       <stop
-         id="stop3102"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop3102" />
       <stop
-         id="stop3104"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3104" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309-604">
       <stop
-         id="stop3094"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop3094" />
       <stop
-         id="stop3096"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3096" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-166-749-654">
       <stop
-         id="stop3088"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop3088" />
       <stop
-         id="stop3090"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3090" />
     </linearGradient>
     <radialGradient
-       r="2.5"
-       fy="43.5"
-       fx="4.9929786"
-       cy="43.5"
-       cx="4.9929786"
-       gradientTransform="matrix(1.9035948,0,0,1.2599994,28.738724,-10.959975)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-654"
        id="radialGradient4172"
-       xlink:href="#linearGradient3688-166-749-654" />
-    <radialGradient
-       r="2.5"
-       fy="43.5"
-       fx="4.9929786"
-       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.2599994,28.738724,-10.959975)"
        cx="4.9929786"
-       gradientTransform="matrix(1.9035948,0,0,1.2599994,-19.261277,-98.659973)"
-       gradientUnits="userSpaceOnUse"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309-604"
        id="radialGradient4174"
-       xlink:href="#linearGradient3688-464-309-604" />
-    <linearGradient
-       gradientTransform="matrix(1.0178572,0,0,0.89999962,-0.42857159,4.7000205)"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.2599994,-19.261277,-98.659973)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757-795"
        id="linearGradient4176"
-       xlink:href="#linearGradient3702-501-757-795" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084"
-       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,124.39616,219.72585)"
        gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       gradientTransform="matrix(1.0178572,0,0,0.89999962,-0.42857159,4.7000205)" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient4180"
-       xlink:href="#linearGradient3104-5" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084"
-       gradientTransform="matrix(-2.6788351,0,0,3.9652608,122.77116,-69.725859)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.6788351,0,0,-3.9652608,124.39616,228.72585)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient4185"
-       xlink:href="#linearGradient3104-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.6788351,0,0,3.9652608,122.77116,-60.725859)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9"
+         offset="0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop3750-1-0-7-6-6-1-3-9" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0"
+         offset="0.26238"
          style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
+         id="stop3752-3-7-4-0-32-8-923-0" />
       <stop
-         id="stop3754-1-8-5-2-7-6-7-1"
+         offset="0.704952"
          style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
+         id="stop3754-1-8-5-2-7-6-7-1" />
       <stop
-         id="stop3756-1-6-2-6-6-1-96-6"
+         offset="1"
          style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3756-1-6-2-6-6-1-96-6" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8"
-       id="radialGradient4173-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,20.456265,-25.113759,0,302.02937,-159.84671)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
+       r="12.671875"
        fy="9.9571075"
-       r="12.671875" />
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,20.456265,-25.113759,0,302.02937,-150.84671)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4173-5"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9-9-0"
+         offset="0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop3750-1-0-7-6-6-1-3-9-9-0" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7-8"
+         offset="0.26238"
          style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
+         id="stop3752-3-7-4-0-32-8-923-0-7-8" />
       <stop
-         id="stop3754-1-8-5-2-7-6-7-1-8-0"
+         offset="0.704952"
          style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
+         id="stop3754-1-8-5-2-7-6-7-1-8-0" />
       <stop
-         id="stop3756-1-6-2-6-6-1-96-6-1-1"
+         offset="1"
          style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3756-1-6-2-6-6-1-96-6-1-1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4356-5"
-       id="linearGradient3076-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,17.90543)"
-       x1="23.999994"
-       y1="5.2628093"
+       y2="41.754993"
        x2="23.99999"
-       y2="41.754993" />
+       y1="5.2628093"
+       x1="23.999994"
+       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,26.90543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3076-9"
+       xlink:href="#linearGradient4356-5" />
     <linearGradient
        id="linearGradient4356-5">
       <stop
-         offset="0"
+         id="stop4358-6"
          style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop4358-6" />
+         offset="0" />
       <stop
-         id="stop4360-9"
+         offset="0.01283212"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.01283212" />
+         id="stop4360-9" />
       <stop
-         offset="0.98265791"
+         id="stop4362-4"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop4362-4" />
+         offset="0.98265791" />
       <stop
-         offset="1"
+         id="stop4364-6"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop4364-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         id="stop3106-3-2"
+         offset="0"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
+         id="stop3106-3-2" />
       <stop
-         id="stop3108-9-8-3"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
+         id="stop3108-9-8-3" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3104-6-6-1"
-       id="linearGradient4420"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6301305,0,0,1.6674276,179.33609,21.019469)"
-       x1="-51.786404"
-       y1="50.786446"
+       y2="2.9062471"
        x2="-51.786404"
-       y2="2.9062471" />
-    <radialGradient
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.62513)"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(2.6301305,0,0,1.6674276,179.33609,30.019469)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
-       id="radialGradient3029"
-       fy="9.9571075"
-       fx="6.0330806"
-       r="12.671875"
+       id="linearGradient4420"
+       xlink:href="#linearGradient3104-6-6-1" />
+    <radialGradient
+       cx="6.5633106"
        cy="9.9571075"
-       cx="6.5633106" />
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
+       id="radialGradient3029"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.62513)" />
     <linearGradient
        id="linearGradient22140">
       <stop
-         offset="0"
+         id="stop22142"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop22142" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop22148"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop22148" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop22144"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop22144" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3412">
       <stop
-         offset="0"
+         id="stop3414"
          style="stop-color:#f0f0f1;stop-opacity:1"
-         id="stop3414" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3416"
          style="stop-color:#cbcdd9;stop-opacity:1"
-         id="stop3416" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
-       cx="6.5633106"
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.63209)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4341"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.63209)"
        cx="6.5633106"
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.6342)"
-       gradientUnits="userSpaceOnUse"
+       cy="9.9571075"
+       fx="6.0330806"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4343"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="3.5"
-       fy="39.464806"
-       fx="7"
-       cy="39.464806"
-       cx="7"
-       gradientTransform="matrix(0,0.89962666,-0.93506352,1.4451651e-8,81.629374,32.204085)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.6342)"
+       cx="6.5633106"
+       cy="9.9571075"
+       fx="6.0330806"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient3104-6-6-1"
        id="radialGradient3159"
-       xlink:href="#linearGradient3104-6-6-1" />
-    <linearGradient
-       gradientTransform="matrix(1,0,0,0.89962592,0,3.8658766)"
-       y2="42.040661"
-       x2="18.142136"
-       y1="35"
-       x1="18.142136"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3161"
-       xlink:href="#linearGradient22140" />
-    <radialGradient
-       r="3.5"
-       fy="39.464806"
-       fx="7"
-       cy="39.464806"
+       gradientTransform="matrix(0,0.89962666,-0.93506352,1.4451651e-8,81.629374,32.204085)"
        cx="7"
-       gradientTransform="matrix(0,0.89962666,0.62337568,1.4451651e-8,-21.328656,32.204085)"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient22140"
+       id="linearGradient3161"
        gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661"
+       gradientTransform="matrix(1,0,0,0.89962592,0,3.8658766)" />
+    <radialGradient
+       xlink:href="#linearGradient3104-6-6-1"
        id="radialGradient4320"
-       xlink:href="#linearGradient3104-6-6-1" />
-    <linearGradient
-       y2="50.73642"
-       x2="45.902721"
-       y1="35.285313"
-       x1="30.739399"
-       gradientTransform="matrix(0,5.4100631,-5.3070628,0,309.7614,-121.83734)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.89962666,0.62337568,1.4451651e-8,-21.328656,32.204085)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient3412"
        id="linearGradient3163"
-       xlink:href="#linearGradient3412" />
-    <linearGradient
-       y2="127.03607"
-       x2="75.779678"
-       y1="86"
-       x1="75.779678"
-       gradientTransform="matrix(-2,0,0,2.0008421,236.50002,-127.60767)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.4100631,-5.3070628,0,309.7614,-121.83734)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-0-0-9"
        id="linearGradient3165"
-       xlink:href="#linearGradient3211-8-8-0-0-9" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,0,0,2.0008421,236.50002,-127.60767)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata4959">
@@ -506,196 +506,196 @@
     </rdf:RDF>
   </metadata>
   <g
-     style="opacity:0.15"
+     transform="matrix(3.368421,0,0,1.4285713,-16.842106,55.857146)"
      id="g3712"
-     transform="matrix(3.368421,0,0,1.4285713,-16.842106,46.857146)">
+     style="opacity:0.15">
     <rect
-       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none"
-       id="rect2801"
-       y="40.700001"
+       width="4.75"
+       height="6.2999973"
        x="38.25"
-       height="6.2999973"
-       width="4.75" />
+       y="40.700001"
+       id="rect2801"
+       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none" />
     <rect
-       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none"
-       id="rect3696"
-       transform="scale(-1,-1)"
-       y="-47"
+       width="4.75"
+       height="6.2999973"
        x="-9.75"
-       height="6.2999973"
-       width="4.75" />
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none" />
     <rect
-       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none"
-       id="rect3700"
-       y="40.700005"
-       x="9.75"
+       width="28.5"
        height="6.2999973"
-       width="28.5" />
+       x="9.75"
+       y="40.700005"
+       id="rect3700"
+       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none" />
   </g>
   <path
-     d="m 28.5,15.499926 71,0 0,8.000155 -71,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-4-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 28.5,24.499926 71,0 0,8.000155 -71,0 z" />
   <path
-     d="m 29.499921,16.5 69.000079,0 0,6.000081 -69.000079,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-6-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 29.499921,25.5 69.000079,0 0,6.000081 -69.000079,0 z" />
   <path
-     d="M 16.499961,21.499925 111.5,21.5 l 0,61.000084 -94.999961,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="M 16.499961,30.499925 111.5,30.5 l 0,61.000084 -94.999961,0 z" />
   <path
-     d="m 17.5,22.5 93,0 0,58.000078 -93,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 17.5,31.5 93,0 0,58.000078 -93,0 z" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
-     id="rect4964"
-     y="28"
-     x="18"
+     width="103"
      height="81"
-     width="103" />
+     x="18"
+     y="37"
+     id="rect4964"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4964-1"
-     y="28.5"
-     x="7.5"
+     width="113"
      height="80"
-     width="113" />
+     x="7.5"
+     y="37.5"
+     id="rect4964-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 18,109.5 -11.5,0 c 0,-28 0.026032,-57.676631 0,-82 l 11.5,-3e-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+     d="m 18,118.5 -11.5,0 c 0,-28 0.026032,-57.676631 0,-82 l 11.5,-3e-6" />
   <path
-     id="rect6741-1-5"
-     d="m 17.5,108.5 -10,0 0,-80 10,0"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 17.5,117.5 -10,0 0,-80 10,0"
+     id="rect6741-1-5" />
   <path
-     d="m 18,109.5 -11.5,0 c 0,-28.5 0.025903,-57.678098 0,-82 l 11.5,-3e-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path4530-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 18,118.5 -11.5,0 c 0,-28.5 0.025903,-57.678098 0,-82 l 11.5,-3e-6" />
   <path
-     id="path4160-6-1"
-     d="m 18,109.5 103.5,0 0,-81.999997 -103.5,0"
-     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 18,118.5 103.5,0 0,-81.999997 -103.5,0"
+     id="path4160-6-1" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     d="m 110,88.999999 0,-2 -4,0 0,2 z m -5,0 0,-2 -12.999998,0 0,2 z m 5,-8 L 110,79 l -6,0 0,1.999999 z m -7,0 L 103,79 l -5,0 0,1.999999 z m -6,0 L 97,79 l -3,0 0,1.999999 z m -4,0 L 93,79 l -4,0 0,1.999999 z M 110,73 l 0,-2 -7,0 0,2 z m -8,0 0,-2 -3,0 0,2 z m -4,0 0,-2 -8,0 0,2 z m 12,-8 0,-2 -7,0 0,2 z m -8,0 0,-2 -5,0 0,2 z m -6,0 0,-2 -7,0 0,2 z"
      id="path3475-4"
-     d="m 110,79.999999 0,-2 -4,0 0,2 z m -5,0 0,-2 -12.999998,0 0,2 z m 5,-8 L 110,70 l -6,0 0,1.999999 z m -7,0 L 103,70 l -5,0 0,1.999999 z m -6,0 L 97,70 l -3,0 0,1.999999 z m -4,0 L 93,70 l -4,0 0,1.999999 z M 110,64 l 0,-2 -7,0 0,2 z m -8,0 0,-2 -3,0 0,2 z m -4,0 0,-2 -8,0 0,2 z m 12,-8 0,-2 -7,0 0,2 z m -8,0 0,-2 -5,0 0,2 z m -6,0 0,-2 -7,0 0,2 z" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     d="m 64.000001,38 0,2 -2.000001,-2e-6 0,-2 z M 61,37.999998 l 0,2 -5,0 0,-2 z m -6.999998,0 0,2 -6,2e-6 0,-2 z m 39.999998,0 0,2 -12,0 0,-2 z m -13,0 0,2 -6,0 0,-2 z m -6.999999,0 0,2 -8.000001,0 0,-2 z"
+     id="path3925"
      style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="path3925" />
+     d="m 64.000001,47 0,2 -2.000001,-2e-6 0,-2 z M 61,46.999998 l 0,2 -5,0 0,-2 z m -6.999998,0 0,2 -6,2e-6 0,-2 z m 39.999998,0 0,2 -12,0 0,-2 z m -13,0 0,2 -6,0 0,-2 z m -6.999999,0 0,2 -8.000001,0 0,-2 z" />
   <path
-     d="m 110,95.999998 0,-2 -7,0 0,2 z m -8,0 0,-2 -3,0 0,2 z m -4,0 0,-2 -7,0 0,2 z m 12,-7.999999 0,-2 -6,0 0,2 z m -7,0 0,-2 -5,0 0,2 z m -6,0 0,-2 -8,0 0,2 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path3966"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+     d="m 110,105 0,-2 -7,0 0,2 z m -8,0 0,-2 -3,0 0,2 z m -4,0 0,-2 -7,0 0,2 z m 12,-8.000001 0,-2 -6,0 0,2 z m -7,0 0,-2 -5,0 0,2 z m -6,0 0,-2 -8,0 0,2 z" />
   <path
-     d="m 88,80.000001 0,-2 -5,0 0,2 z m 0,-8 0,-2 -6,0 0,2 z m 1,-7.999999 0,-2 -5,0 0,2 z m -2,-8 0,-2 -5,0 0,2 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path4178"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+     d="m 88,89.000001 0,-2 -5,0 0,2 z m 0,-8 0,-2 -6,0 0,2 z m 1,-7.999999 0,-2 -5,0 0,2 z m -2,-8 0,-2 -5,0 0,2 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     d="m 88,95.000001 0,2 -7,0 0,-2 z m -8,0 0,2 -3,0 0,-2 z M 89,103 l 0,2 -7,0 0,-2 z m -8,0 0,2 -5,0 0,-2 z m -6,0 0,2 -7,0 0,-2 z"
      id="path4183"
-     d="m 88,86.000001 0,2 -7,0 0,-2 z m -8,0 0,2 -3,0 0,-2 z M 89,94 l 0,2 -7,0 0,-2 z m -8,0 0,2 -5,0 0,-2 z m -6,0 0,2 -7,0 0,-2 z" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     d="M 67.999998,74.999995 A 19.999999,19.999999 0 1 1 57.420232,57.357462 l -9.420236,17.642533 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
      id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+     d="M 67.999998,83.999995 A 19.999999,19.999999 0 1 1 57.420232,66.357462 l -9.420236,17.642533 z" />
   <g
-     transform="translate(-42.000002,-0.00199978)"
-     id="g4387">
+     id="g4387"
+     transform="translate(-42.000002,8.9980004)">
     <path
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4341);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 110,73.999995 A 19.999999,19.999999 0 1 1 99.420234,56.357462 l -9.420236,17.642533 z"
        id="path3035"
-       d="M 110,73.999995 A 19.999999,19.999999 0 1 1 99.420234,56.357462 l -9.420236,17.642533 z" />
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4341);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       d="M 110,73.997889 C 110,83 104,90.874324 95.33681,93.27249 86.68495,95.66752 77.5,92.035573 72.850413,84.282045 72.815033,84.314125 89.999998,73.997889 89.999998,73.997889 Z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="path3964"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       d="M 110,73.997889 C 110,83 104,90.874324 95.33681,93.27249 86.68495,95.66752 77.5,92.035573 72.850413,84.282045 72.815033,84.314125 89.999998,73.997889 89.999998,73.997889 Z" />
     <path
-       d="m 110,74.006966 c 0,8.671378 -5.804,16.822178 -14.66319,19.274601 -0.19524,-0.0339 -5.336812,-19.274601 -5.336812,-19.274601 z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="path3962"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       d="m 110,74.006966 c 0,8.671378 -5.804,16.822178 -14.66319,19.274601 -0.19524,-0.0339 -5.336812,-19.274601 -5.336812,-19.274601 z" />
   </g>
   <g
-     id="g4345"
-     transform="translate(4.0000019,-3.1647301e-7)">
+     transform="translate(4.0000019,-3.1647301e-7)"
+     id="g4345">
     <g
-       transform="matrix(-1.833334,0,0,1.4291655,126.00003,68.47502)"
+       style="opacity:0.3"
        id="g22150"
-       style="opacity:0.3">
+       transform="matrix(-1.833334,0,0,1.4291655,126.00003,68.47502)">
       <path
-         id="rect22134"
+         style="opacity:0.6;fill:url(#radialGradient3159);fill-opacity:1;stroke:none"
          d="m 45.001248,41.650166 -0.273974,0 c 0,-2.833822 0,-5.037905 0,-6.297381 l 0.273974,0 c 1.661308,0 2.998752,1.404316 2.998752,3.14869 0,1.744375 -1.337444,3.148691 -2.998752,3.148691 z"
-         style="opacity:0.6;fill:url(#radialGradient3159);fill-opacity:1;stroke:none" />
+         id="rect22134" />
       <rect
-         width="41.454529"
-         height="6.2973785"
-         x="3.2727435"
-         y="35.352783"
+         style="opacity:0.6;fill:url(#linearGradient3161);fill-opacity:1;stroke:none"
          id="rect22138"
-         style="opacity:0.6;fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
+         y="35.352783"
+         x="3.2727435"
+         height="6.2973785"
+         width="41.454529" />
       <path
-         style="opacity:0.6;fill:url(#radialGradient4320);fill-opacity:1;stroke:none"
+         id="path4318"
          d="m 3.0900944,41.650166 0.1826491,0 c 0,-2.833822 0,-5.037905 0,-6.297381 l -0.1826491,0 c -1.1075393,0 -1.9991683,1.404316 -1.9991683,3.14869 0,1.744375 0.891629,3.148691 1.9991683,3.148691 z"
-         id="path4318" />
+         style="opacity:0.6;fill:url(#radialGradient4320);fill-opacity:1;stroke:none" />
     </g>
     <path
-       d="M 121.50004,45.207214 41.212776,125.5 121.50004,125.499 Z m -16,37.002288 0,27.290538 -27.295082,-8e-5 z"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="path2993"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       d="M 121.50004,45.207214 41.212776,125.5 121.50004,125.499 Z m -16,37.002288 0,27.290538 -27.295082,-8e-5 z" />
     <path
-       d="m 98.500032,124.49288 0,-2.98929"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
        id="path3103"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 109.50003,125.49882 0,-4.00168 m -11.999998,4.00168 0,-4.00168 m -12,4.00168 0,-3.95406 m -12,3.95406 0,-4.00168 m -12,4.00168 0,-4.00168"
-       id="path3091"
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 120.5,47.615627 0,76.884373 -76.873279,0 z M 106.5,79.790078 75.779061,110.5 106.5,110.5 Z"
-       id="path3934"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4292"
-       d="m 110.50005,124.49288 0,-2.98929" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4294"
-       d="m 86.50005,124.49288 0,-2.98929" />
-    <path
-       d="m 74.50005,124.49288 0,-2.98929"
-       id="path4296"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4298"
-       d="m 62.50005,124.49288 0,-2.98929" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4300"
-       d="m 120.50286,78.499968 -2.98929,0" />
+       d="m 98.500032,124.49288 0,-2.98929" />
     <path
        style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4302"
-       d="m 121.5088,65.49995 -4.00168,0 m 4.00168,12 -4.00168,0 m 4.00168,12 -3.95406,0 m 3.95406,12 -4.00168,0 m 4.00168,12 -4.00168,0" />
+       id="path3091"
+       d="m 109.50003,125.49882 0,-4.00168 m -11.999998,4.00168 0,-4.00168 m -12,4.00168 0,-3.95406 m -12,3.95406 0,-4.00168 m -12,4.00168 0,-4.00168" />
     <path
-       d="m 120.50286,66.49995 -2.98929,0"
-       id="path4304"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 120.5,47.615627 0,76.884373 -76.873279,0 z M 106.5,79.790078 75.779061,110.5 106.5,110.5 Z" />
+    <path
+       d="m 110.50005,124.49288 0,-2.98929"
+       id="path4292"
        style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       d="m 120.50286,90.49995 -2.98929,0"
-       id="path4306"
+       d="m 86.50005,124.49288 0,-2.98929"
+       id="path4294"
        style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4308"
-       d="m 120.50286,102.49995 -2.98929,0" />
+       id="path4296"
+       d="m 74.50005,124.49288 0,-2.98929" />
     <path
-       d="m 120.50286,114.49995 -2.98929,0"
-       id="path4310"
+       d="m 62.50005,124.49288 0,-2.98929"
+       id="path4298"
        style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 120.50286,78.499968 -2.98929,0"
+       id="path4300"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 121.5088,65.49995 -4.00168,0 m 4.00168,12 -4.00168,0 m 4.00168,12 -3.95406,0 m 3.95406,12 -4.00168,0 m 4.00168,12 -4.00168,0"
+       id="path4302"
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4304"
+       d="m 120.50286,66.49995 -2.98929,0" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4306"
+       d="m 120.50286,90.49995 -2.98929,0" />
+    <path
+       d="m 120.50286,102.49995 -2.98929,0"
+       id="path4308"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4310"
+       d="m 120.50286,114.49995 -2.98929,0" />
   </g>
 </svg>

--- a/mimes/128/x-office-presentation-template.svg
+++ b/mimes/128/x-office-presentation-template.svg
@@ -6,492 +6,492 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4954"
-   height="128"
+   version="1.1"
    width="128"
-   version="1.1">
+   height="128"
+   id="svg4954">
   <defs
      id="defs4956">
     <linearGradient
        id="linearGradient4356">
       <stop
-         offset="0"
+         id="stop4358"
          style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop4358" />
+         offset="0" />
       <stop
-         id="stop4360"
+         offset="0.01283212"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.01283212" />
+         id="stop4360" />
       <stop
-         offset="0.98265791"
+         id="stop4362"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop4362" />
+         offset="0.98265791" />
       <stop
-         offset="1"
+         id="stop4364"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop4364" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2">
       <stop
-         offset="0"
+         id="stop3602-1-25-9"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-6-5-6"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-6-5-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-4-2-1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-4-2-1" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-1-7-1"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-1-7-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-2-4-5"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-2-4-5" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-8-1-1"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-8-1-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-0-6-4"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-0-6-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-2"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-4"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-3"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-3" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-9"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-5">
       <stop
-         offset="0"
+         id="stop3106-9"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(2.6788351,0,0,-3.9652608,-8.7086648,219.72585)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5"
-       id="linearGradient3091"
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084" />
-    <linearGradient
-       xlink:href="#linearGradient4356"
-       id="linearGradient3076"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,17.90543)"
-       x1="23.999994"
-       y1="5.2628093"
-       x2="23.99999"
-       y2="41.754993" />
-    <linearGradient
-       y2="37.546188"
-       x2="25.132275"
-       y1="15.284525"
-       x1="25.132275"
-       gradientTransform="matrix(2.9136939,0,0,2.9573295,-2.3848139,-1.0517271)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3917"
-       xlink:href="#linearGradient3600-3-2-2" />
-    <linearGradient
-       y2="35.721317"
-       x2="24"
-       y1="14.203104"
-       x1="24"
-       gradientTransform="matrix(4.2341648,0,0,2.3350645,-20.70947,0.56392794)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3928"
-       xlink:href="#linearGradient3211-8-8-9" />
-    <linearGradient
-       y2="37.267109"
-       x2="25.132275"
-       y1="10.060704"
-       x1="25.132275"
-       gradientTransform="matrix(4.0656632,0,0,2.2421191,-19.37221,-0.55729706)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3931"
-       xlink:href="#linearGradient3600-3-2-2-6-8" />
-    <linearGradient
-       y2="11.941198"
-       x2="-51.833466"
-       y1="41.012497"
-       x1="-51.833466"
-       gradientTransform="matrix(3.2830096,0,0,2.0982895,222.16977,-3.0560921)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3933"
-       xlink:href="#linearGradient3104-9-7-3-9-6" />
-    <linearGradient
-       y2="36.481995"
-       x2="24"
-       y1="4.9902573"
-       x1="24"
-       gradientTransform="matrix(5.9859991,0,0,0.22228053,-55.820217,14.890763)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3936"
-       xlink:href="#linearGradient3211-8-8-0-0-9" />
-    <linearGradient
-       y2="35.416233"
-       x2="25.132275"
-       y1="12.629268"
-       x1="25.132275"
-       gradientTransform="matrix(5.3695381,0,0,0.30719318,-46.335455,12.120375)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3939"
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7" />
-    <linearGradient
-       y2="14.685826"
-       x2="-51.816425"
-       y1="38.70771"
-       x1="-51.816425"
-       gradientTransform="matrix(4.3358848,0,0,0.28748705,272.67005,11.778015)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3941"
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(2.6788351,0,0,-3.9652608,-8.7086648,251.72585)"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791"
+       id="linearGradient3091"
+       xlink:href="#linearGradient3104-5"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6788351,0,0,-3.9652608,-8.7086648,228.72585)" />
+    <linearGradient
+       y2="41.754993"
+       x2="23.99999"
+       y1="5.2628093"
+       x1="23.999994"
+       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,26.90543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4356" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2"
+       id="linearGradient3917"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9136939,0,0,2.9573295,-2.3848139,7.9482731)"
+       x1="25.132275"
+       y1="15.284525"
+       x2="25.132275"
+       y2="37.546188" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-9"
+       id="linearGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.2341648,0,0,2.3350645,-20.70947,9.5639281)"
+       x1="24"
+       y1="14.203104"
+       x2="24"
+       y2="35.721317" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-8"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.0656632,0,0,2.2421191,-19.37221,8.4427031)"
+       x1="25.132275"
+       y1="10.060704"
+       x2="25.132275"
+       y2="37.267109" />
+    <linearGradient
+       xlink:href="#linearGradient3104-9-7-3-9-6"
+       id="linearGradient3933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.2830096,0,0,2.0982895,222.16977,5.9439081)"
+       x1="-51.833466"
+       y1="41.012497"
+       x2="-51.833466"
+       y2="11.941198" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       id="linearGradient3936"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.9859991,0,0,0.22228053,-55.820217,23.890763)"
+       x1="24"
+       y1="4.9902573"
+       x2="24"
+       y2="36.481995" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.3695381,0,0,0.30719318,-46.335455,21.120375)"
+       x1="25.132275"
+       y1="12.629268"
+       x2="25.132275"
+       y2="35.416233" />
+    <linearGradient
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
+       id="linearGradient3941"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.3358848,0,0,0.28748705,272.67005,20.778015)"
+       x1="-51.816425"
+       y1="38.70771"
+       x2="-51.816425"
+       y2="14.685826" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient3968"
-       xlink:href="#linearGradient3104-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6788351,0,0,-3.9652608,-8.7086648,260.72585)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
     <linearGradient
        id="linearGradient3702-501-757-795">
       <stop
-         id="stop3100"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop3100" />
       <stop
-         id="stop3102"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop3102" />
       <stop
-         id="stop3104"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3104" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309-604">
       <stop
-         id="stop3094"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop3094" />
       <stop
-         id="stop3096"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3096" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-166-749-654">
       <stop
-         id="stop3088"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop3088" />
       <stop
-         id="stop3090"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3090" />
     </linearGradient>
     <radialGradient
-       r="2.5"
-       fy="43.5"
-       fx="4.9929786"
-       cy="43.5"
-       cx="4.9929786"
-       gradientTransform="matrix(1.9035948,0,0,1.2599994,28.738724,-10.959975)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-654"
        id="radialGradient4172"
-       xlink:href="#linearGradient3688-166-749-654" />
-    <radialGradient
-       r="2.5"
-       fy="43.5"
-       fx="4.9929786"
-       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.2599994,28.738724,-10.959975)"
        cx="4.9929786"
-       gradientTransform="matrix(1.9035948,0,0,1.2599994,-19.261277,-98.659973)"
-       gradientUnits="userSpaceOnUse"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309-604"
        id="radialGradient4174"
-       xlink:href="#linearGradient3688-464-309-604" />
-    <linearGradient
-       gradientTransform="matrix(1.0178572,0,0,0.89999962,-0.42857159,4.7000205)"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.2599994,-19.261277,-98.659973)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757-795"
        id="linearGradient4176"
-       xlink:href="#linearGradient3702-501-757-795" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084"
-       gradientTransform="matrix(2.6788351,0,0,-3.9652608,13.603836,219.72585)"
        gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       gradientTransform="matrix(1.0178572,0,0,0.89999962,-0.42857159,4.7000205)" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient4180"
-       xlink:href="#linearGradient3104-5" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084"
-       gradientTransform="matrix(2.6788351,0,0,3.9652608,15.228836,-69.725859)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6788351,0,0,-3.9652608,13.603836,228.72585)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient4185"
-       xlink:href="#linearGradient3104-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6788351,0,0,3.9652608,15.228836,-60.725859)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9"
+         offset="0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop3750-1-0-7-6-6-1-3-9" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0"
+         offset="0.26238"
          style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
+         id="stop3752-3-7-4-0-32-8-923-0" />
       <stop
-         id="stop3754-1-8-5-2-7-6-7-1"
+         offset="0.704952"
          style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
+         id="stop3754-1-8-5-2-7-6-7-1" />
       <stop
-         id="stop3756-1-6-2-6-6-1-96-6"
+         offset="1"
          style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3756-1-6-2-6-6-1-96-6" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8"
-       id="radialGradient4173-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,20.456265,-25.113759,0,302.02937,-159.84671)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
+       r="12.671875"
        fy="9.9571075"
-       r="12.671875" />
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,20.456265,-25.113759,0,302.02937,-150.84671)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4173-5"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9-9-0"
+         offset="0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop3750-1-0-7-6-6-1-3-9-9-0" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7-8"
+         offset="0.26238"
          style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
+         id="stop3752-3-7-4-0-32-8-923-0-7-8" />
       <stop
-         id="stop3754-1-8-5-2-7-6-7-1-8-0"
+         offset="0.704952"
          style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
+         id="stop3754-1-8-5-2-7-6-7-1-8-0" />
       <stop
-         id="stop3756-1-6-2-6-6-1-96-6-1-1"
+         offset="1"
          style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3756-1-6-2-6-6-1-96-6-1-1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4356-5"
-       id="linearGradient3076-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,17.90543)"
-       x1="23.999994"
-       y1="5.2628093"
+       y2="41.754993"
        x2="23.99999"
-       y2="41.754993" />
+       y1="5.2628093"
+       x1="23.999994"
+       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,26.90543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3076-9"
+       xlink:href="#linearGradient4356-5" />
     <linearGradient
        id="linearGradient4356-5">
       <stop
-         offset="0"
+         id="stop4358-6"
          style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop4358-6" />
+         offset="0" />
       <stop
-         id="stop4360-9"
+         offset="0.01283212"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.01283212" />
+         id="stop4360-9" />
       <stop
-         offset="0.98265791"
+         id="stop4362-4"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop4362-4" />
+         offset="0.98265791" />
       <stop
-         offset="1"
+         id="stop4364-6"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop4364-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         id="stop3106-3-2"
+         offset="0"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
+         id="stop3106-3-2" />
       <stop
-         id="stop3108-9-8-3"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
+         id="stop3108-9-8-3" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3104-6-6-1"
-       id="linearGradient4420"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6301305,0,0,1.6674276,179.33609,21.019469)"
-       x1="-51.786404"
-       y1="50.786446"
+       y2="2.9062471"
        x2="-51.786404"
-       y2="2.9062471" />
-    <radialGradient
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.62513)"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(2.6301305,0,0,1.6674276,179.33609,30.019469)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
-       id="radialGradient3029"
-       fy="9.9571075"
-       fx="6.0330806"
-       r="12.671875"
+       id="linearGradient4420"
+       xlink:href="#linearGradient3104-6-6-1" />
+    <radialGradient
+       cx="6.5633106"
        cy="9.9571075"
-       cx="6.5633106" />
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
+       id="radialGradient3029"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.62513)" />
     <linearGradient
        id="linearGradient22140">
       <stop
-         offset="0"
+         id="stop22142"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop22142" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop22148"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop22148" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop22144"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop22144" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3412">
       <stop
-         offset="0"
+         id="stop3414"
          style="stop-color:#f0f0f1;stop-opacity:1"
-         id="stop3414" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3416"
          style="stop-color:#cbcdd9;stop-opacity:1"
-         id="stop3416" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
-       cx="6.5633106"
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.63209)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4341"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.63209)"
        cx="6.5633106"
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.6342)"
-       gradientUnits="userSpaceOnUse"
+       cy="9.9571075"
+       fx="6.0330806"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4343"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="3.5"
-       fy="39.464806"
-       fx="7"
-       cy="39.464806"
-       cx="7"
-       gradientTransform="matrix(0,0.89962666,-0.93506352,1.4451651e-8,81.629374,32.204085)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.6342)"
+       cx="6.5633106"
+       cy="9.9571075"
+       fx="6.0330806"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient3104-6-6-1"
        id="radialGradient3159"
-       xlink:href="#linearGradient3104-6-6-1" />
-    <linearGradient
-       gradientTransform="matrix(1,0,0,0.89962592,0,3.8658766)"
-       y2="42.040661"
-       x2="18.142136"
-       y1="35"
-       x1="18.142136"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3161"
-       xlink:href="#linearGradient22140" />
-    <radialGradient
-       r="3.5"
-       fy="39.464806"
-       fx="7"
-       cy="39.464806"
+       gradientTransform="matrix(0,0.89962666,-0.93506352,1.4451651e-8,81.629374,32.204085)"
        cx="7"
-       gradientTransform="matrix(0,0.89962666,0.62337568,1.4451651e-8,-21.328656,32.204085)"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient22140"
+       id="linearGradient3161"
        gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661"
+       gradientTransform="matrix(1,0,0,0.89962592,0,3.8658766)" />
+    <radialGradient
+       xlink:href="#linearGradient3104-6-6-1"
        id="radialGradient4320"
-       xlink:href="#linearGradient3104-6-6-1" />
-    <linearGradient
-       y2="50.73642"
-       x2="45.902721"
-       y1="35.285313"
-       x1="30.739399"
-       gradientTransform="matrix(0,5.4100631,-5.3070628,0,309.7614,-121.83734)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.89962666,0.62337568,1.4451651e-8,-21.328656,32.204085)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient3412"
        id="linearGradient3163"
-       xlink:href="#linearGradient3412" />
-    <linearGradient
-       y2="127.03607"
-       x2="75.779678"
-       y1="86"
-       x1="75.779678"
-       gradientTransform="matrix(-2,0,0,2.0008421,236.50002,-127.60767)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.4100631,-5.3070628,0,309.7614,-121.83734)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-0-0-9"
        id="linearGradient3165"
-       xlink:href="#linearGradient3211-8-8-0-0-9" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,0,0,2.0008421,236.50002,-127.60767)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata4959">
@@ -506,196 +506,196 @@
     </rdf:RDF>
   </metadata>
   <g
-     style="opacity:0.15"
+     transform="matrix(3.368421,0,0,1.4285713,-16.842106,55.857146)"
      id="g3712"
-     transform="matrix(3.368421,0,0,1.4285713,-16.842106,46.857146)">
+     style="opacity:0.15">
     <rect
-       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none"
-       id="rect2801"
-       y="40.700001"
+       width="4.75"
+       height="6.2999973"
        x="38.25"
-       height="6.2999973"
-       width="4.75" />
+       y="40.700001"
+       id="rect2801"
+       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none" />
     <rect
-       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none"
-       id="rect3696"
-       transform="scale(-1,-1)"
-       y="-47"
+       width="4.75"
+       height="6.2999973"
        x="-9.75"
-       height="6.2999973"
-       width="4.75" />
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none" />
     <rect
-       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none"
-       id="rect3700"
-       y="40.700005"
-       x="9.75"
+       width="28.5"
        height="6.2999973"
-       width="28.5" />
+       x="9.75"
+       y="40.700005"
+       id="rect3700"
+       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none" />
   </g>
   <path
-     d="m 28.5,15.499926 71,0 0,8.000155 -71,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-4-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 28.5,24.499926 71,0 0,8.000155 -71,0 z" />
   <path
-     d="m 29.499921,16.5 69.000079,0 0,6.000081 -69.000079,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-6-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 29.499921,25.5 69.000079,0 0,6.000081 -69.000079,0 z" />
   <path
-     d="M 16.499961,21.499925 111.5,21.5 l 0,61.000084 -94.999961,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="M 16.499961,30.499925 111.5,30.5 l 0,61.000084 -94.999961,0 z" />
   <path
-     d="m 17.5,22.5 93,0 0,58.000078 -93,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 17.5,31.5 93,0 0,58.000078 -93,0 z" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
-     id="rect4964"
-     y="28"
-     x="18"
+     width="103"
      height="81"
-     width="103" />
+     x="18"
+     y="37"
+     id="rect4964"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4964-1"
-     y="28.5"
-     x="7.5"
+     width="113"
      height="80"
-     width="113" />
+     x="7.5"
+     y="37.5"
+     id="rect4964-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 110,74.999995 A 19.999999,19.999999 0 1 1 99.420234,57.357462 l -9.420236,17.642533 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
      id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+     d="M 110,83.999995 A 19.999999,19.999999 0 1 1 99.420234,66.357462 l -9.420236,17.642533 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     d="m 27.999999,88.999999 0,-2 4.000001,0 0,2 z m 5.000001,0 0,-2 12.999998,0 0,2 z m -5.000001,-8 0,-1.999999 L 34,79 34,80.999999 Z M 35,80.999999 35,79 l 5,0 0,1.999999 z m 6,0 L 41,79 l 3,0 0,1.999999 z m 4,0 L 45,79 l 4,0 0,1.999999 z M 27.999999,73 l 0,-2 L 35,71 35,73 Z M 36,73 l 0,-2 3,0 0,2 z m 4,0 0,-2 8,0 0,2 z m -12.000001,-8 0,-2 L 35,63 35,65 Z M 36,65 l 0,-2 5,0 0,2 z m 6,0 0,-2 7,0 0,2 z"
      id="path3475-4"
-     d="m 27.999999,79.999999 0,-2 4.000001,0 0,2 z m 5.000001,0 0,-2 12.999998,0 0,2 z m -5.000001,-8 0,-1.999999 L 34,70 34,71.999999 Z M 35,71.999999 35,70 l 5,0 0,1.999999 z m 6,0 L 41,70 l 3,0 0,1.999999 z m 4,0 L 45,70 l 4,0 0,1.999999 z M 27.999999,64 l 0,-2 L 35,62 35,64 Z M 36,64 l 0,-2 3,0 0,2 z m 4,0 0,-2 8,0 0,2 z m -12.000001,-8 0,-2 L 35,54 35,56 Z M 36,56 l 0,-2 5,0 0,2 z m 6,0 0,-2 7,0 0,2 z" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     d="m 18,109.5 -11.5,0 c 0,-28 0.026032,-57.676631 0,-82 l 11.5,-3e-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+     d="m 18,118.5 -11.5,0 c 0,-28 0.026032,-57.676631 0,-82 l 11.5,-3e-6" />
   <path
-     id="rect6741-1-5"
-     d="m 17.5,108.5 -10,0 0,-80 10,0"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 17.5,117.5 -10,0 0,-80 10,0"
+     id="rect6741-1-5" />
   <path
-     d="m 73.999999,38 0,2 2.000001,-2e-6 0,-2 z m 3.000001,-2e-6 0,2 5,0 0,-2 z m 6.999998,0 0,2 6,2e-6 0,-2 z m -39.999998,0 0,2 12,0 0,-2 z m 13,0 0,2 6,0 0,-2 z m 6.999999,0 0,2 8.000001,0 0,-2 z"
+     id="path3925"
      style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="path3925" />
+     d="m 73.999999,47 0,2 2.000001,-2e-6 0,-2 z m 3.000001,-2e-6 0,2 5,0 0,-2 z m 6.999998,0 0,2 6,2e-6 0,-2 z m -39.999998,0 0,2 12,0 0,-2 z m 13,0 0,2 6,0 0,-2 z m 6.999999,0 0,2 8.000001,0 0,-2 z" />
   <path
-     d="m 27.999999,95.999998 0,-2 7.000001,0 0,2 z m 8.000001,0 0,-2 3,0 0,2 z m 4,0 0,-2 7,0 0,2 z m -12.000001,-7.999999 0,-2 6.000001,0 0,2 z m 7.000001,0 0,-2 5,0 0,2 z m 6,0 0,-2 8,0 0,2 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path3966"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+     d="m 27.999999,105 0,-2 7.000001,0 0,2 z M 36,105 l 0,-2 3,0 0,2 z m 4,0 0,-2 7,0 0,2 z m -12.000001,-8.000001 0,-2 6.000001,0 0,2 z m 7.000001,0 0,-2 5,0 0,2 z m 6,0 0,-2 8,0 0,2 z" />
   <path
-     d="m 50,80.000001 0,-2 5,0 0,2 z m 0,-8 0,-2 6,0 0,2 z m -1,-7.999999 0,-2 5,0 0,2 z m 2,-8 0,-2 5,0 0,2 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path4178"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+     d="m 50,89.000001 0,-2 5,0 0,2 z m 0,-8 0,-2 6,0 0,2 z m -1,-7.999999 0,-2 5,0 0,2 z m 2,-8 0,-2 5,0 0,2 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     d="m 50,95.000001 0,2 7,0 0,-2 z m 8,0 0,2 3,0 0,-2 z M 49,103 l 0,2 7,0 0,-2 z m 8,0 0,2 5,0 0,-2 z m 6,0 0,2 7,0 0,-2 z"
      id="path4183"
-     d="m 50,86.000001 0,2 7,0 0,-2 z m 8,0 0,2 3,0 0,-2 z M 49,94 l 0,2 7,0 0,-2 z m 8,0 0,2 5,0 0,-2 z m 6,0 0,2 7,0 0,-2 z" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     d="m 18,109.5 -11.5,0 c 0,-28.5 0.025903,-57.678098 0,-82 l 11.5,-3e-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path4530-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 18,118.5 -11.5,0 c 0,-28.5 0.025903,-57.678098 0,-82 l 11.5,-3e-6" />
   <path
-     id="path4160-6-1"
-     d="m 18,109.5 103.5,0 0,-81.999997 -103.5,0"
-     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 18,118.5 103.5,0 0,-81.999997 -103.5,0"
+     id="path4160-6-1" />
   <g
-     transform="translate(0,-0.00199978)"
-     id="g4387">
+     id="g4387"
+     transform="translate(0,8.9980004)">
     <path
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4341);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 110,73.999995 A 19.999999,19.999999 0 1 1 99.420234,56.357462 l -9.420236,17.642533 z"
        id="path3035"
-       d="M 110,73.999995 A 19.999999,19.999999 0 1 1 99.420234,56.357462 l -9.420236,17.642533 z" />
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4341);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       d="M 110,73.997889 C 110,83 104,90.874324 95.33681,93.27249 86.68495,95.66752 77.5,92.035573 72.850413,84.282045 72.815033,84.314125 89.999998,73.997889 89.999998,73.997889 Z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="path3964"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       d="M 110,73.997889 C 110,83 104,90.874324 95.33681,93.27249 86.68495,95.66752 77.5,92.035573 72.850413,84.282045 72.815033,84.314125 89.999998,73.997889 89.999998,73.997889 Z" />
     <path
-       d="m 110,74.006966 c 0,8.671378 -5.804,16.822178 -14.66319,19.274601 -0.19524,-0.0339 -5.336812,-19.274601 -5.336812,-19.274601 z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="path3962"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       d="m 110,74.006966 c 0,8.671378 -5.804,16.822178 -14.66319,19.274601 -0.19524,-0.0339 -5.336812,-19.274601 -5.336812,-19.274601 z" />
   </g>
   <g
-     id="g4345"
-     transform="translate(4.0000019,-3.1647301e-7)">
+     transform="translate(4.0000019,-3.1647301e-7)"
+     id="g4345">
     <g
-       transform="matrix(-1.833334,0,0,1.4291655,126.00003,68.47502)"
+       style="opacity:0.3"
        id="g22150"
-       style="opacity:0.3">
+       transform="matrix(-1.833334,0,0,1.4291655,126.00003,68.47502)">
       <path
-         id="rect22134"
+         style="opacity:0.6;fill:url(#radialGradient3159);fill-opacity:1;stroke:none"
          d="m 45.001248,41.650166 -0.273974,0 c 0,-2.833822 0,-5.037905 0,-6.297381 l 0.273974,0 c 1.661308,0 2.998752,1.404316 2.998752,3.14869 0,1.744375 -1.337444,3.148691 -2.998752,3.148691 z"
-         style="opacity:0.6;fill:url(#radialGradient3159);fill-opacity:1;stroke:none" />
+         id="rect22134" />
       <rect
-         width="41.454529"
-         height="6.2973785"
-         x="3.2727435"
-         y="35.352783"
+         style="opacity:0.6;fill:url(#linearGradient3161);fill-opacity:1;stroke:none"
          id="rect22138"
-         style="opacity:0.6;fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
+         y="35.352783"
+         x="3.2727435"
+         height="6.2973785"
+         width="41.454529" />
       <path
-         style="opacity:0.6;fill:url(#radialGradient4320);fill-opacity:1;stroke:none"
+         id="path4318"
          d="m 3.0900944,41.650166 0.1826491,0 c 0,-2.833822 0,-5.037905 0,-6.297381 l -0.1826491,0 c -1.1075393,0 -1.9991683,1.404316 -1.9991683,3.14869 0,1.744375 0.891629,3.148691 1.9991683,3.148691 z"
-         id="path4318" />
+         style="opacity:0.6;fill:url(#radialGradient4320);fill-opacity:1;stroke:none" />
     </g>
     <path
-       d="M 121.50004,45.207214 41.212776,125.5 121.50004,125.499 Z m -16,37.002288 0,27.290538 -27.295082,-8e-5 z"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="path2993"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       d="M 121.50004,45.207214 41.212776,125.5 121.50004,125.499 Z m -16,37.002288 0,27.290538 -27.295082,-8e-5 z" />
     <path
-       d="m 98.500032,124.49288 0,-2.98929"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
        id="path3103"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 109.50003,125.49882 0,-4.00168 m -11.999998,4.00168 0,-4.00168 m -12,4.00168 0,-3.95406 m -12,3.95406 0,-4.00168 m -12,4.00168 0,-4.00168"
-       id="path3091"
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 120.5,47.615627 0,76.884373 -76.873279,0 z M 106.5,79.790078 75.779061,110.5 106.5,110.5 Z"
-       id="path3934"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4292"
-       d="m 110.50005,124.49288 0,-2.98929" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4294"
-       d="m 86.50005,124.49288 0,-2.98929" />
-    <path
-       d="m 74.50005,124.49288 0,-2.98929"
-       id="path4296"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4298"
-       d="m 62.50005,124.49288 0,-2.98929" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4300"
-       d="m 120.50286,78.499968 -2.98929,0" />
+       d="m 98.500032,124.49288 0,-2.98929" />
     <path
        style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4302"
-       d="m 121.5088,65.49995 -4.00168,0 m 4.00168,12 -4.00168,0 m 4.00168,12 -3.95406,0 m 3.95406,12 -4.00168,0 m 4.00168,12 -4.00168,0" />
+       id="path3091"
+       d="m 109.50003,125.49882 0,-4.00168 m -11.999998,4.00168 0,-4.00168 m -12,4.00168 0,-3.95406 m -12,3.95406 0,-4.00168 m -12,4.00168 0,-4.00168" />
     <path
-       d="m 120.50286,66.49995 -2.98929,0"
-       id="path4304"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 120.5,47.615627 0,76.884373 -76.873279,0 z M 106.5,79.790078 75.779061,110.5 106.5,110.5 Z" />
+    <path
+       d="m 110.50005,124.49288 0,-2.98929"
+       id="path4292"
        style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       d="m 120.50286,90.49995 -2.98929,0"
-       id="path4306"
+       d="m 86.50005,124.49288 0,-2.98929"
+       id="path4294"
        style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path4308"
-       d="m 120.50286,102.49995 -2.98929,0" />
+       id="path4296"
+       d="m 74.50005,124.49288 0,-2.98929" />
     <path
-       d="m 120.50286,114.49995 -2.98929,0"
-       id="path4310"
+       d="m 62.50005,124.49288 0,-2.98929"
+       id="path4298"
        style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 120.50286,78.499968 -2.98929,0"
+       id="path4300"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 121.5088,65.49995 -4.00168,0 m 4.00168,12 -4.00168,0 m 4.00168,12 -3.95406,0 m 3.95406,12 -4.00168,0 m 4.00168,12 -4.00168,0"
+       id="path4302"
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4304"
+       d="m 120.50286,66.49995 -2.98929,0" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4306"
+       d="m 120.50286,90.49995 -2.98929,0" />
+    <path
+       d="m 120.50286,102.49995 -2.98929,0"
+       id="path4308"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4310"
+       d="m 120.50286,114.49995 -2.98929,0" />
   </g>
 </svg>

--- a/mimes/128/x-office-presentation.svg
+++ b/mimes/128/x-office-presentation.svg
@@ -6,419 +6,419 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4954"
-   height="128"
+   version="1.1"
    width="128"
-   version="1.1">
+   height="128"
+   id="svg4954">
   <defs
      id="defs4956">
     <linearGradient
        id="linearGradient4356">
       <stop
-         offset="0"
+         id="stop4358"
          style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop4358" />
+         offset="0" />
       <stop
-         id="stop4360"
+         offset="0.01283212"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.01283212" />
+         id="stop4360" />
       <stop
-         offset="0.98265791"
+         id="stop4362"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop4362" />
+         offset="0.98265791" />
       <stop
-         offset="1"
+         id="stop4364"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop4364" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2">
       <stop
-         offset="0"
+         id="stop3602-1-25-9"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-6-5-6"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-6-5-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-4-2-1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-4-2-1" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-1-7-1"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-1-7-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-2-4-5"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-2-4-5" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-8-1-1"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-8-1-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-0-6-4"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-0-6-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-2"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-4"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-3"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-3" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-9"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-5">
       <stop
-         offset="0"
+         id="stop3106-9"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(2.6788351,0,0,-3.9652608,-8.7086648,219.72585)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5"
-       id="linearGradient3091"
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084" />
-    <linearGradient
-       xlink:href="#linearGradient4356"
-       id="linearGradient3076"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,17.90543)"
-       x1="23.999994"
-       y1="5.2628093"
-       x2="23.99999"
-       y2="41.754993" />
-    <linearGradient
-       y2="37.546188"
-       x2="25.132275"
-       y1="15.284525"
-       x1="25.132275"
-       gradientTransform="matrix(2.9136939,0,0,2.9573295,-2.3848139,-1.0517271)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3917"
-       xlink:href="#linearGradient3600-3-2-2" />
-    <linearGradient
-       y2="35.721317"
-       x2="24"
-       y1="14.203104"
-       x1="24"
-       gradientTransform="matrix(4.2341648,0,0,2.3350645,-20.70947,0.56392794)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3928"
-       xlink:href="#linearGradient3211-8-8-9" />
-    <linearGradient
-       y2="37.267109"
-       x2="25.132275"
-       y1="10.060704"
-       x1="25.132275"
-       gradientTransform="matrix(4.0656632,0,0,2.2421191,-19.37221,-0.55729706)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3931"
-       xlink:href="#linearGradient3600-3-2-2-6-8" />
-    <linearGradient
-       y2="11.941198"
-       x2="-51.833466"
-       y1="41.012497"
-       x1="-51.833466"
-       gradientTransform="matrix(3.2830096,0,0,2.0982895,222.16977,-3.0560921)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3933"
-       xlink:href="#linearGradient3104-9-7-3-9-6" />
-    <linearGradient
-       y2="36.481995"
-       x2="24"
-       y1="4.9902573"
-       x1="24"
-       gradientTransform="matrix(5.9859991,0,0,0.22228053,-55.820217,14.890763)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3936"
-       xlink:href="#linearGradient3211-8-8-0-0-9" />
-    <linearGradient
-       y2="35.416233"
-       x2="25.132275"
-       y1="12.629268"
-       x1="25.132275"
-       gradientTransform="matrix(5.3695381,0,0,0.30719318,-46.335455,12.120375)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3939"
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7" />
-    <linearGradient
-       y2="14.685826"
-       x2="-51.816425"
-       y1="38.70771"
-       x1="-51.816425"
-       gradientTransform="matrix(4.3358848,0,0,0.28748705,272.67005,11.778015)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3941"
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(2.6788351,0,0,-3.9652608,-8.7086648,251.72585)"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791"
+       id="linearGradient3091"
+       xlink:href="#linearGradient3104-5"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6788351,0,0,-3.9652608,-8.7086648,228.72585)" />
+    <linearGradient
+       y2="41.754993"
+       x2="23.99999"
+       y1="5.2628093"
+       x1="23.999994"
+       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,26.90543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4356" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2"
+       id="linearGradient3917"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9136939,0,0,2.9573295,-2.3848139,7.9482731)"
+       x1="25.132275"
+       y1="15.284525"
+       x2="25.132275"
+       y2="37.546188" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-9"
+       id="linearGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.2341648,0,0,2.3350645,-20.70947,9.5639281)"
+       x1="24"
+       y1="14.203104"
+       x2="24"
+       y2="35.721317" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-8"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.0656632,0,0,2.2421191,-19.37221,8.4427031)"
+       x1="25.132275"
+       y1="10.060704"
+       x2="25.132275"
+       y2="37.267109" />
+    <linearGradient
+       xlink:href="#linearGradient3104-9-7-3-9-6"
+       id="linearGradient3933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.2830096,0,0,2.0982895,222.16977,5.9439081)"
+       x1="-51.833466"
+       y1="41.012497"
+       x2="-51.833466"
+       y2="11.941198" />
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       id="linearGradient3936"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.9859991,0,0,0.22228053,-55.820217,23.890763)"
+       x1="24"
+       y1="4.9902573"
+       x2="24"
+       y2="36.481995" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.3695381,0,0,0.30719318,-46.335455,21.120375)"
+       x1="25.132275"
+       y1="12.629268"
+       x2="25.132275"
+       y2="35.416233" />
+    <linearGradient
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
+       id="linearGradient3941"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.3358848,0,0,0.28748705,272.67005,20.778015)"
+       x1="-51.816425"
+       y1="38.70771"
+       x2="-51.816425"
+       y2="14.685826" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient3968"
-       xlink:href="#linearGradient3104-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6788351,0,0,-3.9652608,-8.7086648,260.72585)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
     <linearGradient
        id="linearGradient3702-501-757-795">
       <stop
-         id="stop3100"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop3100" />
       <stop
-         id="stop3102"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop3102" />
       <stop
-         id="stop3104"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3104" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309-604">
       <stop
-         id="stop3094"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop3094" />
       <stop
-         id="stop3096"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3096" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-166-749-654">
       <stop
-         id="stop3088"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop3088" />
       <stop
-         id="stop3090"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3090" />
     </linearGradient>
     <radialGradient
-       r="2.5"
-       fy="43.5"
-       fx="4.9929786"
-       cy="43.5"
-       cx="4.9929786"
-       gradientTransform="matrix(1.9035948,0,0,1.2599994,28.738724,-10.959975)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-654"
        id="radialGradient4172"
-       xlink:href="#linearGradient3688-166-749-654" />
-    <radialGradient
-       r="2.5"
-       fy="43.5"
-       fx="4.9929786"
-       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.2599994,28.738724,-10.959975)"
        cx="4.9929786"
-       gradientTransform="matrix(1.9035948,0,0,1.2599994,-19.261277,-98.659973)"
-       gradientUnits="userSpaceOnUse"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309-604"
        id="radialGradient4174"
-       xlink:href="#linearGradient3688-464-309-604" />
-    <linearGradient
-       gradientTransform="matrix(1.0178572,0,0,0.89999962,-0.42857159,4.7000205)"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.2599994,-19.261277,-98.659973)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757-795"
        id="linearGradient4176"
-       xlink:href="#linearGradient3702-501-757-795" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084"
-       gradientTransform="matrix(2.6788351,0,0,-3.9652608,13.603836,219.72585)"
        gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       gradientTransform="matrix(1.0178572,0,0,0.89999962,-0.42857159,4.7000205)" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient4180"
-       xlink:href="#linearGradient3104-5" />
-    <linearGradient
-       y2="25.646791"
-       x2="22.004084"
-       y1="63.217903"
-       x1="22.004084"
-       gradientTransform="matrix(2.6788351,0,0,3.9652608,15.228836,-69.725859)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6788351,0,0,-3.9652608,13.603836,228.72585)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
+    <linearGradient
+       xlink:href="#linearGradient3104-5"
        id="linearGradient4185"
-       xlink:href="#linearGradient3104-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6788351,0,0,3.9652608,15.228836,-60.725859)"
+       x1="22.004084"
+       y1="63.217903"
+       x2="22.004084"
+       y2="25.646791" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9"
+         offset="0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop3750-1-0-7-6-6-1-3-9" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0"
+         offset="0.26238"
          style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
+         id="stop3752-3-7-4-0-32-8-923-0" />
       <stop
-         id="stop3754-1-8-5-2-7-6-7-1"
+         offset="0.704952"
          style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
+         id="stop3754-1-8-5-2-7-6-7-1" />
       <stop
-         id="stop3756-1-6-2-6-6-1-96-6"
+         offset="1"
          style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3756-1-6-2-6-6-1-96-6" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8"
-       id="radialGradient4173-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,20.456265,-25.113759,0,302.02937,-159.84671)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
+       r="12.671875"
        fy="9.9571075"
-       r="12.671875" />
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,20.456265,-25.113759,0,302.02937,-150.84671)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4173-5"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9-9-0"
+         offset="0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop3750-1-0-7-6-6-1-3-9-9-0" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7-8"
+         offset="0.26238"
          style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
+         id="stop3752-3-7-4-0-32-8-923-0-7-8" />
       <stop
-         id="stop3754-1-8-5-2-7-6-7-1-8-0"
+         offset="0.704952"
          style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
+         id="stop3754-1-8-5-2-7-6-7-1-8-0" />
       <stop
-         id="stop3756-1-6-2-6-6-1-96-6-1-1"
+         offset="1"
          style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3756-1-6-2-6-6-1-96-6-1-1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4356-5"
-       id="linearGradient3076-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,17.90543)"
-       x1="23.999994"
-       y1="5.2628093"
+       y2="41.754993"
        x2="23.99999"
-       y2="41.754993" />
+       y1="5.2628093"
+       x1="23.999994"
+       gradientTransform="matrix(1.7837837,0,0,2.1081079,-0.81079964,26.90543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3076-9"
+       xlink:href="#linearGradient4356-5" />
     <linearGradient
        id="linearGradient4356-5">
       <stop
-         offset="0"
+         id="stop4358-6"
          style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop4358-6" />
+         offset="0" />
       <stop
-         id="stop4360-9"
+         offset="0.01283212"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.01283212" />
+         id="stop4360-9" />
       <stop
-         offset="0.98265791"
+         id="stop4362-4"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop4362-4" />
+         offset="0.98265791" />
       <stop
-         offset="1"
+         id="stop4364-6"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop4364-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         id="stop3106-3-2"
+         offset="0"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
+         id="stop3106-3-2" />
       <stop
-         id="stop3108-9-8-3"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
+         id="stop3108-9-8-3" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3104-6-6-1"
-       id="linearGradient4420"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6301305,0,0,1.6674276,179.33609,21.019469)"
-       x1="-51.786404"
-       y1="50.786446"
+       y2="2.9062471"
        x2="-51.786404"
-       y2="2.9062471" />
-    <radialGradient
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.62513)"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(2.6301305,0,0,1.6674276,179.33609,30.019469)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       id="linearGradient4420"
+       xlink:href="#linearGradient3104-6-6-1" />
+    <radialGradient
+       cx="6.5633106"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
        id="radialGradient3029"
-       fy="9.9571075"
-       fx="6.0330806"
-       r="12.671875"
-       cy="9.9571075"
-       cx="6.5633106" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
-       cx="6.5633106"
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.63209)"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.62513)" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4341"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
-       cx="6.5633106"
-       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.6342)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.63209)"
+       cx="6.5633106"
+       cy="9.9571075"
+       fx="6.0330806"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4343"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,20.070195,-24.639785,0,309.31217,-176.6342)"
+       cx="6.5633106"
+       cy="9.9571075"
+       fx="6.0330806"
+       fy="9.9571075"
+       r="12.671875" />
   </defs>
   <metadata
      id="metadata4959">
@@ -433,116 +433,116 @@
     </rdf:RDF>
   </metadata>
   <g
-     style="opacity:0.15"
+     transform="matrix(3.368421,0,0,1.4285713,-16.842106,55.857146)"
      id="g3712"
-     transform="matrix(3.368421,0,0,1.4285713,-16.842106,46.857146)">
+     style="opacity:0.15">
     <rect
-       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none"
-       id="rect2801"
-       y="40.700001"
+       width="4.75"
+       height="6.2999973"
        x="38.25"
-       height="6.2999973"
-       width="4.75" />
+       y="40.700001"
+       id="rect2801"
+       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none" />
     <rect
-       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none"
-       id="rect3696"
-       transform="scale(-1,-1)"
-       y="-47"
+       width="4.75"
+       height="6.2999973"
        x="-9.75"
-       height="6.2999973"
-       width="4.75" />
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none" />
     <rect
-       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none"
-       id="rect3700"
-       y="40.700005"
-       x="9.75"
+       width="28.5"
        height="6.2999973"
-       width="28.5" />
+       x="9.75"
+       y="40.700005"
+       id="rect3700"
+       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none" />
   </g>
   <path
-     d="m 28.5,15.499926 71,0 0,8.000155 -71,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-4-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 28.5,24.499926 71,0 0,8.000155 -71,0 z" />
   <path
-     d="m 29.499921,16.5 69.000079,0 0,6.000081 -69.000079,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-6-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 29.499921,25.5 69.000079,0 0,6.000081 -69.000079,0 z" />
   <path
-     d="M 16.499961,21.499925 111.5,21.5 l 0,61.000084 -94.999961,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="M 16.499961,30.499925 111.5,30.5 l 0,61.000084 -94.999961,0 z" />
   <path
-     d="m 17.5,22.5 93,0 0,58.000078 -93,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 17.5,31.5 93,0 0,58.000078 -93,0 z" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
-     id="rect4964"
-     y="28"
-     x="18"
+     width="103"
      height="81"
-     width="103" />
+     x="18"
+     y="37"
+     id="rect4964"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4964-1"
-     y="28.5"
-     x="7.5"
+     width="113"
      height="80"
-     width="113" />
+     x="7.5"
+     y="37.5"
+     id="rect4964-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 110,74.999995 A 19.999999,19.999999 0 1 1 99.420234,57.357462 l -9.420236,17.642533 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
      id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+     d="M 110,83.999995 A 19.999999,19.999999 0 1 1 99.420234,66.357462 l -9.420236,17.642533 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     d="m 27.999999,88.999999 0,-2 4.000001,0 0,2 z m 5.000001,0 0,-2 12.999998,0 0,2 z m -5.000001,-8 0,-1.999999 L 34,79 34,80.999999 Z M 35,80.999999 35,79 l 5,0 0,1.999999 z m 6,0 L 41,79 l 3,0 0,1.999999 z m 4,0 L 45,79 l 4,0 0,1.999999 z M 27.999999,73 l 0,-2 L 35,71 35,73 Z M 36,73 l 0,-2 3,0 0,2 z m 4,0 0,-2 8,0 0,2 z m -12.000001,-8 0,-2 L 35,63 35,65 Z M 36,65 l 0,-2 5,0 0,2 z m 6,0 0,-2 7,0 0,2 z"
      id="path3475-4"
-     d="m 27.999999,79.999999 0,-2 4.000001,0 0,2 z m 5.000001,0 0,-2 12.999998,0 0,2 z m -5.000001,-8 0,-1.999999 L 34,70 34,71.999999 Z M 35,71.999999 35,70 l 5,0 0,1.999999 z m 6,0 L 41,70 l 3,0 0,1.999999 z m 4,0 L 45,70 l 4,0 0,1.999999 z M 27.999999,64 l 0,-2 L 35,62 35,64 Z M 36,64 l 0,-2 3,0 0,2 z m 4,0 0,-2 8,0 0,2 z m -12.000001,-8 0,-2 L 35,54 35,56 Z M 36,56 l 0,-2 5,0 0,2 z m 6,0 0,-2 7,0 0,2 z" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     d="m 18,109.5 -11.5,0 c 0,-28 0.026032,-57.676631 0,-82 l 11.5,-3e-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+     d="m 18,118.5 -11.5,0 c 0,-28 0.026032,-57.676631 0,-82 l 11.5,-3e-6" />
   <path
-     id="rect6741-1-5"
-     d="m 17.5,108.5 -10,0 0,-80 10,0"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 17.5,117.5 -10,0 0,-80 10,0"
+     id="rect6741-1-5" />
   <path
-     d="m 73.999999,38 0,2 2.000001,-2e-6 0,-2 z m 3.000001,-2e-6 0,2 5,0 0,-2 z m 6.999998,0 0,2 6,2e-6 0,-2 z m -39.999998,0 0,2 12,0 0,-2 z m 13,0 0,2 6,0 0,-2 z m 6.999999,0 0,2 8.000001,0 0,-2 z"
+     id="path3925"
      style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="path3925" />
+     d="m 73.999999,47 0,2 2.000001,-2e-6 0,-2 z m 3.000001,-2e-6 0,2 5,0 0,-2 z m 6.999998,0 0,2 6,2e-6 0,-2 z m -39.999998,0 0,2 12,0 0,-2 z m 13,0 0,2 6,0 0,-2 z m 6.999999,0 0,2 8.000001,0 0,-2 z" />
   <path
-     d="m 27.999999,95.999998 0,-2 7.000001,0 0,2 z m 8.000001,0 0,-2 3,0 0,2 z m 4,0 0,-2 7,0 0,2 z m -12.000001,-7.999999 0,-2 6.000001,0 0,2 z m 7.000001,0 0,-2 5,0 0,2 z m 6,0 0,-2 8,0 0,2 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path3966"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+     d="m 27.999999,105 0,-2 7.000001,0 0,2 z M 36,105 l 0,-2 3,0 0,2 z m 4,0 0,-2 7,0 0,2 z m -12.000001,-8.000001 0,-2 6.000001,0 0,2 z m 7.000001,0 0,-2 5,0 0,2 z m 6,0 0,-2 8,0 0,2 z" />
   <path
-     d="m 50,80.000001 0,-2 5,0 0,2 z m 0,-8 0,-2 6,0 0,2 z m -1,-7.999999 0,-2 5,0 0,2 z m 2,-8 0,-2 5,0 0,2 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path4178"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+     d="m 50,89.000001 0,-2 5,0 0,2 z m 0,-8 0,-2 6,0 0,2 z m -1,-7.999999 0,-2 5,0 0,2 z m 2,-8 0,-2 5,0 0,2 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     d="m 50,95.000001 0,2 7,0 0,-2 z m 8,0 0,2 3,0 0,-2 z M 49,103 l 0,2 7,0 0,-2 z m 8,0 0,2 5,0 0,-2 z m 6,0 0,2 7,0 0,-2 z"
      id="path4183"
-     d="m 50,86.000001 0,2 7,0 0,-2 z m 8,0 0,2 3,0 0,-2 z M 49,94 l 0,2 7,0 0,-2 z m 8,0 0,2 5,0 0,-2 z m 6,0 0,2 7,0 0,-2 z" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     d="m 18,109.5 -11.5,0 c 0,-28.5 0.025903,-57.678098 0,-82 l 11.5,-3e-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path4530-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 18,118.5 -11.5,0 c 0,-28.5 0.025903,-57.678098 0,-82 l 11.5,-3e-6" />
   <path
-     id="path4160-6-1"
-     d="m 18,109.5 103.5,0 0,-81.999997 -103.5,0"
-     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 18,118.5 103.5,0 0,-81.999997 -103.5,0"
+     id="path4160-6-1" />
   <g
-     transform="translate(0,-0.00199978)"
-     id="g4387">
+     id="g4387"
+     transform="translate(0,8.9980004)">
     <path
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4341);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 110,73.999995 A 19.999999,19.999999 0 1 1 99.420234,56.357462 l -9.420236,17.642533 z"
        id="path3035"
-       d="M 110,73.999995 A 19.999999,19.999999 0 1 1 99.420234,56.357462 l -9.420236,17.642533 z" />
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4341);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       d="M 110,73.997889 C 110,83 104,90.874324 95.33681,93.27249 86.68495,95.66752 77.5,92.035573 72.850413,84.282045 72.815033,84.314125 89.999998,73.997889 89.999998,73.997889 Z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="path3964"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       d="M 110,73.997889 C 110,83 104,90.874324 95.33681,93.27249 86.68495,95.66752 77.5,92.035573 72.850413,84.282045 72.815033,84.314125 89.999998,73.997889 89.999998,73.997889 Z" />
     <path
-       d="m 110,74.006966 c 0,8.671378 -5.804,16.822178 -14.66319,19.274601 -0.19524,-0.0339 -5.336812,-19.274601 -5.336812,-19.274601 z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="path3962"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       d="m 110,74.006966 c 0,8.671378 -5.804,16.822178 -14.66319,19.274601 -0.19524,-0.0339 -5.336812,-19.274601 -5.336812,-19.274601 z" />
   </g>
 </svg>

--- a/mimes/16/x-office-presentation-rtl.svg
+++ b/mimes/16/x-office-presentation-rtl.svg
@@ -6,7 +6,6 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 16 16"
    version="1.1"
    width="16"
    height="16"
@@ -144,9 +143,9 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76025,-25.570651)"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76625,-25.593496)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient5105"
+       id="radialGradient4176"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
     <radialGradient
        r="12.671875"
@@ -154,9 +153,9 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76025,-25.570651)"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76625,-25.603041)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient5107"
+       id="radialGradient4178"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
     <radialGradient
        r="12.671875"
@@ -164,9 +163,9 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76025,-25.570651)"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76625,-25.602169)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient5109"
+       id="radialGradient4180"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
   </defs>
   <metadata
@@ -182,63 +181,63 @@
     </rdf:RDF>
   </metadata>
   <path
-     style="display:inline;fill:url(#linearGradient3741);fill-opacity:1;stroke:none"
+     style="fill:url(#linearGradient3741);fill-opacity:1;stroke:none;display:inline"
      id="path4160"
-     d="m 3,3 c 2.7498091,0 11.999985,6.996e-4 11.999985,6.996e-4 L 15,14 C 15,14 7,14 3,14 3,10.333334 3,6.6666664 3,3 Z" />
+     d="m 3,3 c 2.7498091,0 11.999985,6.996e-4 11.999985,6.996e-4 L 15,14 C 15,14 7,14 3,14 3,10.333334 3,6.6666664 3,3 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
-     id="path3035-5"
-     d="M 9.994,10 A 3,3 0 1 1 8.407036,7.3536196 L 6.994,10 Z" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5109);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3035-0"
-     d="M 9.994,9.0315169 A 3,3 0 1 1 8.407036,6.3851373 L 6.994,9.0315169 Z" />
-  <path
-     d="M 9.994,9.0315169 C 9.994,10.332224 9.047981,11.575721 7.794522,11.922707 6.541062,12.269693 5.0904945,11.689634 4.4215622,10.574141 4.4162122,10.578941 6.994,9.0315169 6.994,9.0315169 Z"
-     id="path3964"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5107);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     style="display:inline;fill:none;stroke:url(#linearGradient3679);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 3,14.500039 H 15.500039 V 2.4999608 H 3"
+     style="fill:none;stroke:url(#linearGradient3679);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     d="m 3,14.500039 12.500039,0 0,-12.0000782 -12.500039,0"
      id="path4160-6-1" />
   <path
-     style="fill:none;stroke:url(#linearGradient3733);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="fill:none;stroke:url(#linearGradient3733);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1"
-     d="M 14.5,13.5 H 1.4999999 V 3.5 H 14.5 Z" />
+     d="m 14.5,13.5 -13.0000001,0 0,-10 L 14.5,3.5 z" />
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530-2"
-     d="M 3,14.5 H 0.62415021 c -0.23300037,-0.142087 -0.0558237,-0.424186 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 L 0.54546106,2.520152 0.62415076,2.5 v 0 H 3" />
+     d="m 3,14.5 -2.5,0 c 0.001983,-3.654651 0.002262,-11.5212846 0,-12 0.6755518,0 1.7298379,0 2.5,0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path4530"
-     d="m 3,14.5 c -0.9586147,0 -1.4172301,0 -2.37584979,0 -0.23300037,-0.142086 -0.0558237,-0.424185 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 L 0.54546106,2.5201526 0.62415076,2.5 v 0 C 1.6218754,2.5 2.0022802,2.5 3,2.5" />
+     d="m 3,14.5 c -0.9586147,0 -1.4172301,0 -2.37584979,0 -0.23300037,-0.142086 -0.0558237,-0.424185 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 L 0.54546106,2.5201526 0.62415076,2.5 l 0,0 C 1.6218754,2.5 2.0022802,2.5 3,2.5" />
   <path
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3695);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 2.5000001,13.5 H 1.5 v -10 h 1.0000001"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3695);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     d="M 2.5000001,13.5 1.5,13.5 l 0,-10 1.0000001,0"
      id="rect6741-1-5" />
   <g
      id="g4827"
-     transform="matrix(-1,0,0,1,42.945162,-3.6559055)">
+     transform="matrix(-1,0,0,1,42.951162,-3.6559055)">
     <path
-       d="m 28.951162,11.155905 h 2"
+       d="m 28.951162,11.155905 2,0"
        id="path4167"
        style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       d="m 28.945162,13.155905 h 1.006"
+       d="m 28.951162,13.155905 1,0"
        id="path4169"
        style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       d="m 28.945169,15.181889 h 3.005993"
+       d="m 28.951162,15.155905 3,0"
        id="path4173"
        style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       d="m 30.951162,13.155905 h 1"
+       d="m 30.951162,13.155905 1,0"
        id="path4175"
        style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
   <path
-     d="M 9.994,9.0315169 C 9.994,10.332224 9.047981,11.575721 7.794522,11.922707 7.765232,11.917607 6.994,9.0315169 6.994,9.0315169 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
+     id="path3035-5"
+     d="M 10,10 A 3,3 0 1 1 8.413036,7.3536196 L 7,10 Z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4180);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3035-0"
+     d="M 10,8.9999992 A 3,3 0 1 1 8.413036,6.3536196 L 7,8.9999992 Z" />
+  <path
+     d="M 10,9.0086719 C 10,10.309379 9.053981,11.552876 7.800522,11.899862 6.547062,12.246848 5.0964945,11.666789 4.4275622,10.551296 4.4222122,10.556096 7,9.0086719 7,9.0086719 Z"
+     id="path3964"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4176);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     d="M 10,8.9991261 C 10,10.299834 9.053981,11.543331 7.800522,11.890317 7.771232,11.885217 7,8.9991261 7,8.9991261 Z"
      id="path3962"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5105);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4178);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/16/x-office-presentation-template-rtl.svg
+++ b/mimes/16/x-office-presentation-template-rtl.svg
@@ -6,140 +6,169 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 16 16"
-   id="svg3810"
-   height="16"
+   version="1.1"
    width="16"
-   version="1.1">
+   height="16"
+   id="svg3810">
   <defs
      id="defs3812">
     <linearGradient
        id="linearGradient4589">
       <stop
-         id="stop4591"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop4591" />
       <stop
-         id="stop4593"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
+         id="stop4593" />
       <stop
-         id="stop4595"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
+         id="stop4595" />
       <stop
-         id="stop4597"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop4597" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600">
       <stop
-         offset="0"
+         id="stop3602"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         offset="0"
+         id="stop3106-3-2"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8-3"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-8-3" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient4356">
       <stop
-         id="stop4358"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4358" />
+      <stop
+         id="stop4360"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
          offset="0" />
       <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop4360" />
-      <stop
-         id="stop4362"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="1" />
+         id="stop4362" />
       <stop
-         id="stop4364"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop4364" />
     </linearGradient>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.33196022,0,0,0.24401541,22.862892,1.5515839)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient3679"
-       xlink:href="#linearGradient3104-6-6-1" />
-    <linearGradient
-       y2="40.64999"
-       x2="11.002663"
-       y1="7.3499894"
-       x1="11.002663"
-       gradientTransform="matrix(0.22297298,0,0,0.27027026,0.27364997,2.0135165)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33196022,0,0,0.24401541,22.862892,1.5515839)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       xlink:href="#linearGradient4356"
        id="linearGradient3695"
-       xlink:href="#linearGradient4356" />
-    <linearGradient
-       y2="40.444435"
-       x2="23.99999"
-       y1="7.349988"
-       x1="23.99999"
-       gradientTransform="matrix(0.35135134,0,0,0.27027025,-0.4324303,2.0135169)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22297298,0,0,0.27027026,0.27364997,2.0135165)"
+       x1="11.002663"
+       y1="7.3499894"
+       x2="11.002663"
+       y2="40.64999" />
+    <linearGradient
+       xlink:href="#linearGradient4589"
        id="linearGradient3733"
-       xlink:href="#linearGradient4589" />
-    <linearGradient
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275"
-       gradientTransform="matrix(0.34285635,0,0,0.23901194,0.77144719,2.3970465)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135134,0,0,0.27027025,-0.4324303,2.0135169)"
+       x1="23.99999"
+       y1="7.349988"
+       x2="23.99999"
+       y2="40.444435" />
+    <linearGradient
+       xlink:href="#linearGradient3600"
        id="linearGradient3741"
-       xlink:href="#linearGradient3600" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.34285635,0,0,0.23901194,0.77144719,2.3970465)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3"
+       id="radialGradient3698-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.570651)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9-9-0-0"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7-4-0-32-8-923-0-7-8-8"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8-5-2-7-6-7-1-8-0-3"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6-2-6-6-1-96-6-1-1-0"
+         style="stop-color:#ac441f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <radialGradient
        r="12.671875"
        fy="9.9571075"
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.570651)"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76625,-25.593496)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3698-6"
+       id="radialGradient4176"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76625,-25.603041)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4178"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76625,-25.602169)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4180"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3">
-      <stop
-         offset="0"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-9-0-0" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7-8-8" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-8-0-3" />
-      <stop
-         offset="1"
-         style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-1-1-0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0,0.6,0.6,0,5.8976269,-12.49769)"
+       gradientTransform="matrix(0,0.6,-0.6,0,26.6,-11.8)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3412"
        id="linearGradient3040"
@@ -158,36 +187,6 @@
          style="stop-color:#cbcdd9;stop-opacity:1"
          id="stop3416" />
     </linearGradient>
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76025,-25.570651)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4516"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76025,-25.570651)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4518"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,3.0412936,-3.4225923,0,36.76025,-25.570651)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4520"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
   </defs>
   <metadata
      id="metadata3815">
@@ -202,71 +201,67 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="m 3,3 c 2.7498091,0 11.999985,6.996e-4 11.999985,6.996e-4 L 15,14 C 15,14 7,14 3,14 3,10.333334 3,6.6666664 3,3 Z"
+     style="fill:url(#linearGradient3741);fill-opacity:1;stroke:none;display:inline"
      id="path4160"
-     style="display:inline;fill:url(#linearGradient3741);fill-opacity:1;stroke:none" />
+     d="m 3,3 c 2.7498091,0 11.999985,6.996e-4 11.999985,6.996e-4 L 15,14 C 15,14 7,14 3,14 3,10.333334 3,6.6666664 3,3 z" />
   <path
-     d="M 9.994,10 A 3,3 0 1 1 8.407036,7.3536196 L 6.994,10 Z"
-     id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+     style="fill:none;stroke:url(#linearGradient3679);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     d="m 3,14.500039 12.500039,0 0,-12.0000782 -12.500039,0"
+     id="path4160-6-1" />
   <path
-     d="M 9.994,9.0315169 A 3,3 0 1 1 8.407036,6.3851373 L 6.994,9.0315169 Z"
-     id="path3035-0"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4520);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4518);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3964"
-     d="M 9.994,9.0315169 C 9.994,10.332224 9.047981,11.575721 7.794522,11.922707 6.541062,12.269693 5.0904945,11.689634 4.4215622,10.574141 4.4162122,10.578941 6.994,9.0315169 6.994,9.0315169 Z" />
-  <path
-     id="path4160-6-1"
-     d="M 3,14.500039 H 15.500039 V 2.4999608 H 3"
-     style="display:inline;fill:none;stroke:url(#linearGradient3679);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     d="M 14.5,13.5 H 1.4999999 V 3.5 H 14.5 Z"
+     style="fill:none;stroke:url(#linearGradient3733);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3733);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     d="m 14.5,13.5 -13.0000001,0 0,-10 L 14.5,3.5 z" />
   <path
-     d="M 3,14.5 H 0.62415021 c -0.23300037,-0.142087 -0.0558237,-0.424186 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 L 0.54546106,2.520152 0.62415076,2.5 v 0 H 3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530-2"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+     d="m 3,14.5 -2.5,0 c 0.001983,-3.654651 0.002262,-11.5212846 0,-12 0.6755518,0 1.7298379,0 2.5,0" />
   <path
-     d="m 3,14.5 c -0.9586147,0 -1.4172301,0 -2.37584979,0 -0.23300037,-0.142086 -0.0558237,-0.424185 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 L 0.54546106,2.5201526 0.62415076,2.5 v 0 C 1.6218754,2.5 2.0022802,2.5 3,2.5"
+     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path4530"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 3,14.5 c -0.9586147,0 -1.4172301,0 -2.37584979,0 -0.23300037,-0.142086 -0.0558237,-0.424185 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 L 0.54546106,2.5201526 0.62415076,2.5 l 0,0 C 1.6218754,2.5 2.0022802,2.5 3,2.5" />
   <path
-     id="rect6741-1-5"
-     d="M 2.5000001,13.5 H 1.5 v -10 h 1.0000001"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3695);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3695);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     d="M 2.5000001,13.5 1.5,13.5 l 0,-10 1.0000001,0"
+     id="rect6741-1-5" />
   <g
-     transform="matrix(-1,0,0,1,42.945162,-3.6559055)"
-     id="g4827">
+     id="g4827"
+     transform="matrix(-1,0,0,1,42.951162,-3.6559055)">
     <path
-       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 28.951162,11.155905 2,0"
        id="path4167"
-       d="m 28.951162,11.155905 h 2" />
+       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 28.951162,13.155905 1,0"
        id="path4169"
-       d="m 28.945162,13.155905 h 1.006" />
+       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 28.951162,15.155905 3,0"
        id="path4173"
-       d="m 28.945169,15.181889 h 3.005993" />
+       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 30.951162,13.155905 1,0"
        id="path4175"
-       d="m 30.951162,13.155905 h 1" />
+       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4516);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
+     id="path3035-5"
+     d="M 10,10 A 3,3 0 1 1 8.413036,7.3536196 L 7,10 Z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4180);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3035-0"
+     d="M 10,8.9999992 A 3,3 0 1 1 8.413036,6.3536196 L 7,8.9999992 Z" />
+  <path
+     d="M 10,9.0086719 C 10,10.309379 9.053981,11.552876 7.800522,11.899862 6.547062,12.246848 5.0964945,11.666789 4.4275622,10.551296 4.4222122,10.556096 7,9.0086719 7,9.0086719 Z"
+     id="path3964"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4176);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     d="M 10,8.9991261 C 10,10.299834 9.053981,11.543331 7.800522,11.890317 7.771232,11.885217 7,8.9991261 7,8.9991261 Z"
      id="path3962"
-     d="M 9.994,9.0315169 C 9.994,10.332224 9.047981,11.575721 7.794522,11.922707 7.765232,11.917607 6.994,9.0315169 6.994,9.0315169 Z" />
-  <g
-     transform="matrix(-1,0,0,1,32.497627,0.69769011)"
-     id="g3082">
-    <path
-       d="m 16.997627,5.8023097 9,9.0000003 h -9 z m 2,5.0000003 v 2 h 2 z"
-       id="path3410"
-       style="opacity:0.8;fill:url(#linearGradient3040);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  </g>
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4178);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     d="m 15.5,6.5 -9,9 9,0 0,-9 z m -2,5 0,2 -2,0 2,-2 z"
+     id="path3410"
+     style="opacity:0.8;fill:url(#linearGradient3040);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
 </svg>

--- a/mimes/16/x-office-presentation-template.svg
+++ b/mimes/16/x-office-presentation-template.svg
@@ -137,25 +137,55 @@
          style="stop-color:#ac441f;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="33.876614"
-       y1="19.948324"
-       x2="44.118835"
-       y2="30.190546"
-       id="linearGradient3040"
-       xlink:href="#linearGradient3412"
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.593496)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.6,0.6,0,5.8976269,-12.49769)" />
+       id="radialGradient4176"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.603041)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4178"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.602169)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4180"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
+    <linearGradient
+       gradientTransform="matrix(0,0.6,-0.6,0,26.6,-11.8)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3040"
+       y2="30.190546"
+       x2="44.118835"
+       y1="19.948324"
+       x1="33.876614" />
     <linearGradient
        id="linearGradient3412">
       <stop
-         id="stop3414"
+         offset="0"
          style="stop-color:#fcfcfc;stop-opacity:1"
-         offset="0" />
+         id="stop3414" />
       <stop
-         id="stop3416"
+         offset="1"
          style="stop-color:#cbcdd9;stop-opacity:1"
-         offset="1" />
+         id="stop3416" />
     </linearGradient>
   </defs>
   <metadata
@@ -179,13 +209,13 @@
      id="path3035-5"
      d="M 14,10 A 3,3 0 1 1 12.413036,7.3536196 L 11,10 z" />
   <path
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4180);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3035-0"
-     d="M 14,9.0315169 A 3,3 0 1 1 12.413036,6.3851373 L 11,9.0315169 z" />
+     d="M 14,8.9999992 A 3,3 0 1 1 12.413036,6.3536196 L 11,8.9999992 Z" />
   <path
-     d="M 14,9.0315169 C 14,10.332224 13.053981,11.575721 11.800522,11.922707 10.547062,12.269693 9.0964945,11.689634 8.4275622,10.574141 8.4222122,10.578941 11,9.0315169 11,9.0315169 z"
+     d="M 14,9.0086719 C 14,10.309379 13.053981,11.552876 11.800522,11.899862 10.547062,12.246848 9.0964945,11.666789 8.4275622,10.551296 8.4222122,10.556096 11,9.0086719 11,9.0086719 Z"
      id="path3964"
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4176);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
      style="fill:none;stroke:url(#linearGradient3679);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
      d="m 3,14.500039 12.500039,0 0,-12.0000782 -12.500039,0"
@@ -195,9 +225,9 @@
      id="rect6741-1"
      d="m 14.5,13.5 -13.0000001,0 0,-10 L 14.5,3.5 z" />
   <path
-     style="color:#000000;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530-2"
-     d="m 3,14.5 -2.37584979,0 c -0.23300037,-0.142087 -0.0558237,-0.424186 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 l 0.0324955,-0.0488 L 0.62415076,2.5 l 0,0 L 3,2.5" />
+     d="m 3,14.5 -2.5,0 c 0.001983,-3.654651 0.002262,-11.5212846 0,-12 0.6755518,0 1.7298379,0 2.5,0" />
   <path
      style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path4530"
@@ -214,11 +244,11 @@
        id="path4167"
        style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       d="m 28.945162,13.155905 1.006,0"
+       d="m 28.951162,13.155905 1,0"
        id="path4169"
        style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       d="m 28.945169,15.181889 3.005993,0"
+       d="m 28.951162,15.155905 3,0"
        id="path4173"
        style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
@@ -227,15 +257,11 @@
        style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
   <path
-     d="M 14,9.0315169 C 14,10.332224 13.053981,11.575721 11.800522,11.922707 11.771232,11.917607 11,9.0315169 11,9.0315169 z"
+     d="M 14,8.9991261 C 14,10.299834 13.053981,11.543331 11.800522,11.890317 11.771232,11.885217 11,8.9991261 11,8.9991261 Z"
      id="path3962"
-     style="opacity:0.8;color:#000000;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
-  <g
-     id="g3082"
-     transform="matrix(-1,0,0,1,32.497627,0.69769011)">
-    <path
-       style="opacity:0.8;fill:url(#linearGradient3040);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3410"
-       d="m 16.997627,5.8023097 9,9.0000003 -9,0 0,-9.0000003 z m 2,5.0000003 0,2 2,0 -2,-2 z" />
-  </g>
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4178);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     d="m 15.5,6.5 -9.0000002,9 9.0000002,0 0,-9 z m -2,5 0,2 -2,0 2,-2 z"
+     id="path3410"
+     style="opacity:0.8;fill:url(#linearGradient3040);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
 </svg>

--- a/mimes/16/x-office-presentation.svg
+++ b/mimes/16/x-office-presentation.svg
@@ -6,137 +6,167 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg3810"
-   height="16"
+   version="1.1"
    width="16"
-   version="1.1">
+   height="16"
+   id="svg3810">
   <defs
      id="defs3812">
     <linearGradient
        id="linearGradient4589">
       <stop
-         id="stop4591"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop4591" />
       <stop
-         id="stop4593"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
+         id="stop4593" />
       <stop
-         id="stop4595"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
+         id="stop4595" />
       <stop
-         id="stop4597"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop4597" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600">
       <stop
-         offset="0"
+         id="stop3602"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         offset="0"
+         id="stop3106-3-2"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8-3"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-8-3" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient4356">
       <stop
-         id="stop4358"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4358" />
+      <stop
+         id="stop4360"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
          offset="0" />
       <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop4360" />
-      <stop
-         id="stop4362"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="1" />
+         id="stop4362" />
       <stop
-         id="stop4364"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop4364" />
     </linearGradient>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.33196022,0,0,0.24401541,22.862892,1.5515839)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient3679"
-       xlink:href="#linearGradient3104-6-6-1" />
-    <linearGradient
-       y2="40.64999"
-       x2="11.002663"
-       y1="7.3499894"
-       x1="11.002663"
-       gradientTransform="matrix(0.22297298,0,0,0.27027026,0.27364997,2.0135165)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33196022,0,0,0.24401541,22.862892,1.5515839)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       xlink:href="#linearGradient4356"
        id="linearGradient3695"
-       xlink:href="#linearGradient4356" />
-    <linearGradient
-       y2="40.444435"
-       x2="23.99999"
-       y1="7.349988"
-       x1="23.99999"
-       gradientTransform="matrix(0.35135134,0,0,0.27027025,-0.4324303,2.0135169)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22297298,0,0,0.27027026,0.27364997,2.0135165)"
+       x1="11.002663"
+       y1="7.3499894"
+       x2="11.002663"
+       y2="40.64999" />
+    <linearGradient
+       xlink:href="#linearGradient4589"
        id="linearGradient3733"
-       xlink:href="#linearGradient4589" />
-    <linearGradient
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275"
-       gradientTransform="matrix(0.34285635,0,0,0.23901194,0.77144719,2.3970465)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135134,0,0,0.27027025,-0.4324303,2.0135169)"
+       x1="23.99999"
+       y1="7.349988"
+       x2="23.99999"
+       y2="40.444435" />
+    <linearGradient
+       xlink:href="#linearGradient3600"
        id="linearGradient3741"
-       xlink:href="#linearGradient3600" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.34285635,0,0,0.23901194,0.77144719,2.3970465)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3"
+       id="radialGradient3698-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.570651)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9-9-0-0"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7-4-0-32-8-923-0-7-8-8"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8-5-2-7-6-7-1-8-0-3"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6-2-6-6-1-96-6-1-1-0"
+         style="stop-color:#ac441f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <radialGradient
        r="12.671875"
        fy="9.9571075"
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.570651)"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.593496)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3698-6"
+       id="radialGradient4176"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3">
-      <stop
-         offset="0"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-9-0-0" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7-8-8" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-8-0-3" />
-      <stop
-         offset="1"
-         style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-1-1-0" />
-    </linearGradient>
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.603041)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4178"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,3.0412936,-3.4225923,0,40.76625,-25.602169)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4180"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-3" />
   </defs>
   <metadata
      id="metadata3815">
@@ -151,63 +181,63 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="m 3,3 c 2.7498091,0 11.999985,6.996e-4 11.999985,6.996e-4 L 15,14 C 15,14 7,14 3,14 3,10.333334 3,6.6666664 3,3 z"
+     style="fill:url(#linearGradient3741);fill-opacity:1;stroke:none;display:inline"
      id="path4160"
-     style="fill:url(#linearGradient3741);fill-opacity:1;stroke:none;display:inline" />
+     d="m 3,3 c 2.7498091,0 11.999985,6.996e-4 11.999985,6.996e-4 L 15,14 C 15,14 7,14 3,14 3,10.333334 3,6.6666664 3,3 z" />
   <path
-     d="M 14,10 A 3,3 0 1 1 12.413036,7.3536196 L 11,10 z"
+     style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path3035-5"
-     style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 14,10 A 3,3 0 1 1 12.413036,7.3536196 L 11,10 z" />
   <path
-     d="M 14,9.0315169 A 3,3 0 1 1 12.413036,6.3851373 L 11,9.0315169 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4180);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3035-0"
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     d="M 14,8.9999992 A 3,3 0 1 1 12.413036,6.3536196 L 11,8.9999992 Z" />
   <path
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+     d="M 14,9.0086719 C 14,10.309379 13.053981,11.552876 11.800522,11.899862 10.547062,12.246848 9.0964945,11.666789 8.4275622,10.551296 8.4222122,10.556096 11,9.0086719 11,9.0086719 Z"
      id="path3964"
-     d="M 14,9.0315169 C 14,10.332224 13.053981,11.575721 11.800522,11.922707 10.547062,12.269693 9.0964945,11.689634 8.4275622,10.574141 8.4222122,10.578941 11,9.0315169 11,9.0315169 z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4176);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
-     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3679);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
      d="m 3,14.500039 12.500039,0 0,-12.0000782 -12.500039,0"
-     style="fill:none;stroke:url(#linearGradient3679);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+     id="path4160-6-1" />
   <path
-     d="m 14.5,13.5 -13.0000001,0 0,-10 L 14.5,3.5 z"
+     style="fill:none;stroke:url(#linearGradient3733);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3733);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="m 14.5,13.5 -13.0000001,0 0,-10 L 14.5,3.5 z" />
   <path
-     d="m 3,14.5 -2.37584979,0 c -0.23300037,-0.142087 -0.0558237,-0.424186 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 l 0.0324955,-0.0488 L 0.62415076,2.5 l 0,0 L 3,2.5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530-2"
-     style="color:#000000;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 3,14.5 -2.5,0 c 0.001983,-3.654651 0.002262,-11.5212846 0,-12 0.6755518,0 1.7298379,0 2.5,0" />
   <path
-     d="m 3,14.5 c -0.9586147,0 -1.4172301,0 -2.37584979,0 -0.23300037,-0.142086 -0.0558237,-0.424185 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 L 0.54546106,2.5201526 0.62415076,2.5 l 0,0 C 1.6218754,2.5 2.0022802,2.5 3,2.5"
+     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path4530"
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 3,14.5 c -0.9586147,0 -1.4172301,0 -2.37584979,0 -0.23300037,-0.142086 -0.0558237,-0.424185 -0.11118465,-0.625336 0,-3.768571 0,-7.5371421 0,-11.305712 L 0.54546106,2.5201526 0.62415076,2.5 l 0,0 C 1.6218754,2.5 2.0022802,2.5 3,2.5" />
   <path
-     id="rect6741-1-5"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3695);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      d="M 2.5000001,13.5 1.5,13.5 l 0,-10 1.0000001,0"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3695);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     id="rect6741-1-5" />
   <g
-     transform="translate(-24.951162,-3.6559055)"
-     id="g4827">
+     id="g4827"
+     transform="translate(-24.951162,-3.6559055)">
     <path
-       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 28.951162,11.155905 2,0"
        id="path4167"
-       d="m 28.951162,11.155905 2,0" />
+       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 28.951162,13.155905 1,0"
        id="path4169"
-       d="m 28.945162,13.155905 1.006,0" />
+       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 28.951162,15.155905 3,0"
        id="path4173"
-       d="m 28.945169,15.181889 3.005993,0" />
+       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 30.951162,13.155905 1,0"
        id="path4175"
-       d="m 30.951162,13.155905 1,0" />
+       style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
   <path
-     style="opacity:0.8;color:#000000;fill:url(#radialGradient3698-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+     d="M 14,8.9991261 C 14,10.299834 13.053981,11.543331 11.800522,11.890317 11.771232,11.885217 11,8.9991261 11,8.9991261 Z"
      id="path3962"
-     d="M 14,9.0315169 C 14,10.332224 13.053981,11.575721 11.800522,11.922707 11.771232,11.917607 11,9.0315169 11,9.0315169 z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4178);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/24/x-office-presentation-rtl.svg
+++ b/mimes/24/x-office-presentation-rtl.svg
@@ -6,7 +6,6 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 24 24"
    version="1.1"
    width="24"
    height="24"
@@ -257,7 +256,7 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4274"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4.578264,-5.6206455,0,86.777476,-38.572847)"
+       gradientTransform="matrix(0,4.578264,-5.6206455,0,86.777476,-38.561284)"
        cx="6.7304144"
        cy="9.9571075"
        fx="6.2001843"
@@ -280,93 +279,93 @@
      id="g4731"
      style="opacity:0.75">
     <path
-       d="M 3.4999054,2.4999609 20.500094,2.5243049 V 13.500039 H 3.5961105 Z"
+       d="M 3.4999054,2.4999609 20.500094,2.5 l 0,11.000039 -17.000094,0 z"
        id="rect4964-4-1"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:none;stroke:url(#linearGradient3944);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       d="m 4,2.9999221 16,0.024344 V 14 H 4.090545 Z"
+       d="M 4,2.9999221 20,3 20,14 4,14 Z"
        id="rect4964-4"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3869);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate" />
   </g>
   <rect
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3789);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     style="opacity:0.15;fill:url(#linearGradient3789);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="rect2879"
      y="21"
      x="2.6500008"
      height="2"
      width="18.699997" />
   <path
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3786);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     style="opacity:0.15;fill:url(#radialGradient3786);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="path2881"
-     d="m 2.6499999,21.000085 c 0,0 0,1.999891 0,1.999891 C 1.9674803,23.003776 1,22.551901 1,21.999901 1,21.447902 1.76164,21.000085 2.6499999,21.000085 Z" />
+     d="m 2.6499999,21.000085 c 0,0 0,1.999891 0,1.999891 C 1.9674803,23.003776 1,22.551901 1,21.999901 1,21.447902 1.76164,21.000085 2.6499999,21.000085 z" />
   <path
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3783);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     style="opacity:0.15;fill:url(#radialGradient3783);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="path2883"
      d="m 21.35,21.000085 c 0,0 0,1.999891 0,1.999891 0.682519,0.0038 1.65,-0.448075 1.65,-1.000075 0,-0.551999 -0.761642,-0.999816 -1.65,-0.999816 z" />
   <path
      style="display:inline;fill:url(#linearGradient3780);fill-opacity:1;stroke:none"
      id="path4160-3"
-     d="M 5,5 21.99998,5.001 22,21 H 4.9999999 V 5.000016 Z" />
+     d="M 5,5 21.99998,5 22,21 4.9999999,21 l 0,-15.999984 z" />
   <path
-     style="fill:none;stroke:url(#linearGradient3777);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="fill:none;stroke:url(#linearGradient3777);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1"
-     d="M 21.5,20.5 H 2.5000001 V 5.5 H 21.5 Z" />
+     d="m 21.5,20.5 -18.9999999,0 0,-15 L 21.5,5.5 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3774);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     style="color:#000000;fill:url(#radialGradient3774);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect5505"
-     d="M 2,4.5 C 1.723,4.5 1.5,4.723 1.5,5 v 16 c 0,0.277 0.223,0.5 0.5,0.5 h 3 v -17 z" />
+     d="M 2,4.5 C 1.723,4.5 1.5,4.723 1.5,5 l 0,16 c 0,0.277 0.223,0.5 0.5,0.5 l 3,0 0,-17 z" />
   <path
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3771);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3771);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1-5"
-     d="m 4.5,20.5 h -2 v -15 h 2" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4159"
-     d="M 20,7.5 H 16" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4161"
-     d="M 15,7.5 H 13" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4163"
-     d="M 12,7.5 H 11" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4165"
-     d="M 10,7.5 H 8" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4167"
-     d="M 20,11.5 H 18" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4169"
-     d="M 20,13.5 H 19" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4171"
-     d="M 20,15.5 H 18" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4173"
-     d="M 20,17.5 H 18" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4175"
-     d="M 18,13.5 H 17" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4177"
-     d="M 17,17.5 H 16" />
+     d="m 4.5,20.5 -2,0 0,-15 2,0" />
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3756);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect5505-21-8-6"
-     d="M 5,21.5 H 22.46875 V 4.5 H 5" />
+     d="m 5,21.5 17.5,0 0,-17 -17.5,0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect5505-21-8-6-4"
-     d="M 5,21.5 H 1.4999609 V 4.5 H 5" />
+     d="m 5,21.5 -3.5000391,0 0,-17 L 5,4.5" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4159"
+     d="m 20,7.5 -4,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4161"
+     d="m 15,7.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4163"
+     d="m 12,7.5 -1,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4165"
+     d="m 10,7.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4167"
+     d="m 20,11.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4169"
+     d="m 20,13.5 -1,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4171"
+     d="m 20,15.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4173"
+     d="m 20,17.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4175"
+     d="m 18,13.5 -1,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4177"
+     d="m 17,17.5 -1,0" />
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
      id="path3035-5-4"
@@ -376,7 +375,7 @@
      id="path3035-3"
      d="M 14,13.999999 A 3.9999999,3.9999999 0 1 1 11.884048,10.471493 L 10,13.999999 Z" />
   <path
-     d="m 14,13.999999 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 C 9.396084,18.317568 7.461993,17.544155 6.570084,16.05683 6.563006,16.063244 10,13.999999 10,13.999999 Z"
+     d="m 14,14.011562 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 C 9.396084,18.329131 7.461993,17.555718 6.570084,16.068393 6.563006,16.074807 10,14.011562 10,14.011562 Z"
      id="path3964"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4274);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path

--- a/mimes/24/x-office-presentation-template-rtl.svg
+++ b/mimes/24/x-office-presentation-template-rtl.svg
@@ -6,127 +6,221 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 24 24"
-   id="svg4104"
-   height="24"
+   version="1.1"
    width="24"
-   version="1.1">
+   height="24"
+   id="svg4104">
   <defs
      id="defs4106">
     <linearGradient
        id="linearGradient3104-6-2">
       <stop
-         offset="0"
+         id="stop3106-3-4"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-4" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-9"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3977-6">
       <stop
-         offset="0"
+         id="stop3979-9"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979-9" />
+         offset="0" />
       <stop
-         offset="0"
+         id="stop3981-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981-3" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3983-7"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983-7" />
+         offset="1" />
       <stop
-         offset="1"
+         id="stop3985-4"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
       <stop
-         offset="0"
+         id="stop3750-1-0-7-6-6-1-3-9"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9" />
+         offset="0" />
       <stop
-         offset="0.26238"
+         id="stop3752-3-7-4-0-32-8-923-0"
          style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0" />
+         offset="0.26238" />
       <stop
-         offset="0.704952"
+         id="stop3754-1-8-5-2-7-6-7-1"
          style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1" />
+         offset="0.704952" />
       <stop
-         offset="1"
+         id="stop3756-1-6-2-6-6-1-96-6"
          style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3028">
       <stop
-         offset="0"
+         id="stop3030"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3030" />
+         offset="0" />
       <stop
-         offset="0"
+         id="stop3032"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3032" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3034"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3034" />
+         offset="1" />
       <stop
-         offset="1"
+         id="stop3036"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3036" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-4">
       <stop
-         offset="0"
+         id="stop3602-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-6"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
-         offset="0"
+         id="stop5062"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop5064"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5048">
       <stop
-         offset="0"
+         id="stop5050"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop5056"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop5052"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         id="stop3602-1-25-9-9-7"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-1-25-9-9-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-4-2-0-2-0" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6-2"
+       id="linearGradient3756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37459597,0,0,0.37082941,29.392827,2.4405192)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       xlink:href="#linearGradient3977-6"
+       id="linearGradient3771"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66891892,0,0,0.4054054,-1.17905,3.270275)"
+       x1="23.99999"
+       y1="6.7333217"
+       x2="23.99999"
+       y2="41.266655" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       id="radialGradient3774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.1399587,-5.0825466,0,60.969731,-32.403501)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       xlink:href="#linearGradient3028"
+       id="linearGradient3777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.51351311,0,0,0.4054054,-0.3250622,3.270274)"
+       x1="37.633045"
+       y1="6.7333241"
+       x2="37.633045"
+       y2="41.266659" />
+    <linearGradient
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3780"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45714179,0,0,0.34765335,3.0285964,4.122978)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3783"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01325345,0,0,0.0082353,13.362672,17.980564)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01325345,0,0,0.0082353,10.637327,17.980564)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3789"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03872781,0,0,0.0082353,-1.9973372,17.980547)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-8"
+       id="linearGradient3869"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69202661,0,0,0.40431838,-2.1909906,-0.9776278)"
+       x1="25.132275"
+       y1="15.284525"
+       x2="25.132275"
+       y2="37.546188" />
+    <linearGradient
+       id="linearGradient3104-6-2-7">
+      <stop
+         id="stop3106-3-4-9"
+         style="stop-color:#000000;stop-opacity:0.31782946"
          offset="0" />
       <stop
-         id="stop3604-4-2-0-2-0"
-         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3108-9-9-2"
+         style="stop-color:#000000;stop-opacity:0.24031007"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -134,145 +228,40 @@
        x2="-51.786404"
        y1="50.786446"
        x1="-51.786404"
-       gradientTransform="matrix(0.37459597,0,0,0.37082941,29.392827,2.4405192)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3756"
-       xlink:href="#linearGradient3104-6-2" />
-    <linearGradient
-       y2="41.266655"
-       x2="23.99999"
-       y1="6.7333217"
-       x1="23.99999"
-       gradientTransform="matrix(0.66891892,0,0,0.4054054,-1.17905,3.270275)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3771"
-       xlink:href="#linearGradient3977-6" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,4.1399587,-5.0825466,0,60.969731,-32.403501)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3774"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <linearGradient
-       y2="41.266659"
-       x2="37.633045"
-       y1="6.7333241"
-       x1="37.633045"
-       gradientTransform="matrix(0.51351311,0,0,0.4054054,-0.3250622,3.270274)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3777"
-       xlink:href="#linearGradient3028" />
-    <linearGradient
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275"
-       gradientTransform="matrix(0.45714179,0,0,0.34765335,3.0285964,4.122978)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3780"
-       xlink:href="#linearGradient3600-4" />
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(0.01325345,0,0,0.0082353,13.362672,17.980564)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3783"
-       xlink:href="#linearGradient5060" />
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(-0.01325345,0,0,0.0082353,10.637327,17.980564)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3786"
-       xlink:href="#linearGradient5060" />
-    <linearGradient
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715"
-       gradientTransform="matrix(0.03872781,0,0,0.0082353,-1.9973372,17.980547)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3789"
-       xlink:href="#linearGradient5048" />
-    <linearGradient
-       y2="37.546188"
-       x2="25.132275"
-       y1="15.284525"
-       x1="25.132275"
-       gradientTransform="matrix(0.69202661,0,0,0.40431838,-2.1909906,-0.9776278)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3869"
-       xlink:href="#linearGradient3600-3-2-2-6-8" />
-    <linearGradient
-       id="linearGradient3104-6-2-7">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-4-9" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-9-2" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3104-6-2-7"
-       id="linearGradient3944"
-       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.37459597,0,0,0.37082941,29.392826,2.440519)"
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,4.578264,-5.6206455,0,86.777476,-38.572847)"
        gradientUnits="userSpaceOnUse"
+       id="linearGradient3944"
+       xlink:href="#linearGradient3104-6-2-7" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4270"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,4.578264,-5.6206455,0,86.777476,-38.572847)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.578264,-5.6206455,0,86.777476,-38.572847)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4272"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0,4.578264,-5.6206455,0,86.777476,-38.572847)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4274"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
     <radialGradient
-       gradientTransform="matrix(-0.01472605,0,0,0.0095356,21.208141,18.688026)"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       id="radialGradient4274"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-6-2"
-       id="radialGradient3044"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
+       gradientTransform="matrix(0,4.578264,-5.6206455,0,86.777476,-38.561284)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
     <linearGradient
        gradientTransform="matrix(0,0.61754391,-0.65185192,0,33.55926,-4.7561431)"
        gradientUnits="userSpaceOnUse"
@@ -307,122 +296,118 @@
     </rdf:RDF>
   </metadata>
   <g
-     style="opacity:0.75"
-     id="g4731">
+     id="g4731"
+     style="opacity:0.75">
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:none;stroke:url(#linearGradient3944);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 3.4999054,2.4999609 20.500094,2.5 l 0,11.000039 -17.000094,0 z"
        id="rect4964-4-1"
-       d="M 3.4999054,2.4999609 20.500094,2.5243049 V 13.500039 H 3.5961105 Z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:none;stroke:url(#linearGradient3944);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3869);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
+       d="M 4,2.9999221 20,3 20,14 4,14 Z"
        id="rect4964-4"
-       d="m 4,2.9999221 16,0.024344 V 14 H 4.090545 Z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3869);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate" />
   </g>
   <rect
-     width="18.699997"
-     height="2"
-     x="2.6500008"
-     y="21"
+     style="opacity:0.15;fill:url(#linearGradient3789);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="rect2879"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3789);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     y="21"
+     x="2.6500008"
+     height="2"
+     width="18.699997" />
   <path
-     d="m 2.6499999,21.000085 c 0,0 0,1.999891 0,1.999891 C 1.9674803,23.003776 1,22.551901 1,21.999901 1,21.447902 1.76164,21.000085 2.6499999,21.000085 Z"
+     style="opacity:0.15;fill:url(#radialGradient3786);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="path2881"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3786);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     d="m 2.6499999,21.000085 c 0,0 0,1.999891 0,1.999891 C 1.9674803,23.003776 1,22.551901 1,21.999901 1,21.447902 1.76164,21.000085 2.6499999,21.000085 z" />
   <path
-     d="m 21.35,21.000085 c 0,0 0,1.999891 0,1.999891 0.682519,0.0038 1.65,-0.448075 1.65,-1.000075 0,-0.551999 -0.761642,-0.999816 -1.65,-0.999816 z"
+     style="opacity:0.15;fill:url(#radialGradient3783);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="path2883"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3783);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     d="m 21.35,21.000085 c 0,0 0,1.999891 0,1.999891 0.682519,0.0038 1.65,-0.448075 1.65,-1.000075 0,-0.551999 -0.761642,-0.999816 -1.65,-0.999816 z" />
   <path
-     d="M 5,5 21.99998,5.001 22,21 H 4.9999999 V 5.000016 Z"
+     style="display:inline;fill:url(#linearGradient3780);fill-opacity:1;stroke:none"
      id="path4160-3"
-     style="display:inline;fill:url(#linearGradient3780);fill-opacity:1;stroke:none" />
+     d="M 5,5 21.99998,5 22,21 4.9999999,21 l 0,-15.999984 z" />
   <path
-     d="M 21.5,20.5 H 2.5000001 V 5.5 H 21.5 Z"
+     style="fill:none;stroke:url(#linearGradient3777);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3777);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     d="m 21.5,20.5 -18.9999999,0 0,-15 L 21.5,5.5 z" />
   <path
-     d="M 2,4.5 C 1.723,4.5 1.5,4.723 1.5,5 v 16 c 0,0.277 0.223,0.5 0.5,0.5 h 3 v -17 z"
+     style="color:#000000;fill:url(#radialGradient3774);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect5505"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3774);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+     d="M 2,4.5 C 1.723,4.5 1.5,4.723 1.5,5 l 0,16 c 0,0.277 0.223,0.5 0.5,0.5 l 3,0 0,-17 z" />
   <path
-     d="m 4.5,20.5 h -2 v -15 h 2"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3771);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1-5"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3771);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     d="m 4.5,20.5 -2,0 0,-15 2,0" />
   <path
-     d="M 20,7.5 H 16"
-     id="path4159"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 15,7.5 H 13"
-     id="path4161"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 12,7.5 H 11"
-     id="path4163"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 10,7.5 H 8"
-     id="path4165"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 20,11.5 H 18"
-     id="path4167"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 20,13.5 H 19"
-     id="path4169"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 20,15.5 H 18"
-     id="path4171"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 20,17.5 H 18"
-     id="path4173"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 18,13.5 H 17"
-     id="path4175"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 17,17.5 H 16"
-     id="path4177"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="M 5,21.5 H 22.46875 V 4.5 H 5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3756);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect5505-21-8-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3756);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 5,21.5 17.5,0 0,-17 -17.5,0" />
   <path
-     d="M 5,21.5 H 1.4999609 V 4.5 H 5"
+     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect5505-21-8-6-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 5,21.5 -3.5000391,0 0,-17 L 5,4.5" />
   <path
-     d="M 14,15 A 4,4 0 1 1 11.884048,11.471493 L 10,15 Z"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4159"
+     d="m 20,7.5 -4,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4161"
+     d="m 15,7.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4163"
+     d="m 12,7.5 -1,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4165"
+     d="m 10,7.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4167"
+     d="m 20,11.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4169"
+     d="m 20,13.5 -1,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4171"
+     d="m 20,15.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4173"
+     d="m 20,17.5 -2,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4175"
+     d="m 18,13.5 -1,0" />
+  <path
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4177"
+     d="m 17,17.5 -1,0" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
      id="path3035-5-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+     d="M 14,15 A 4,4 0 1 1 11.884048,11.471493 L 10,15 Z" />
   <path
-     d="M 14,13.999999 A 3.9999999,3.9999999 0 1 1 11.884048,10.471493 L 10,13.999999 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4270);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3035-3"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4270);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="M 14,13.999999 A 3.9999999,3.9999999 0 1 1 11.884048,10.471493 L 10,13.999999 Z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4274);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 14,14.011562 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 C 9.396084,18.329131 7.461993,17.555718 6.570084,16.068393 6.563006,16.074807 10,14.011562 10,14.011562 Z"
      id="path3964"
-     d="m 14,13.999999 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 C 9.396084,18.317568 7.461993,17.544155 6.570084,16.05683 6.563006,16.063244 10,13.999999 10,13.999999 Z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4274);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4272);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 14,13.999999 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 C 11.028314,17.848174 10,13.999999 10,13.999999 Z"
      id="path3962"
-     d="m 14,13.999999 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 C 11.028314,17.848174 10,13.999999 10,13.999999 Z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4272);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <g
      id="g4198"
-     transform="translate(2.0000004)">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2883-8"
-       d="m 12.333333,22.18431 c 0,0 0,2.315662 0,2.315662 C 11.574979,24.504372 10.5,23.981149 10.5,23.341991 c 0,-0.639157 0.846268,-1.157681 1.833333,-1.157681 z" />
+     transform="translate(2.000001,-4.9551612e-4)">
     <path
        style="opacity:0.8;fill:url(#linearGradient3080);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        id="path3410"
-       d="M 21.499999,13 10.5,23.5 21.499999,23.500474 Z M 19.5,17.8 v 3.7 h -3.9 z" />
+       d="M 21.499999,13 10.5,23.5 21.499999,23.500474 Z M 19.5,17.8 l 0,3.7 -3.9,0 z" />
   </g>
 </svg>

--- a/mimes/24/x-office-presentation-template.svg
+++ b/mimes/24/x-office-presentation-template.svg
@@ -256,41 +256,31 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4274"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4.578264,-5.6206455,0,92.777476,-38.572847)"
+       gradientTransform="matrix(0,4.578264,-5.6206455,0,92.777476,-38.561284)"
        cx="6.7304144"
        cy="9.9571075"
        fx="6.2001843"
        fy="9.9571075"
        r="12.671875" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3044"
-       xlink:href="#linearGradient3104-6-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.01472605,0,0,0.0095356,21.208141,18.688026)" />
     <linearGradient
-       x1="33.876614"
-       y1="19.948324"
-       x2="44.118835"
-       y2="30.190546"
-       id="linearGradient3080"
-       xlink:href="#linearGradient3412"
+       gradientTransform="matrix(0,0.61754391,-0.65185192,0,33.55926,-4.7561431)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.61754391,-0.65185192,0,33.55926,-4.7561431)" />
+       xlink:href="#linearGradient3412"
+       id="linearGradient3080"
+       y2="30.190546"
+       x2="44.118835"
+       y1="19.948324"
+       x1="33.876614" />
     <linearGradient
        id="linearGradient3412">
       <stop
-         id="stop3414"
+         offset="0"
          style="stop-color:#fcfcfc;stop-opacity:1"
-         offset="0" />
+         id="stop3414" />
       <stop
-         id="stop3416"
+         offset="1"
          style="stop-color:#cbcdd9;stop-opacity:1"
-         offset="1" />
+         id="stop3416" />
     </linearGradient>
   </defs>
   <metadata
@@ -309,13 +299,13 @@
      id="g4731"
      style="opacity:0.75">
     <path
-       d="m 3.4999054,2.4999609 17.0001886,0.024344 0,10.9757341 -16.9039835,0 z"
+       d="M 3.4999054,2.4999609 20.500094,2.5 l 0,11.000039 -17.000094,0 z"
        id="rect4964-4-1"
-       style="opacity:0.75000000000000000;color:#000000;fill:none;stroke:url(#linearGradient3944);stroke-width:0.99992174000000000;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:none;stroke:url(#linearGradient3944);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       d="M 4,2.9999221 20,3.0242661 20,14 4.090545,14 z"
+       d="M 4,2.9999221 20,3 20,14 4,14 Z"
        id="rect4964-4"
-       style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient3869);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186000000005;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3869);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate" />
   </g>
   <rect
      style="opacity:0.15;fill:url(#linearGradient3789);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
@@ -333,9 +323,9 @@
      id="path2883"
      d="m 21.35,21.000085 c 0,0 0,1.999891 0,1.999891 0.682519,0.0038 1.65,-0.448075 1.65,-1.000075 0,-0.551999 -0.761642,-0.999816 -1.65,-0.999816 z" />
   <path
-     style="fill:url(#linearGradient3780);fill-opacity:1;stroke:none;display:inline"
+     style="display:inline;fill:url(#linearGradient3780);fill-opacity:1;stroke:none"
      id="path4160-3"
-     d="M 5,5 21.99998,5.001 22,21 4.9999999,21 l 0,-15.999984 z" />
+     d="M 5,5 21.99998,5 22,21 4.9999999,21 l 0,-15.999984 z" />
   <path
      style="fill:none;stroke:url(#linearGradient3777);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1"
@@ -389,9 +379,9 @@
      id="path4177"
      d="m 9,17.5 1,0" />
   <path
-     style="color:#000000;fill:none;stroke:url(#linearGradient3756);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3756);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect5505-21-8-6"
-     d="m 5,21.5 17.46875,0 0,-17 L 5,4.5" />
+     d="m 5,21.5 17.5,0 0,-17 -17.5,0" />
   <path
      style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect5505-21-8-6-4"
@@ -405,7 +395,7 @@
      id="path3035-3"
      d="M 20,13.999999 A 3.9999999,3.9999999 0 1 1 17.884048,10.471493 L 16,13.999999 Z" />
   <path
-     d="m 20,13.999999 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 -1.671279,0.462649 -3.60537,-0.310764 -4.497279,-1.798089 C 12.563006,16.063244 16,13.999999 16,13.999999 Z"
+     d="m 20,14.011562 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 -1.671279,0.462649 -3.60537,-0.310764 -4.497279,-1.798089 C 12.563006,16.074807 16,14.011562 16,14.011562 Z"
      id="path3964"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4274);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
@@ -413,15 +403,11 @@
      id="path3962"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4272);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <g
-     transform="translate(2.0000004,-2.5422134e-7)"
-     id="g4198">
+     id="g4198"
+     transform="translate(2.000001,-4.9551612e-4)">
     <path
-       d="m 12.333333,22.18431 c 0,0 0,2.315662 0,2.315662 C 11.574979,24.504372 10.5,23.981149 10.5,23.341991 c 0,-0.639157 0.846268,-1.157681 1.833333,-1.157681 z"
-       id="path2883-8"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-    <path
-       d="M 21.499999,13 10.5,23.5 21.499999,23.500474 Z M 19.5,17.8 l 0,3.7 -3.9,0 z"
+       style="opacity:0.8;fill:url(#linearGradient3080);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        id="path3410"
-       style="opacity:0.8;fill:url(#linearGradient3080);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       d="M 21.499999,13 10.5,23.5 21.499999,23.500474 Z M 19.5,17.8 l 0,3.7 -3.9,0 z" />
   </g>
 </svg>

--- a/mimes/24/x-office-presentation.svg
+++ b/mimes/24/x-office-presentation.svg
@@ -6,126 +6,221 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4104"
-   height="24"
+   version="1.1"
    width="24"
-   version="1.1">
+   height="24"
+   id="svg4104">
   <defs
      id="defs4106">
     <linearGradient
        id="linearGradient3104-6-2">
       <stop
-         offset="0"
+         id="stop3106-3-4"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-4" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-9"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3977-6">
       <stop
-         offset="0"
+         id="stop3979-9"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979-9" />
+         offset="0" />
       <stop
-         offset="0"
+         id="stop3981-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981-3" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3983-7"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983-7" />
+         offset="1" />
       <stop
-         offset="1"
+         id="stop3985-4"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
       <stop
-         offset="0"
+         id="stop3750-1-0-7-6-6-1-3-9"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9" />
+         offset="0" />
       <stop
-         offset="0.26238"
+         id="stop3752-3-7-4-0-32-8-923-0"
          style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0" />
+         offset="0.26238" />
       <stop
-         offset="0.704952"
+         id="stop3754-1-8-5-2-7-6-7-1"
          style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1" />
+         offset="0.704952" />
       <stop
-         offset="1"
+         id="stop3756-1-6-2-6-6-1-96-6"
          style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3028">
       <stop
-         offset="0"
+         id="stop3030"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3030" />
+         offset="0" />
       <stop
-         offset="0"
+         id="stop3032"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3032" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3034"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3034" />
+         offset="1" />
       <stop
-         offset="1"
+         id="stop3036"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3036" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-4">
       <stop
-         offset="0"
+         id="stop3602-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-6"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
-         offset="0"
+         id="stop5062"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop5064"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5048">
       <stop
-         offset="0"
+         id="stop5050"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop5056"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop5052"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         id="stop3602-1-25-9-9-7"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-1-25-9-9-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-4-2-0-2-0" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6-2"
+       id="linearGradient3756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37459597,0,0,0.37082941,29.392827,2.4405192)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       xlink:href="#linearGradient3977-6"
+       id="linearGradient3771"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66891892,0,0,0.4054054,-1.17905,3.270275)"
+       x1="23.99999"
+       y1="6.7333217"
+       x2="23.99999"
+       y2="41.266655" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       id="radialGradient3774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.1399587,-5.0825466,0,60.969731,-32.403501)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       xlink:href="#linearGradient3028"
+       id="linearGradient3777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.51351311,0,0,0.4054054,-0.3250622,3.270274)"
+       x1="37.633045"
+       y1="6.7333241"
+       x2="37.633045"
+       y2="41.266659" />
+    <linearGradient
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3780"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45714179,0,0,0.34765335,3.0285964,4.122978)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3783"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01325345,0,0,0.0082353,13.362672,17.980564)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01325345,0,0,0.0082353,10.637327,17.980564)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3789"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03872781,0,0,0.0082353,-1.9973372,17.980547)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       xlink:href="#linearGradient3600-3-2-2-6-8"
+       id="linearGradient3869"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69202661,0,0,0.40431838,-2.1909906,-0.9776278)"
+       x1="25.132275"
+       y1="15.284525"
+       x2="25.132275"
+       y2="37.546188" />
+    <linearGradient
+       id="linearGradient3104-6-2-7">
+      <stop
+         id="stop3106-3-4-9"
+         style="stop-color:#000000;stop-opacity:0.31782946"
          offset="0" />
       <stop
-         id="stop3604-4-2-0-2-0"
-         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3108-9-9-2"
+         style="stop-color:#000000;stop-opacity:0.24031007"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -133,135 +228,40 @@
        x2="-51.786404"
        y1="50.786446"
        x1="-51.786404"
-       gradientTransform="matrix(0.37459597,0,0,0.37082941,29.392827,2.4405192)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3756"
-       xlink:href="#linearGradient3104-6-2" />
-    <linearGradient
-       y2="41.266655"
-       x2="23.99999"
-       y1="6.7333217"
-       x1="23.99999"
-       gradientTransform="matrix(0.66891892,0,0,0.4054054,-1.17905,3.270275)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3771"
-       xlink:href="#linearGradient3977-6" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,4.1399587,-5.0825466,0,60.969731,-32.403501)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3774"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <linearGradient
-       y2="41.266659"
-       x2="37.633045"
-       y1="6.7333241"
-       x1="37.633045"
-       gradientTransform="matrix(0.51351311,0,0,0.4054054,-0.3250622,3.270274)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3777"
-       xlink:href="#linearGradient3028" />
-    <linearGradient
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275"
-       gradientTransform="matrix(0.45714179,0,0,0.34765335,3.0285964,4.122978)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3780"
-       xlink:href="#linearGradient3600-4" />
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(0.01325345,0,0,0.0082353,13.362672,17.980564)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3783"
-       xlink:href="#linearGradient5060" />
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(-0.01325345,0,0,0.0082353,10.637327,17.980564)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3786"
-       xlink:href="#linearGradient5060" />
-    <linearGradient
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715"
-       gradientTransform="matrix(0.03872781,0,0,0.0082353,-1.9973372,17.980547)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3789"
-       xlink:href="#linearGradient5048" />
-    <linearGradient
-       y2="37.546188"
-       x2="25.132275"
-       y1="15.284525"
-       x1="25.132275"
-       gradientTransform="matrix(0.69202661,0,0,0.40431838,-2.1909906,-0.9776278)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3869"
-       xlink:href="#linearGradient3600-3-2-2-6-8" />
-    <linearGradient
-       id="linearGradient3104-6-2-7">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-4-9" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-9-2" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3104-6-2-7"
-       id="linearGradient3944"
-       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.37459597,0,0,0.37082941,29.392826,2.440519)"
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,4.578264,-5.6206455,0,92.777476,-38.572847)"
        gradientUnits="userSpaceOnUse"
+       id="linearGradient3944"
+       xlink:href="#linearGradient3104-6-2-7" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4270"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,4.578264,-5.6206455,0,92.777476,-38.572847)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.578264,-5.6206455,0,92.777476,-38.572847)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4272"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,4.578264,-5.6206455,0,92.777476,-38.572847)"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.578264,-5.6206455,0,92.777476,-38.572847)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient4274"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.578264,-5.6206455,0,92.777476,-38.561284)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
   </defs>
   <metadata
      id="metadata4109">
@@ -276,110 +276,110 @@
     </rdf:RDF>
   </metadata>
   <g
-     style="opacity:0.75"
-     id="g4731">
+     id="g4731"
+     style="opacity:0.75">
     <path
-       style="opacity:0.75000000000000000;color:#000000;fill:none;stroke:url(#linearGradient3944);stroke-width:0.99992174000000000;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 3.4999054,2.4999609 20.500094,2.5 l 0,11.000039 -17.000094,0 z"
        id="rect4964-4-1"
-       d="m 3.4999054,2.4999609 17.0001886,0.024344 0,10.9757341 -16.9039835,0 z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:none;stroke:url(#linearGradient3944);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient3869);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186000000005;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 4,2.9999221 20,3 20,14 4,14 Z"
        id="rect4964-4"
-       d="M 4,2.9999221 20,3.0242661 20,14 4.090545,14 z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3869);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate" />
   </g>
   <rect
-     width="18.699997"
-     height="2"
-     x="2.6500008"
-     y="21"
+     style="opacity:0.15;fill:url(#linearGradient3789);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="rect2879"
-     style="opacity:0.15;fill:url(#linearGradient3789);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     y="21"
+     x="2.6500008"
+     height="2"
+     width="18.699997" />
   <path
-     d="m 2.6499999,21.000085 c 0,0 0,1.999891 0,1.999891 C 1.9674803,23.003776 1,22.551901 1,21.999901 1,21.447902 1.76164,21.000085 2.6499999,21.000085 z"
+     style="opacity:0.15;fill:url(#radialGradient3786);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="path2881"
-     style="opacity:0.15;fill:url(#radialGradient3786);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     d="m 2.6499999,21.000085 c 0,0 0,1.999891 0,1.999891 C 1.9674803,23.003776 1,22.551901 1,21.999901 1,21.447902 1.76164,21.000085 2.6499999,21.000085 z" />
   <path
-     d="m 21.35,21.000085 c 0,0 0,1.999891 0,1.999891 0.682519,0.0038 1.65,-0.448075 1.65,-1.000075 0,-0.551999 -0.761642,-0.999816 -1.65,-0.999816 z"
+     style="opacity:0.15;fill:url(#radialGradient3783);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="path2883"
-     style="opacity:0.15;fill:url(#radialGradient3783);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     d="m 21.35,21.000085 c 0,0 0,1.999891 0,1.999891 0.682519,0.0038 1.65,-0.448075 1.65,-1.000075 0,-0.551999 -0.761642,-0.999816 -1.65,-0.999816 z" />
   <path
-     d="M 5,5 21.99998,5.001 22,21 4.9999999,21 l 0,-15.999984 z"
+     style="display:inline;fill:url(#linearGradient3780);fill-opacity:1;stroke:none"
      id="path4160-3"
-     style="fill:url(#linearGradient3780);fill-opacity:1;stroke:none;display:inline" />
+     d="M 5,5 21.99998,5 22,21 4.9999999,21 l 0,-15.999984 z" />
   <path
-     d="m 21.5,20.5 -18.9999999,0 0,-15 L 21.5,5.5 z"
+     style="fill:none;stroke:url(#linearGradient3777);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3777);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="m 21.5,20.5 -18.9999999,0 0,-15 L 21.5,5.5 z" />
   <path
-     d="M 2,4.5 C 1.723,4.5 1.5,4.723 1.5,5 l 0,16 c 0,0.277 0.223,0.5 0.5,0.5 l 3,0 0,-17 z"
+     style="color:#000000;fill:url(#radialGradient3774);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect5505"
-     style="color:#000000;fill:url(#radialGradient3774);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 2,4.5 C 1.723,4.5 1.5,4.723 1.5,5 l 0,16 c 0,0.277 0.223,0.5 0.5,0.5 l 3,0 0,-17 z" />
   <path
-     d="m 4.5,20.5 -2,0 0,-15 2,0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3771);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1-5"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3771);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="m 4.5,20.5 -2,0 0,-15 2,0" />
   <path
-     d="m 6,7.5 4,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4159"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 6,7.5 4,0" />
   <path
-     d="m 11,7.5 2,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4161"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 11,7.5 2,0" />
   <path
-     d="m 14,7.5 1,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4163"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 14,7.5 1,0" />
   <path
-     d="m 16,7.5 2,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4165"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 16,7.5 2,0" />
   <path
-     d="m 6,11.5 2,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4167"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 6,11.5 2,0" />
   <path
-     d="m 6,13.5 1,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4169"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 6,13.5 1,0" />
   <path
-     d="m 6,15.5 2,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4171"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 6,15.5 2,0" />
   <path
-     d="m 6,17.5 2,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4173"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 6,17.5 2,0" />
   <path
-     d="m 8,13.5 1,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4175"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 8,13.5 1,0" />
   <path
-     d="m 9,17.5 1,0"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path4177"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 9,17.5 1,0" />
   <path
-     d="m 5,21.5 17.46875,0 0,-17 L 5,4.5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3756);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect5505-21-8-6"
-     style="color:#000000;fill:none;stroke:url(#linearGradient3756);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 5,21.5 17.5,0 0,-17 -17.5,0" />
   <path
-     d="m 5,21.5 -3.5000391,0 0,-17 L 5,4.5"
+     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect5505-21-8-6-4"
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 5,21.5 -3.5000391,0 0,-17 L 5,4.5" />
   <path
-     d="M 20,15 A 4,4 0 1 1 17.884048,11.471493 L 16,15 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
      id="path3035-5-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+     d="M 20,15 A 4,4 0 1 1 17.884048,11.471493 L 16,15 Z" />
   <path
-     d="M 20,13.999999 A 3.9999999,3.9999999 0 1 1 17.884048,10.471493 L 16,13.999999 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4270);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3035-3"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4270);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="M 20,13.999999 A 3.9999999,3.9999999 0 1 1 17.884048,10.471493 L 16,13.999999 Z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4274);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 20,14.011562 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 -1.671279,0.462649 -3.60537,-0.310764 -4.497279,-1.798089 C 12.563006,16.074807 16,14.011562 16,14.011562 Z"
      id="path3964"
-     d="m 20,13.999999 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 -1.671279,0.462649 -3.60537,-0.310764 -4.497279,-1.798089 C 12.563006,16.063244 16,13.999999 16,13.999999 Z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4274);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4272);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 20,13.999999 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 C 17.028314,17.848174 16,13.999999 16,13.999999 Z"
      id="path3962"
-     d="m 20,13.999999 c 0,1.734276 -1.261358,3.392272 -2.932637,3.85492 C 17.028314,17.848174 16,13.999999 16,13.999999 Z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4272);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.90426379;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/32/x-office-presentation-rtl.svg
+++ b/mimes/32/x-office-presentation-rtl.svg
@@ -6,7 +6,6 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 32 32"
    version="1.1"
    width="32"
    height="32"
@@ -77,7 +76,7 @@
        id="linearGradient3012"
        xlink:href="#linearGradient3028"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972916,0,0,0.56756756,-1.5145621,3.3783836)" />
+       gradientTransform="matrix(0.72972916,0,0,0.56756756,-1.5145621,4.3783836)" />
     <linearGradient
        x1="25.132275"
        y1="0.98520643"
@@ -86,7 +85,7 @@
        id="linearGradient3015"
        xlink:href="#linearGradient3600-4"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.79999811,0,0,0.47802334,-3.1999562,4.794095)" />
+       gradientTransform="matrix(0.79999811,0,0,0.47802334,-3.1999562,5.794095)" />
     <radialGradient
        cx="605.71429"
        cy="486.64789"
@@ -96,7 +95,7 @@
        id="radialGradient3020"
        xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.01927775,0,0,0.0082353,17.982069,24.980564)" />
+       gradientTransform="matrix(0.01927775,0,0,0.0082353,17.982069,25.980564)" />
     <radialGradient
        cx="605.71429"
        cy="486.64789"
@@ -106,7 +105,7 @@
        id="radialGradient3023"
        xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.01927775,0,0,0.0082353,14.01793,24.980564)" />
+       gradientTransform="matrix(-0.01927775,0,0,0.0082353,14.01793,25.980564)" />
     <linearGradient
        x1="302.85715"
        y1="366.64789"
@@ -115,7 +114,7 @@
        id="linearGradient3026"
        xlink:href="#linearGradient5048"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.05633135,0,0,0.0082353,-4.3597632,24.980547)" />
+       gradientTransform="matrix(0.05633135,0,0,0.0082353,-4.3597632,25.980547)" />
     <linearGradient
        x1="9.6095304"
        y1="6.3948526"
@@ -124,7 +123,7 @@
        id="linearGradient3076"
        xlink:href="#linearGradient3977-6"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66891892,0,0,0.56756756,-1.17905,3.378385)" />
+       gradientTransform="matrix(0.66891892,0,0,0.56756756,-1.17905,4.378385)" />
     <linearGradient
        id="linearGradient3977-6">
       <stop
@@ -155,13 +154,6 @@
          style="stop-color:#c8c8c8;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <clipPath
-       id="clipPath3877">
-      <path
-         d="m 10.751345,-0.72641891 19.105374,0.0251951 V 9.7797336 L 10.751345,9.7545316 Z"
-         id="path3879"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate" />
-    </clipPath>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
@@ -236,7 +228,7 @@
        id="linearGradient3514"
        xlink:href="#linearGradient3104-5-66"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,47.354333,94.86293)" />
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,47.354333,95.86293)" />
     <linearGradient
        x1="25.132275"
        y1="15.284525"
@@ -272,7 +264,7 @@
        id="linearGradient3556"
        xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-2.9300489)" />
+       gradientTransform="matrix(1.6122259,0,0,1.0767345,-17.128673,-9.3123805)" />
     <linearGradient
        x1="-51.786404"
        y1="41.797989"
@@ -281,7 +273,7 @@
        id="linearGradient3558"
        xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-3.9956799)" />
+       gradientTransform="matrix(1.3018673,0,0,1.0076631,78.654041,-10.512379)" />
     <linearGradient
        x1="24"
        y1="14.203104"
@@ -290,7 +282,7 @@
        id="linearGradient3560"
        xlink:href="#linearGradient3211-8-8-0-0-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0351164,0,0,0.9866216,-0.70291674,-2.1699512)" />
+       gradientTransform="matrix(1.6688415,0,0,1.1110264,-17.457342,-8.4564408)" />
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
@@ -306,7 +298,7 @@
        xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient3976"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.74052449,0,0,0.46769471,46.924817,3.6822435)"
+       gradientTransform="matrix(0.74052449,0,0,0.46769471,46.924817,4.6822435)"
        x1="-51.786404"
        y1="50.786446"
        x2="-51.786404"
@@ -315,7 +307,7 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4"
        id="radialGradient3995-5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-49.833181)"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.833181)"
        cx="6.7304144"
        cy="9.9571075"
        fx="6.2001843"
@@ -346,9 +338,9 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.500482,-49.833181)"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.479826,-48.880056)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient5217"
+       id="radialGradient4223"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
     <radialGradient
        r="12.671875"
@@ -356,9 +348,9 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.500482,-49.833181)"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.479826,-48.866281)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient5219"
+       id="radialGradient4225"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
     <radialGradient
        r="12.671875"
@@ -366,9 +358,9 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.500482,-49.833181)"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.479826,-48.883625)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient5221"
+       id="radialGradient4227"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
   </defs>
   <metadata
@@ -387,101 +379,101 @@
      width="27.199997"
      height="2"
      x="2.4000013"
-     y="28"
+     y="29"
      id="rect2879"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3026);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 2.3999999,28.000085 c 0,0 0,1.999891 0,1.999891 C 1.4072441,30.003776 0,29.551901 0,28.999901 0,28.447902 1.10784,28.000085 2.3999999,28.000085 Z"
+     d="m 2.3999999,29.000085 c 0,0 0,1.999891 0,1.999891 C 1.4072441,31.003776 0,30.551901 0,29.999901 0,29.447902 1.10784,29.000085 2.3999999,29.000085 Z"
      id="path2881"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3023);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 29.6,28.000085 c 0,0 0,1.999891 0,1.999891 0.992755,0.0038 2.4,-0.448075 2.4,-1.000075 0,-0.551999 -1.107843,-0.999816 -2.4,-0.999816 z"
+     d="m 29.6,29.000085 c 0,0 0,1.999891 0,1.999891 0.992755,0.0038 2.4,-0.448075 2.4,-1.000075 0,-0.551999 -1.107843,-0.999816 -2.4,-0.999816 z"
      id="path2883"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3020);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <g
-     transform="matrix(1.6122259,0,0,1.1260917,-16.324081,-7.0128768)"
-     clip-path="url(#clipPath3877)"
-     id="g6242-7-5"
-     style="display:inline;opacity:0.5">
+     style="opacity:0.5"
+     id="g4245">
     <path
-       d="M 13.531084,7.5891404 H 26.567616 V 32.490428 H 13.531084 Z"
+       mask="none"
+       clip-path="none"
+       d="m 5.4910831,2.5331912 21.0178349,0 L 26.5,5.5 l -21,0 z"
        id="rect4964-4-4"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3558);stroke-width:0.74210644;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3558);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       d="M 14.310274,9.4115011 H 25.723213 V 31.605021 H 14.310274 Z"
+       d="m 6.5,3.5 19,0 0,1 -19,0 z"
        id="rect4964-1-6-5"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3560);stroke-width:0.74210638;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3560);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
   <g
-     transform="translate(0,1)"
+     transform="translate(0,2)"
      id="g3546">
     <path
-       d="M 3.499961,2.499961 28.500039,2.537582 V 19.500039 H 3.6414385 Z"
+       d="M 3.499961,2.499961 28.500039,2.5 l 0,17.000039 -25.000039,0 z"
        id="rect4964-4"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3550);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3552);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       d="M 4.4999609,3.4999609 27.500039,3.5164779 27.387055,18.500039 H 4.6865201 Z"
+       d="M 4.4999609,3.4999609 27.500039,3.5 27.5,18.500039 l -23,0 z"
        id="rect4964-1-6"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3554);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
   <path
-     d="M 2.0000002,6 C 8.4162208,6 29.999965,6.00143 29.999965,6.00143 L 30,28 C 30,28 11.333334,28 2,28 2,20.666674 2,13.33335 2,6.0000237 Z"
+     d="M 2.0000002,7 C 8.4162208,7 29.999965,7.00143 29.999965,7.00143 L 30,29 C 30,29 11.333334,29 2,29 2,21.666674 2,14.33335 2,7.0000237 Z"
      id="path4160-3"
      style="display:inline;fill:url(#linearGradient3015);fill-opacity:1;stroke:none" />
   <path
-     d="M 29.5,27.5 H 2.5000002 V 6.5 H 29.5 Z"
+     d="m 29.5,28.5 -26.9999998,0 0,-21 L 29.5,7.5 Z"
      id="rect6741-1"
      style="fill:none;stroke:url(#linearGradient3012);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 6,28.5 c -1.4379221,0 -2.8758452,0 -4.3137745,0 -0.3495006,-0.272334 -0.083736,-0.813022 -0.166777,-1.198561 0,-7.223095 0,-14.446189 0,-21.669283 L 1.5681915,5.538627 1.6862261,5.500001 v 0 c 1.4965868,0 4.3137739,0 4.3137739,0"
+     d="m 6,29.5 -4.5,0 c 0,-7.248272 0,-16.5 0,-23 1.186199,0 3.1440605,1e-6 4.5,1e-6"
      id="path4530"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
   <path
-     d="m 5.5,27.5 h -3 v -21 h 3"
+     d="m 5.5,28.5 -3,0 0,-21 3,0"
      id="rect6741-1-5"
      style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 25.15625,8.5 h -4"
-     id="path4159"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="m 20.15625,8.5 h -2"
-     id="path4161"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="m 17.15625,8.5 h -1"
-     id="path4163"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="m 15.15625,8.5 h -2"
-     id="path4165"
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     d="m 29,25 v -1 h -2.21875 v 1 z m -2.65625,0 V 24 H 20 v 1 z M 29,21 v -1 h -2.96875 v 1 z m -3.71875,0 V 20 H 22.9375 v 1 z m -2.9375,0 v -1 h -1.1875 v 1 z M 29,17 v -1 h -3.28125 v 1 z m -3.875,0 v -1 h -1.65625 v 1 z m -2.21875,0 v -1 h -1.75 v 1 z M 29,13 v -1 h -3.28125 v 1 z m -3.90625,0 V 12 H 22.75 v 1 z"
-     id="path3475-4"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3514);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
-     id="path3035-5"
-     d="m 19.020656,18.999999 a 6,6 0 1 1 -3.173929,-5.29276 l -2.826071,5.29276 z" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5221);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3035"
-     d="m 19.020656,18.050444 a 6,6 0 1 1 -3.173929,-5.292761 l -2.826071,5.292761 z" />
-  <path
-     d="m 19.020656,18.050444 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 -2.506919,0.693972 -5.4080552,-0.466147 -6.7459182,-2.697134 -0.0106,0.0096 5.1448742,-3.085246 5.1448742,-3.085246 z"
-     id="path3964"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5219);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
      style="display:inline;fill:none;stroke:url(#linearGradient3976);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 6,28.500039 H 30.50004 V 5.4999606 H 6"
+     d="m 6,29.500039 24.50004,0 0,-23.0000784 -24.50004,0"
      id="path4160-6-1" />
   <path
-     d="m 6,28.5 c -1.4379221,0 -2.8758452,0 -4.3137745,0 -0.3495006,-0.272334 -0.083736,-0.813022 -0.166777,-1.198561 0,-7.223095 0,-14.446189 0,-21.669283 L 1.5681915,5.538627 1.6862261,5.500001 v 0 c 1.4965868,0 4.3137739,0 4.3137739,0"
+     d="m 6,29.5 -4.5,0 c 0,-7.093297 0.019448,-15.349915 0.019448,-22.867844 l 0.048743,-0.093529 0.1180346,-0.038626 0,0 4.3137739,0"
      id="path4530-2"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 19.020656,18.050444 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 -0.05858,-0.01016 -1.601044,-5.78238 -1.601044,-5.78238 z"
+     d="m 25,9.5 -4,0"
+     id="path4159"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 20,9.5 -2,0"
+     id="path4161"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 17,9.5 -1,0"
+     id="path4163"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 15,9.5 -2,0"
+     id="path4165"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 29,26 0,-1 -2,0 0,1 z m -3,0 0,-1 -6,0 0,1 z m 3,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -1,0 0,1 z m 7,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -2,0 0,1 z m 6,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -3,0 0,1 z"
+     id="path3475-4"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3514);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
+     id="path3035-5"
+     d="m 19,19.999999 a 6,6 0 1 1 -3.173929,-5.29276 L 13,19.999999 Z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4227);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3035"
+     d="M 19,19 A 6,6 0 1 1 15.826071,13.707239 L 13,19 Z" />
+  <path
+     d="m 19,19.017344 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 12.094125,25.493696 9.192988,24.333577 7.855125,22.10259 7.844525,22.11219 13,19.017344 13,19.017344 Z"
+     id="path3964"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4225);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     d="m 19,19.003569 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 14.542464,24.775789 13,19.003569 13,19.003569 Z"
      id="path3962"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5217);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4223);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/32/x-office-presentation-template-rtl.svg
+++ b/mimes/32/x-office-presentation-template-rtl.svg
@@ -6,342 +6,364 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 32 32"
-   id="svg3828"
-   height="32"
+   version="1.1"
    width="32"
-   version="1.1">
+   height="32"
+   id="svg3828">
   <defs
      id="defs3830">
     <linearGradient
        id="linearGradient3028">
       <stop
-         offset="0"
+         id="stop3030"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3030" />
+         offset="0" />
       <stop
-         offset="0.01124695"
+         id="stop3032"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3032" />
+         offset="0.01124695" />
       <stop
-         offset="0.97092199"
+         id="stop3034"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3034" />
+         offset="0.97092199" />
       <stop
-         offset="1"
+         id="stop3036"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3036" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-4">
       <stop
-         offset="0"
+         id="stop3602-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-6"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
-         offset="0"
+         id="stop5062"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop5064"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5048">
       <stop
-         offset="0"
+         id="stop5050"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop5056"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop5052"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.72972916,0,0,0.56756756,-1.5145621,3.3783836)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3028"
-       id="linearGradient3012"
-       y2="41.44783"
-       x2="23.99999"
+       x1="23.99999"
        y1="6.7927485"
-       x1="23.99999" />
-    <linearGradient
-       gradientTransform="matrix(0.79999811,0,0,0.47802334,-3.1999562,4.794095)"
+       x2="23.99999"
+       y2="41.44783"
+       id="linearGradient3012"
+       xlink:href="#linearGradient3028"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3015"
-       y2="47.013336"
-       x2="25.132275"
+       gradientTransform="matrix(0.72972916,0,0,0.56756756,-1.5145621,4.3783836)" />
+    <linearGradient
+       x1="25.132275"
        y1="0.98520643"
-       x1="25.132275" />
-    <radialGradient
-       gradientTransform="matrix(0.01927775,0,0,0.0082353,17.982069,24.980564)"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3015"
+       xlink:href="#linearGradient3600-4"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
+       gradientTransform="matrix(0.79999811,0,0,0.47802334,-3.1999562,5.794095)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
        id="radialGradient3020"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <radialGradient
-       gradientTransform="matrix(-0.01927775,0,0,0.0082353,14.01793,24.980564)"
-       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5060"
-       id="radialGradient3023"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01927775,0,0,0.0082353,17.982069,25.980564)" />
+    <radialGradient
+       cx="605.71429"
        cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       gradientTransform="matrix(0.05633135,0,0,0.0082353,-4.3597632,24.980547)"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3023"
+       xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5048"
-       id="linearGradient3026"
-       y2="609.50507"
-       x2="302.85715"
+       gradientTransform="matrix(-0.01927775,0,0,0.0082353,14.01793,25.980564)" />
+    <linearGradient
+       x1="302.85715"
        y1="366.64789"
-       x1="302.85715" />
-    <linearGradient
-       gradientTransform="matrix(0.66891892,0,0,0.56756756,-1.17905,3.378385)"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3026"
+       xlink:href="#linearGradient5048"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977-6"
-       id="linearGradient3076"
-       y2="41.481415"
-       x2="9.6095304"
+       gradientTransform="matrix(0.05633135,0,0,0.0082353,-4.3597632,25.980547)" />
+    <linearGradient
+       x1="9.6095304"
        y1="6.3948526"
-       x1="9.6095304" />
+       x2="9.6095304"
+       y2="41.481415"
+       id="linearGradient3076"
+       xlink:href="#linearGradient3977-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66891892,0,0,0.56756756,-1.17905,4.378385)" />
     <linearGradient
        id="linearGradient3977-6">
       <stop
-         offset="0"
+         id="stop3979-9"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979-9" />
+         offset="0" />
       <stop
-         offset="0.0066674"
+         id="stop3981-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981-3" />
+         offset="0.0066674" />
       <stop
-         offset="0.99594194"
+         id="stop3983-7"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983-7" />
+         offset="0.99594194" />
       <stop
-         offset="1"
+         id="stop3985-4"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-5-66">
       <stop
-         offset="0"
+         id="stop3106-9"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-9-8" />
+         offset="1" />
     </linearGradient>
-    <clipPath
-       id="clipPath3877">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
-         id="path3879"
-         d="m 10.751345,-0.72641891 19.105374,0.0251951 V 9.7797336 L 10.751345,9.7545316 Z" />
-    </clipPath>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-3"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-3" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-9"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-2"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-4"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-8-1-1"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-8-1-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-0-6-4"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-0-6-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-1-7-1"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-1-7-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-2-4-5"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-2-4-5" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-6-5-6"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-6-5-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-4-2-1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-4-2-1" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,47.258455,94.86293)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5-66"
-       id="linearGradient3514"
-       y2="25.646791"
-       x2="22.004084"
+       x1="22.004084"
        y1="63.217903"
-       x1="22.004084" />
-    <linearGradient
-       gradientTransform="matrix(1.081295,0,0,0.62485417,-6.1734925,-3.6471464)"
+       x2="22.004084"
+       y2="25.646791"
+       id="linearGradient3514"
+       xlink:href="#linearGradient3104-5-66"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-3-2-2-6-8"
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,47.354333,95.86293)" />
+    <linearGradient
+       x1="25.132275"
+       y1="15.284525"
+       x2="25.132275"
+       y2="37.546188"
        id="linearGradient3550"
-       y2="37.546188"
-       x2="25.132275"
-       y1="15.284525"
-       x1="25.132275" />
-    <linearGradient
-       gradientTransform="matrix(0.87314224,0,0,0.58477041,58.066492,-4.3435334)"
+       xlink:href="#linearGradient3600-3-2-2-6-8"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-9-7-3-9-6"
+       gradientTransform="matrix(1.081295,0,0,0.62485417,-6.1734925,-3.6471464)" />
+    <linearGradient
+       x1="-51.786404"
+       y1="41.797989"
+       x2="-51.786404"
+       y2="17.555471"
        id="linearGradient3552"
-       y2="17.555471"
-       x2="-51.786404"
-       y1="41.797989"
-       x1="-51.786404" />
-    <linearGradient
-       gradientTransform="matrix(1.0820661,0,0,0.61449222,-5.6480107,-2.535845)"
+       xlink:href="#linearGradient3104-9-7-3-9-6"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3211-8-8-9"
+       gradientTransform="matrix(0.87314224,0,0,0.58477041,58.066492,-4.3435334)" />
+    <linearGradient
+       x1="24"
+       y1="14.203104"
+       x2="24"
+       y2="35.721317"
        id="linearGradient3554"
-       y2="35.721317"
-       x2="24"
-       y1="14.203104"
-       x1="24" />
-    <linearGradient
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-2.9300489)"
+       xlink:href="#linearGradient3211-8-8-9"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
-       id="linearGradient3556"
-       y2="37.546188"
-       x2="25.132275"
+       gradientTransform="matrix(1.0820661,0,0,0.61449222,-5.6480107,-2.535845)" />
+    <linearGradient
+       x1="25.132275"
        y1="15.284525"
-       x1="25.132275" />
-    <linearGradient
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-3.9956799)"
+       x2="25.132275"
+       y2="37.546188"
+       id="linearGradient3556"
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
-       id="linearGradient3558"
-       y2="17.555471"
-       x2="-51.786404"
+       gradientTransform="matrix(1.6122259,0,0,1.0767345,-17.128673,-9.3123805)" />
+    <linearGradient
+       x1="-51.786404"
        y1="41.797989"
-       x1="-51.786404" />
-    <linearGradient
-       gradientTransform="matrix(1.0351164,0,0,0.9866216,-0.70291674,-2.1699512)"
+       x2="-51.786404"
+       y2="17.555471"
+       id="linearGradient3558"
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3211-8-8-0-0-9"
-       id="linearGradient3560"
-       y2="35.721317"
-       x2="24"
+       gradientTransform="matrix(1.3018673,0,0,1.0076631,78.654041,-10.512379)" />
+    <linearGradient
+       x1="24"
        y1="14.203104"
-       x1="24" />
+       x2="24"
+       y2="35.721317"
+       id="linearGradient3560"
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6688415,0,0,1.1110264,-17.457342,-8.4564408)" />
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         offset="0"
+         id="stop3106-3-2"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8-3"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-8-3" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.74052449,0,0,0.46769471,46.924817,3.6822435)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient3976"
-       xlink:href="#linearGradient3104-6-6-1" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74052449,0,0,0.46769471,46.924817,4.6822435)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4"
+       id="radialGradient3995-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.833181)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9-9-0-3"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7-4-0-32-8-923-0-7-8-7"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8-5-2-7-6-7-1-8-0-6"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6-2-6-6-1-96-6-1-1-0"
+         style="stop-color:#ac441f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <radialGradient
        r="12.671875"
        fy="9.9571075"
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-49.833181)"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.479826,-48.880056)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3995-5"
+       id="radialGradient4223"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.479826,-48.866281)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4225"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.479826,-48.883625)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4227"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4">
-      <stop
-         offset="0"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-9-0-3" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7-8-7" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-8-0-6" />
-      <stop
-         offset="1"
-         style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-1-1-0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1,0,0,-1,-16.999999,48.999999)"
+       gradientTransform="matrix(1,0,0,-1,-13.999999,48.999999)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3412"
        id="linearGradient3273"
@@ -361,7 +383,7 @@
          id="stop3416" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.99749995,0,0,-0.99749995,-16.923748,48.896056)"
+       gradientTransform="matrix(0.99749995,0,0,-0.99749995,-13.923748,48.896056)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3211-8-8-9"
        id="linearGradient3148"
@@ -369,36 +391,6 @@
        x2="33.811069"
        y1="31.65719"
        x1="40.105618" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.540196,-49.833181)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4567"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.540196,-49.833181)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4569"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,78.540196,-49.833181)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4571"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
   </defs>
   <metadata
      id="metadata3833">
@@ -413,116 +405,112 @@
     </rdf:RDF>
   </metadata>
   <rect
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3026);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-     id="rect2879"
-     y="28"
-     x="2.4000013"
+     width="27.199997"
      height="2"
-     width="27.199997" />
+     x="2.4000013"
+     y="29"
+     id="rect2879"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3026);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3023);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     d="m 2.3999999,29.000085 c 0,0 0,1.999891 0,1.999891 C 1.4072441,31.003776 0,30.551901 0,29.999901 0,29.447902 1.10784,29.000085 2.3999999,29.000085 Z"
      id="path2881"
-     d="m 2.3999999,28.000085 c 0,0 0,1.999891 0,1.999891 C 1.4072441,30.003776 0,29.551901 0,28.999901 0,28.447902 1.10784,28.000085 2.3999999,28.000085 Z" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3023);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3020);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     d="m 29.6,29.000085 c 0,0 0,1.999891 0,1.999891 0.992755,0.0038 2.4,-0.448075 2.4,-1.000075 0,-0.551999 -1.107843,-0.999816 -2.4,-0.999816 z"
      id="path2883"
-     d="m 29.6,28.000085 c 0,0 0,1.999891 0,1.999891 0.992755,0.0038 2.4,-0.448075 2.4,-1.000075 0,-0.551999 -1.107843,-0.999816 -2.4,-0.999816 z" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3020);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <g
-     style="display:inline;opacity:0.5"
-     id="g6242-7-5"
-     clip-path="url(#clipPath3877)"
-     transform="matrix(1.6122259,0,0,1.1260917,-16.324081,-7.0128768)">
+     style="opacity:0.5"
+     id="g4245">
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3558);stroke-width:0.74210644;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       mask="none"
+       clip-path="none"
+       d="m 5.4910831,2.5331912 21.0178349,0 L 26.5,5.5 l -21,0 z"
        id="rect4964-4-4"
-       d="M 13.531084,7.5891404 H 26.567616 V 32.490428 H 13.531084 Z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3558);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3560);stroke-width:0.74210638;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 6.5,3.5 19,0 0,1 -19,0 z"
        id="rect4964-1-6-5"
-       d="M 14.310274,9.4115011 H 25.723213 V 31.605021 H 14.310274 Z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3560);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
   <g
-     id="g3546"
-     transform="translate(0,1)">
+     transform="translate(0,2)"
+     id="g3546">
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3550);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3552);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 3.499961,2.499961 28.500039,2.5 l 0,17.000039 -25.000039,0 z"
        id="rect4964-4"
-       d="M 3.499961,2.499961 28.500039,2.537582 V 19.500039 H 3.6414385 Z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3550);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3552);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3554);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 4.4999609,3.4999609 27.500039,3.5 27.5,18.500039 l -23,0 z"
        id="rect4964-1-6"
-       d="M 4.4999609,3.4999609 27.500039,3.5164779 27.387055,18.500039 H 4.6865201 Z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3554);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
   <path
-     style="display:inline;fill:url(#linearGradient3015);fill-opacity:1;stroke:none"
+     d="M 2.0000002,7 C 8.4162208,7 29.999965,7.00143 29.999965,7.00143 L 30,29 C 30,29 11.333334,29 2,29 2,21.666674 2,14.33335 2,7.0000237 Z"
      id="path4160-3"
-     d="M 2.0000002,6 C 8.4162208,6 29.999965,6.00143 29.999965,6.00143 L 30,28 C 30,28 11.333334,28 2,28 2,20.666674 2,13.33335 2,6.0000237 Z" />
+     style="display:inline;fill:url(#linearGradient3015);fill-opacity:1;stroke:none" />
   <path
-     style="fill:none;stroke:url(#linearGradient3012);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 29.5,28.5 -26.9999998,0 0,-21 L 29.5,7.5 Z"
      id="rect6741-1"
-     d="M 29.5,27.5 H 2.5000002 V 6.5 H 29.5 Z" />
+     style="fill:none;stroke:url(#linearGradient3012);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="m 6,29.5 -4.5,0 c 0,-7.248272 0,-16.5 0,-23 1.186199,0 3.1440605,1e-6 4.5,1e-6"
      id="path4530"
-     d="m 6,28.5 c -1.4379221,0 -2.8758452,0 -4.3137745,0 -0.3495006,-0.272334 -0.083736,-0.813022 -0.166777,-1.198561 0,-7.223095 0,-14.446189 0,-21.669283 L 1.5681915,5.538627 1.6862261,5.500001 v 0 c 1.4965868,0 4.3137739,0 4.3137739,0" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 5.5,28.5 -3,0 0,-21 3,0"
      id="rect6741-1-5"
-     d="m 5.5,27.5 h -3 v -21 h 3" />
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4159"
-     d="m 25.060372,8.5 h -4" />
+     style="display:inline;fill:none;stroke:url(#linearGradient3976);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 6,29.500039 24.50004,0 0,-23.0000784 -24.50004,0"
+     id="path4160-6-1" />
   <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4161"
-     d="m 20.060372,8.5 h -2" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4163"
-     d="m 17.060372,8.5 h -1" />
-  <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path4165"
-     d="m 15.060372,8.5 h -2" />
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3514);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
-     id="path3475-4"
-     d="m 28.904122,25 v -1 h -2.21875 v 1 z m -2.65625,0 v -1 h -6.34375 v 1 z m 2.65625,-4 v -1 h -2.96875 v 1 z m -3.71875,0 v -1 h -2.34375 v 1 z m -2.9375,0 v -1 h -1.1875 v 1 z m 6.65625,-4 v -1 h -3.28125 v 1 z m -3.875,0 v -1 h -1.65625 v 1 z m -2.21875,0 v -1 h -1.75 v 1 z m 6.09375,-4 v -1 h -3.28125 v 1 z m -3.90625,0 v -1 h -2.34375 v 1 z" />
-  <path
-     d="m 19.060371,18.999999 a 6,6 0 1 1 -3.17393,-5.29276 l -2.826071,5.29276 z"
-     id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
-  <path
-     d="m 19.060371,18.050444 a 6,6 0 1 1 -3.17393,-5.292761 l -2.826071,5.292761 z"
-     id="path3035"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4571);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4569);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3964"
-     d="m 19.060371,18.050444 c 0,2.601413 -1.892038,5.088408 -4.398957,5.78238 -2.506919,0.693972 -5.4080556,-0.466147 -6.7459186,-2.697134 -0.0106,0.0096 5.1448746,-3.085246 5.1448746,-3.085246 z" />
-  <path
-     id="path4160-6-1"
-     d="M 6,28.500039 H 30.50004 V 5.4999606 H 6"
-     style="display:inline;fill:none;stroke:url(#linearGradient3976);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 6,29.5 -4.5,0 c 0,-7.093297 0.019448,-15.349915 0.019448,-22.867844 l 0.048743,-0.093529 0.1180346,-0.038626 0,0 4.3137739,0"
      id="path4530-2"
-     d="m 6,28.5 c -1.4379221,0 -2.8758452,0 -4.3137745,0 -0.3495006,-0.272334 -0.083736,-0.813022 -0.166777,-1.198561 0,-7.223095 0,-14.446189 0,-21.669283 L 1.5681915,5.538627 1.6862261,5.500001 v 0 c 1.4965868,0 4.3137739,0 4.3137739,0" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4567);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 25,9.5 -4,0"
+     id="path4159"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 20,9.5 -2,0"
+     id="path4161"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 17,9.5 -1,0"
+     id="path4163"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 15,9.5 -2,0"
+     id="path4165"
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="m 29,26 0,-1 -2,0 0,1 z m -3,0 0,-1 -6,0 0,1 z m 3,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -1,0 0,1 z m 7,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -2,0 0,1 z m 6,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -3,0 0,1 z"
+     id="path3475-4"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3514);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
+     id="path3035-5"
+     d="m 19,19.999999 a 6,6 0 1 1 -3.173929,-5.29276 L 13,19.999999 Z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4227);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3035"
+     d="M 19,19 A 6,6 0 1 1 15.826071,13.707239 L 13,19 Z" />
+  <path
+     d="m 19,19.017344 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 12.094125,25.493696 9.192988,24.333577 7.855125,22.10259 7.844525,22.11219 13,19.017344 13,19.017344 Z"
+     id="path3964"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4225);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     d="m 19,19.003569 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 14.542464,24.775789 13,19.003569 13,19.003569 Z"
      id="path3962"
-     d="m 19.060371,18.050444 c 0,2.601413 -1.892038,5.088408 -4.398957,5.78238 -0.05858,-0.01016 -1.601044,-5.78238 -1.601044,-5.78238 z" />
-  <g
-     id="g3297"
-     transform="translate(2.9999998)">
-    <path
-       style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410"
-       d="m 13.5,30.5 15,-15 v 15 z m 6.999999,-3.000001 h 5 V 22.5 Z" />
-    <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3148);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 15.713203,29.538323 27.558515,17.693011 v 11.845312 z" />
-  </g>
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4223);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     d="m 16.5,30.5 15,-15 0,15 -15,0 z m 6.999999,-3.000001 5,0 0,-4.999999 -5,4.999999 z"
+     id="path3410"
+     style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 18.713203,29.538323 11.845312,-11.845312 0,11.845312 -11.845312,0 z"
+     id="path3424"
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3148);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/mimes/32/x-office-presentation-template.svg
+++ b/mimes/32/x-office-presentation-template.svg
@@ -76,7 +76,7 @@
        id="linearGradient3012"
        xlink:href="#linearGradient3028"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972916,0,0,0.56756756,-1.5145621,3.3783836)" />
+       gradientTransform="matrix(0.72972916,0,0,0.56756756,-1.5145621,4.3783836)" />
     <linearGradient
        x1="25.132275"
        y1="0.98520643"
@@ -85,7 +85,7 @@
        id="linearGradient3015"
        xlink:href="#linearGradient3600-4"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.79999811,0,0,0.47802334,-3.1999562,4.794095)" />
+       gradientTransform="matrix(0.79999811,0,0,0.47802334,-3.1999562,5.794095)" />
     <radialGradient
        cx="605.71429"
        cy="486.64789"
@@ -95,7 +95,7 @@
        id="radialGradient3020"
        xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.01927775,0,0,0.0082353,17.982069,24.980564)" />
+       gradientTransform="matrix(0.01927775,0,0,0.0082353,17.982069,25.980564)" />
     <radialGradient
        cx="605.71429"
        cy="486.64789"
@@ -105,7 +105,7 @@
        id="radialGradient3023"
        xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.01927775,0,0,0.0082353,14.01793,24.980564)" />
+       gradientTransform="matrix(-0.01927775,0,0,0.0082353,14.01793,25.980564)" />
     <linearGradient
        x1="302.85715"
        y1="366.64789"
@@ -114,7 +114,7 @@
        id="linearGradient3026"
        xlink:href="#linearGradient5048"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.05633135,0,0,0.0082353,-4.3597632,24.980547)" />
+       gradientTransform="matrix(0.05633135,0,0,0.0082353,-4.3597632,25.980547)" />
     <linearGradient
        x1="9.6095304"
        y1="6.3948526"
@@ -123,7 +123,7 @@
        id="linearGradient3076"
        xlink:href="#linearGradient3977-6"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66891892,0,0,0.56756756,-1.17905,3.378385)" />
+       gradientTransform="matrix(0.66891892,0,0,0.56756756,-1.17905,4.378385)" />
     <linearGradient
        id="linearGradient3977-6">
       <stop
@@ -154,13 +154,6 @@
          style="stop-color:#c8c8c8;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <clipPath
-       id="clipPath3877">
-      <path
-         d="m 10.751345,-0.72641891 19.105374,0.0251951 0,10.48095741 -19.105374,-0.025202 z"
-         id="path3879"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    </clipPath>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
@@ -235,7 +228,7 @@
        id="linearGradient3514"
        xlink:href="#linearGradient3104-5-66"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-11.198083,94.86293)" />
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-11.354333,95.86293)" />
     <linearGradient
        x1="25.132275"
        y1="15.284525"
@@ -271,7 +264,7 @@
        id="linearGradient3556"
        xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-2.9300489)" />
+       gradientTransform="matrix(1.6122259,0,0,1.0767345,-17.128673,-9.3123805)" />
     <linearGradient
        x1="-51.786404"
        y1="41.797989"
@@ -280,7 +273,7 @@
        id="linearGradient3558"
        xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-3.9956799)" />
+       gradientTransform="matrix(1.3018673,0,0,1.0076631,78.654041,-10.512379)" />
     <linearGradient
        x1="24"
        y1="14.203104"
@@ -289,7 +282,7 @@
        id="linearGradient3560"
        xlink:href="#linearGradient3211-8-8-0-0-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0351164,0,0,0.9866216,-0.70291674,-2.1699512)" />
+       gradientTransform="matrix(1.6688415,0,0,1.1110264,-17.457342,-8.4564408)" />
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
@@ -305,7 +298,7 @@
        xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient3976"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.74052449,0,0,0.46769471,46.924817,3.6822435)"
+       gradientTransform="matrix(0.74052449,0,0,0.46769471,46.924817,4.6822435)"
        x1="-51.786404"
        y1="50.786446"
        x2="-51.786404"
@@ -314,7 +307,7 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4"
        id="radialGradient3995-5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-49.833181)"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.833181)"
        cx="6.7304144"
        cy="9.9571075"
        fx="6.2001843"
@@ -339,35 +332,65 @@
          style="stop-color:#ac441f;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="42.783993"
-       y1="32.537422"
-       x2="38.972309"
-       y2="18.12406"
-       id="linearGradient3273"
-       xlink:href="#linearGradient3412"
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.880056)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,-1,-16.999999,48.999999)" />
+       id="radialGradient4223"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.866281)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4225"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.883625)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4227"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,-1,-13.999999,48.999999)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273"
+       y2="18.12406"
+       x2="38.972309"
+       y1="32.537422"
+       x1="42.783993" />
     <linearGradient
        id="linearGradient3412">
       <stop
-         id="stop3414"
+         offset="0"
          style="stop-color:#fcfcfc;stop-opacity:1"
-         offset="0" />
+         id="stop3414" />
       <stop
-         id="stop3416"
+         offset="1"
          style="stop-color:#cbcdd9;stop-opacity:1"
-         offset="1" />
+         id="stop3416" />
     </linearGradient>
     <linearGradient
-       x1="40.105618"
-       y1="31.65719"
-       x2="33.811069"
-       y2="18.353575"
-       id="linearGradient3148"
-       xlink:href="#linearGradient3211-8-8-9"
+       gradientTransform="matrix(0.99749995,0,0,-0.99749995,-13.923748,48.896056)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99749995,0,0,-0.99749995,-16.923748,48.896056)" />
+       xlink:href="#linearGradient3211-8-8-9"
+       id="linearGradient3148"
+       y2="18.353575"
+       x2="33.811069"
+       y1="31.65719"
+       x1="40.105618" />
   </defs>
   <metadata
      id="metadata3833">
@@ -385,113 +408,109 @@
      width="27.199997"
      height="2"
      x="2.4000013"
-     y="28"
+     y="29"
      id="rect2879"
-     style="opacity:0.15;fill:url(#linearGradient3026);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3026);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 2.3999999,28.000085 c 0,0 0,1.999891 0,1.999891 C 1.4072441,30.003776 0,29.551901 0,28.999901 0,28.447902 1.10784,28.000085 2.3999999,28.000085 z"
+     d="m 2.3999999,29.000085 c 0,0 0,1.999891 0,1.999891 C 1.4072441,31.003776 0,30.551901 0,29.999901 0,29.447902 1.10784,29.000085 2.3999999,29.000085 Z"
      id="path2881"
-     style="opacity:0.15;fill:url(#radialGradient3023);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3023);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 29.6,28.000085 c 0,0 0,1.999891 0,1.999891 0.992755,0.0038 2.4,-0.448075 2.4,-1.000075 0,-0.551999 -1.107843,-0.999816 -2.4,-0.999816 z"
+     d="m 29.6,29.000085 c 0,0 0,1.999891 0,1.999891 0.992755,0.0038 2.4,-0.448075 2.4,-1.000075 0,-0.551999 -1.107843,-0.999816 -2.4,-0.999816 z"
      id="path2883"
-     style="opacity:0.15;fill:url(#radialGradient3020);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3020);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <g
-     transform="matrix(1.6122259,0,0,1.1260917,-16.324081,-7.0128768)"
-     clip-path="url(#clipPath3877)"
-     id="g6242-7-5"
-     style="opacity:0.5;display:inline">
+     style="opacity:0.5"
+     id="g4245">
     <path
-       d="m 13.531084,7.5891404 13.036532,0 0,24.9012876 -13.036532,0 z"
+       mask="none"
+       clip-path="none"
+       d="m 5.4910831,2.5331912 21.0178349,0 L 26.5,5.5 l -21,0 z"
        id="rect4964-4-4"
-       style="color:#000000;fill:url(#linearGradient3556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3558);stroke-width:0.74210644;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3558);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       d="m 14.310274,9.4115011 11.412939,0 0,22.1935199 -11.412939,0 z"
+       d="m 6.5,3.5 19,0 0,1 -19,0 z"
        id="rect4964-1-6-5"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3560);stroke-width:0.74210638;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3560);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
   <g
-     transform="translate(0,1)"
+     transform="translate(0,2)"
      id="g3546">
     <path
-       d="m 3.499961,2.499961 25.000078,0.037621 0,16.962457 -24.8586005,0 z"
+       d="M 3.499961,2.499961 28.500039,2.5 l 0,17.000039 -25.000039,0 z"
        id="rect4964-4"
-       style="opacity:0.75;color:#000000;fill:url(#linearGradient3550);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3552);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3550);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3552);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       d="m 4.4999609,3.4999609 23.0000781,0.016517 -0.112984,14.9835611 -22.7005349,0 z"
+       d="M 4.4999609,3.4999609 27.500039,3.5 27.5,18.500039 l -23,0 z"
        id="rect4964-1-6"
-       style="opacity:0.45;color:#000000;fill:none;stroke:url(#linearGradient3554);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3554);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
   <path
-     d="m 2.0000002,6 c 6.4162206,0 27.9999648,0.00143 27.9999648,0.00143 L 30,28 C 30,28 11.333334,28 2,28 2,20.666674 2,13.33335 2,6.0000237 z"
+     d="M 2.0000002,7 C 8.4162208,7 29.999965,7.00143 29.999965,7.00143 L 30,29 C 30,29 11.333334,29 2,29 2,21.666674 2,14.33335 2,7.0000237 Z"
      id="path4160-3"
-     style="fill:url(#linearGradient3015);fill-opacity:1;stroke:none;display:inline" />
+     style="display:inline;fill:url(#linearGradient3015);fill-opacity:1;stroke:none" />
   <path
-     d="m 29.5,27.5 -26.9999998,0 0,-21 L 29.5,6.5 z"
+     d="m 29.5,28.5 -26.9999998,0 0,-21 L 29.5,7.5 Z"
      id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3012);stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     style="fill:none;stroke:url(#linearGradient3012);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 6,28.5 c -1.4379221,0 -2.8758452,0 -4.3137745,0 -0.3495006,-0.272334 -0.083736,-0.813022 -0.166777,-1.198561 0,-7.223095 0,-14.446189 0,-21.669283 l 0.048743,-0.093529 0.1180346,-0.038626 0,0 c 1.4965868,0 4.3137739,0 4.3137739,0"
+     d="m 6,29.5 -4.5,0 c 0,-7.248272 0,-16.5 0,-23 1.186199,0 3.1440605,1e-6 4.5,1e-6"
      id="path4530"
-     style="color:#000000;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
   <path
-     d="m 5.5,27.5 -3,0 0,-21 3,0"
+     d="m 5.5,28.5 -3,0 0,-21 3,0"
      id="rect6741-1-5"
-     style="opacity:0.50000000000000000;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 11,8.5 4,0"
+     d="m 11,9.5 4,0"
      id="path4159"
      style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     d="m 16,8.5 2,0"
+     d="m 16,9.5 2,0"
      id="path4161"
      style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     d="m 19,8.5 1,0"
+     d="m 19,9.5 1,0"
      id="path4163"
      style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     d="m 21,8.5 2,0"
+     d="m 21,9.5 2,0"
      id="path4165"
      style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     d="m 7.15625,25 0,-1 2.21875,0 0,1 z m 2.65625,0 0,-1 6.34375,0 0,1 z m -2.65625,-4 0,-1 2.96875,0 0,1 z m 3.71875,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 1.1875,0 0,1 z m -6.65625,-4 0,-1 3.28125,0 0,1 z m 3.875,0 0,-1 1.65625,0 0,1 z m 2.21875,0 0,-1 1.75,0 0,1 z m -6.09375,-4 0,-1 3.28125,0 0,1 z m 3.90625,0 0,-1 2.34375,0 0,1 z"
+     d="m 7,26 0,-1 2,0 0,1 z m 3,0 0,-1 6,0 0,1 z m -3,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 1,0 0,1 z m -7,-4 0,-1 3,0 0,1 z m 4,0 0,-1 1,0 0,1 z m 2,0 0,-1 2,0 0,1 z m -6,-4 0,-1 3,0 0,1 z m 4,0 0,-1 3,0 0,1 z"
      id="path3475-4"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient3514);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3514);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
      id="path3035-5"
-     d="m 29,18.999999 a 6,6 0 1 1 -3.173929,-5.29276 L 23,18.999999 z" />
+     d="m 29,19.999999 a 6,6 0 1 1 -3.173929,-5.29276 L 23,19.999999 Z" />
   <path
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4227);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3035"
-     d="M 29,18.050444 A 6,6 0 1 1 25.826071,12.757683 L 23,18.050444 z" />
+     d="M 29,19 A 6,6 0 1 1 25.826071,13.707239 L 23,19 Z" />
   <path
-     d="m 29,18.050444 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 22.094125,24.526796 19.192988,23.366677 17.855125,21.13569 17.844525,21.14529 23,18.050444 23,18.050444 z"
+     d="m 29,19.017344 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 22.094125,25.493696 19.192988,24.333577 17.855125,22.10259 17.844525,22.11219 23,19.017344 23,19.017344 Z"
      id="path3964"
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4225);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
-     style="fill:none;stroke:url(#linearGradient3976);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-     d="m 6,28.500039 24.50004,0 0,-23.0000784 -24.50004,0"
+     style="display:inline;fill:none;stroke:url(#linearGradient3976);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 6,29.500039 24.50004,0 0,-23.0000784 -24.50004,0"
      id="path4160-6-1" />
   <path
-     d="m 6,28.5 c -1.4379221,0 -2.8758452,0 -4.3137745,0 -0.3495006,-0.272334 -0.083736,-0.813022 -0.166777,-1.198561 0,-7.223095 0,-14.446189 0,-21.669283 l 0.048743,-0.093529 0.1180346,-0.038626 0,0 c 1.4965868,0 4.3137739,0 4.3137739,0"
+     d="m 6,29.5 -4.5,0 c 0,-7.093297 0.019448,-15.349915 0.019448,-22.867844 l 0.048743,-0.093529 0.1180346,-0.038626 0,0 4.3137739,0"
      id="path4530-2"
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 29,18.050444 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 24.542464,23.822664 23,18.050444 23,18.050444 z"
+     d="m 29,19.003569 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 24.542464,24.775789 23,19.003569 23,19.003569 Z"
      id="path3962"
-     style="opacity:0.8;color:#000000;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
-  <g
-     transform="translate(2.9999998,-2.1881345e-7)"
-     id="g3297">
-    <path
-       d="m 13.5,30.5 15,-15 0,15 -15,0 z m 6.999999,-3.000001 5,0 0,-4.999999 -5,4.999999 z"
-       id="path3410"
-       style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       d="m 15.713203,29.538323 11.845312,-11.845312 0,11.845312 -11.845312,0 z"
-       id="path3424"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3148);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  </g>
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4223);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     d="m 16.5,30.5 15,-15 0,15 -15,0 z m 6.999999,-3.000001 5,0 0,-4.999999 -5,4.999999 z"
+     id="path3410"
+     style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 18.713203,29.538323 11.845312,-11.845312 0,11.845312 -11.845312,0 z"
+     id="path3424"
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3148);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/mimes/32/x-office-presentation.svg
+++ b/mimes/32/x-office-presentation.svg
@@ -6,339 +6,362 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg3828"
-   height="32"
+   version="1.1"
    width="32"
-   version="1.1">
+   height="32"
+   id="svg3828">
   <defs
      id="defs3830">
     <linearGradient
        id="linearGradient3028">
       <stop
-         offset="0"
+         id="stop3030"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3030" />
+         offset="0" />
       <stop
-         offset="0.01124695"
+         id="stop3032"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3032" />
+         offset="0.01124695" />
       <stop
-         offset="0.97092199"
+         id="stop3034"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3034" />
+         offset="0.97092199" />
       <stop
-         offset="1"
+         id="stop3036"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3036" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-4">
       <stop
-         offset="0"
+         id="stop3602-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-6"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
-         offset="0"
+         id="stop5062"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop5064"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5048">
       <stop
-         offset="0"
+         id="stop5050"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop5056"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop5052"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.72972916,0,0,0.56756756,-1.5145621,3.3783836)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3028"
-       id="linearGradient3012"
-       y2="41.44783"
-       x2="23.99999"
+       x1="23.99999"
        y1="6.7927485"
-       x1="23.99999" />
-    <linearGradient
-       gradientTransform="matrix(0.79999811,0,0,0.47802334,-3.1999562,4.794095)"
+       x2="23.99999"
+       y2="41.44783"
+       id="linearGradient3012"
+       xlink:href="#linearGradient3028"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3015"
-       y2="47.013336"
-       x2="25.132275"
+       gradientTransform="matrix(0.72972916,0,0,0.56756756,-1.5145621,4.3783836)" />
+    <linearGradient
+       x1="25.132275"
        y1="0.98520643"
-       x1="25.132275" />
-    <radialGradient
-       gradientTransform="matrix(0.01927775,0,0,0.0082353,17.982069,24.980564)"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3015"
+       xlink:href="#linearGradient3600-4"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
+       gradientTransform="matrix(0.79999811,0,0,0.47802334,-3.1999562,5.794095)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
        id="radialGradient3020"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <radialGradient
-       gradientTransform="matrix(-0.01927775,0,0,0.0082353,14.01793,24.980564)"
-       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5060"
-       id="radialGradient3023"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01927775,0,0,0.0082353,17.982069,25.980564)" />
+    <radialGradient
+       cx="605.71429"
        cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       gradientTransform="matrix(0.05633135,0,0,0.0082353,-4.3597632,24.980547)"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3023"
+       xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5048"
-       id="linearGradient3026"
-       y2="609.50507"
-       x2="302.85715"
+       gradientTransform="matrix(-0.01927775,0,0,0.0082353,14.01793,25.980564)" />
+    <linearGradient
+       x1="302.85715"
        y1="366.64789"
-       x1="302.85715" />
-    <linearGradient
-       gradientTransform="matrix(0.66891892,0,0,0.56756756,-1.17905,3.378385)"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3026"
+       xlink:href="#linearGradient5048"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977-6"
-       id="linearGradient3076"
-       y2="41.481415"
-       x2="9.6095304"
+       gradientTransform="matrix(0.05633135,0,0,0.0082353,-4.3597632,25.980547)" />
+    <linearGradient
+       x1="9.6095304"
        y1="6.3948526"
-       x1="9.6095304" />
+       x2="9.6095304"
+       y2="41.481415"
+       id="linearGradient3076"
+       xlink:href="#linearGradient3977-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66891892,0,0,0.56756756,-1.17905,4.378385)" />
     <linearGradient
        id="linearGradient3977-6">
       <stop
-         offset="0"
+         id="stop3979-9"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979-9" />
+         offset="0" />
       <stop
-         offset="0.0066674"
+         id="stop3981-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981-3" />
+         offset="0.0066674" />
       <stop
-         offset="0.99594194"
+         id="stop3983-7"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983-7" />
+         offset="0.99594194" />
       <stop
-         offset="1"
+         id="stop3985-4"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-5-66">
       <stop
-         offset="0"
+         id="stop3106-9"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-9" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-9-8" />
+         offset="1" />
     </linearGradient>
-    <clipPath
-       id="clipPath3877">
-      <path
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path3879"
-         d="m 10.751345,-0.72641891 19.105374,0.0251951 0,10.48095741 -19.105374,-0.025202 z" />
-    </clipPath>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-3"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-3" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-9"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-9" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-2"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-4"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-0" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         offset="0"
+         id="stop3213-0-0-8-1-1"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3213-0-0-8-1-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3215-1-8-0-6-4"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3215-1-8-0-6-4" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         offset="0"
+         id="stop3106-1-5-9-3-1-7-1"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3106-1-5-9-3-1-7-1" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-1-5-5-7-2-4-5"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop3108-1-5-5-7-2-4-5" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         offset="0"
+         id="stop3602-1-25-9-9-6-5-6"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-1-25-9-9-6-5-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-4-2-0-2-4-2-1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-4-2-0-2-4-2-1" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-11.198083,94.86293)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5-66"
-       id="linearGradient3514"
-       y2="25.646791"
-       x2="22.004084"
+       x1="22.004084"
        y1="63.217903"
-       x1="22.004084" />
-    <linearGradient
-       gradientTransform="matrix(1.081295,0,0,0.62485417,-6.1734925,-3.6471464)"
+       x2="22.004084"
+       y2="25.646791"
+       id="linearGradient3514"
+       xlink:href="#linearGradient3104-5-66"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-3-2-2-6-8"
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-11.354333,95.86293)" />
+    <linearGradient
+       x1="25.132275"
+       y1="15.284525"
+       x2="25.132275"
+       y2="37.546188"
        id="linearGradient3550"
-       y2="37.546188"
-       x2="25.132275"
-       y1="15.284525"
-       x1="25.132275" />
-    <linearGradient
-       gradientTransform="matrix(0.87314224,0,0,0.58477041,58.066492,-4.3435334)"
+       xlink:href="#linearGradient3600-3-2-2-6-8"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-9-7-3-9-6"
+       gradientTransform="matrix(1.081295,0,0,0.62485417,-6.1734925,-3.6471464)" />
+    <linearGradient
+       x1="-51.786404"
+       y1="41.797989"
+       x2="-51.786404"
+       y2="17.555471"
        id="linearGradient3552"
-       y2="17.555471"
-       x2="-51.786404"
-       y1="41.797989"
-       x1="-51.786404" />
-    <linearGradient
-       gradientTransform="matrix(1.0820661,0,0,0.61449222,-5.6480107,-2.535845)"
+       xlink:href="#linearGradient3104-9-7-3-9-6"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3211-8-8-9"
+       gradientTransform="matrix(0.87314224,0,0,0.58477041,58.066492,-4.3435334)" />
+    <linearGradient
+       x1="24"
+       y1="14.203104"
+       x2="24"
+       y2="35.721317"
        id="linearGradient3554"
-       y2="35.721317"
-       x2="24"
-       y1="14.203104"
-       x1="24" />
-    <linearGradient
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-2.9300489)"
+       xlink:href="#linearGradient3211-8-8-9"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
-       id="linearGradient3556"
-       y2="37.546188"
-       x2="25.132275"
+       gradientTransform="matrix(1.0820661,0,0,0.61449222,-5.6480107,-2.535845)" />
+    <linearGradient
+       x1="25.132275"
        y1="15.284525"
-       x1="25.132275" />
-    <linearGradient
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-3.9956799)"
+       x2="25.132275"
+       y2="37.546188"
+       id="linearGradient3556"
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
-       id="linearGradient3558"
-       y2="17.555471"
-       x2="-51.786404"
+       gradientTransform="matrix(1.6122259,0,0,1.0767345,-17.128673,-9.3123805)" />
+    <linearGradient
+       x1="-51.786404"
        y1="41.797989"
-       x1="-51.786404" />
-    <linearGradient
-       gradientTransform="matrix(1.0351164,0,0,0.9866216,-0.70291674,-2.1699512)"
+       x2="-51.786404"
+       y2="17.555471"
+       id="linearGradient3558"
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3211-8-8-0-0-9"
-       id="linearGradient3560"
-       y2="35.721317"
-       x2="24"
+       gradientTransform="matrix(1.3018673,0,0,1.0076631,78.654041,-10.512379)" />
+    <linearGradient
+       x1="24"
        y1="14.203104"
-       x1="24" />
+       x2="24"
+       y2="35.721317"
+       id="linearGradient3560"
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6688415,0,0,1.1110264,-17.457342,-8.4564408)" />
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         offset="0"
+         id="stop3106-3-2"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8-3"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-8-3" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.74052449,0,0,0.46769471,46.924817,3.6822435)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient3976"
-       xlink:href="#linearGradient3104-6-6-1" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74052449,0,0,0.46769471,46.924817,4.6822435)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4"
+       id="radialGradient3995-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.833181)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9-9-0-3"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7-4-0-32-8-923-0-7-8-7"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8-5-2-7-6-7-1-8-0-6"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6-2-6-6-1-96-6-1-1-0"
+         style="stop-color:#ac441f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <radialGradient
        r="12.671875"
        fy="9.9571075"
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-49.833181)"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.880056)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3995-5"
+       id="radialGradient4223"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4">
-      <stop
-         offset="0"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-9-0-3" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7-8-7" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-8-0-6" />
-      <stop
-         offset="1"
-         style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-1-1-0" />
-    </linearGradient>
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.866281)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4225"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,5.9871994,-7.3503682,0,88.479826,-48.883625)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4227"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-4" />
   </defs>
   <metadata
      id="metadata3833">
@@ -353,104 +376,104 @@
     </rdf:RDF>
   </metadata>
   <rect
-     style="opacity:0.15;fill:url(#linearGradient3026);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2879"
-     y="28"
-     x="2.4000013"
+     width="27.199997"
      height="2"
-     width="27.199997" />
+     x="2.4000013"
+     y="29"
+     id="rect2879"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3026);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="opacity:0.15;fill:url(#radialGradient3023);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     d="m 2.3999999,29.000085 c 0,0 0,1.999891 0,1.999891 C 1.4072441,31.003776 0,30.551901 0,29.999901 0,29.447902 1.10784,29.000085 2.3999999,29.000085 Z"
      id="path2881"
-     d="m 2.3999999,28.000085 c 0,0 0,1.999891 0,1.999891 C 1.4072441,30.003776 0,29.551901 0,28.999901 0,28.447902 1.10784,28.000085 2.3999999,28.000085 z" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3023);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="opacity:0.15;fill:url(#radialGradient3020);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     d="m 29.6,29.000085 c 0,0 0,1.999891 0,1.999891 0.992755,0.0038 2.4,-0.448075 2.4,-1.000075 0,-0.551999 -1.107843,-0.999816 -2.4,-0.999816 z"
      id="path2883"
-     d="m 29.6,28.000085 c 0,0 0,1.999891 0,1.999891 0.992755,0.0038 2.4,-0.448075 2.4,-1.000075 0,-0.551999 -1.107843,-0.999816 -2.4,-0.999816 z" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3020);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <g
-     style="opacity:0.5;display:inline"
-     id="g6242-7-5"
-     clip-path="url(#clipPath3877)"
-     transform="matrix(1.6122259,0,0,1.1260917,-16.324081,-7.0128768)">
+     style="opacity:0.5"
+     id="g4245">
     <path
-       style="color:#000000;fill:url(#linearGradient3556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3558);stroke-width:0.74210644;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       mask="none"
+       clip-path="none"
+       d="m 5.4910831,2.5331912 21.0178349,0 L 26.5,5.5 l -21,0 z"
        id="rect4964-4-4"
-       d="m 13.531084,7.5891404 13.036532,0 0,24.9012876 -13.036532,0 z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3558);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3560);stroke-width:0.74210638;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 6.5,3.5 19,0 0,1 -19,0 z"
        id="rect4964-1-6-5"
-       d="m 14.310274,9.4115011 11.412939,0 0,22.1935199 -11.412939,0 z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3560);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
   <g
-     id="g3546"
-     transform="translate(0,1)">
+     transform="translate(0,2)"
+     id="g3546">
     <path
-       style="opacity:0.75;color:#000000;fill:url(#linearGradient3550);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3552);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 3.499961,2.499961 28.500039,2.5 l 0,17.000039 -25.000039,0 z"
        id="rect4964-4"
-       d="m 3.499961,2.499961 25.000078,0.037621 0,16.962457 -24.8586005,0 z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3550);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3552);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       style="opacity:0.45;color:#000000;fill:none;stroke:url(#linearGradient3554);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 4.4999609,3.4999609 27.500039,3.5 27.5,18.500039 l -23,0 z"
        id="rect4964-1-6"
-       d="m 4.4999609,3.4999609 23.0000781,0.016517 -0.112984,14.9835611 -22.7005349,0 z" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3554);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
   <path
-     style="fill:url(#linearGradient3015);fill-opacity:1;stroke:none;display:inline"
+     d="M 2.0000002,7 C 8.4162208,7 29.999965,7.00143 29.999965,7.00143 L 30,29 C 30,29 11.333334,29 2,29 2,21.666674 2,14.33335 2,7.0000237 Z"
      id="path4160-3"
-     d="m 2.0000002,6 c 6.4162206,0 27.9999648,0.00143 27.9999648,0.00143 L 30,28 C 30,28 11.333334,28 2,28 2,20.666674 2,13.33335 2,6.0000237 z" />
+     style="display:inline;fill:url(#linearGradient3015);fill-opacity:1;stroke:none" />
   <path
-     style="fill:none;stroke:url(#linearGradient3012);stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     d="m 29.5,28.5 -26.9999998,0 0,-21 L 29.5,7.5 Z"
      id="rect6741-1"
-     d="m 29.5,27.5 -26.9999998,0 0,-21 L 29.5,6.5 z" />
+     style="fill:none;stroke:url(#linearGradient3012);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="color:#000000;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 6,29.5 -4.5,0 c 0,-7.248272 0,-16.5 0,-23 1.186199,0 3.1440605,1e-6 4.5,1e-6"
      id="path4530"
-     d="m 6,28.5 c -1.4379221,0 -2.8758452,0 -4.3137745,0 -0.3495006,-0.272334 -0.083736,-0.813022 -0.166777,-1.198561 0,-7.223095 0,-14.446189 0,-21.669283 l 0.048743,-0.093529 0.1180346,-0.038626 0,0 c 1.4965868,0 4.3137739,0 4.3137739,0" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.50000000000000000;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     d="m 5.5,28.5 -3,0 0,-21 3,0"
      id="rect6741-1-5"
-     d="m 5.5,27.5 -3,0 0,-21 3,0" />
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 11,9.5 4,0"
      id="path4159"
-     d="m 11,8.5 4,0" />
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 16,9.5 2,0"
      id="path4161"
-     d="m 16,8.5 2,0" />
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 19,9.5 1,0"
      id="path4163"
-     d="m 19,8.5 1,0" />
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 21,9.5 2,0"
      id="path4165"
-     d="m 21,8.5 2,0" />
+     style="fill:none;stroke:#aaaaaa;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient3514);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+     d="m 7,26 0,-1 2,0 0,1 z m 3,0 0,-1 6,0 0,1 z m -3,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 1,0 0,1 z m -7,-4 0,-1 3,0 0,1 z m 4,0 0,-1 1,0 0,1 z m 2,0 0,-1 2,0 0,1 z m -6,-4 0,-1 3,0 0,1 z m 4,0 0,-1 3,0 0,1 z"
      id="path3475-4"
-     d="m 7.15625,25 0,-1 2.21875,0 0,1 z m 2.65625,0 0,-1 6.34375,0 0,1 z m -2.65625,-4 0,-1 2.96875,0 0,1 z m 3.71875,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 1.1875,0 0,1 z m -6.65625,-4 0,-1 3.28125,0 0,1 z m 3.875,0 0,-1 1.65625,0 0,1 z m 2.21875,0 0,-1 1.75,0 0,1 z m -6.09375,-4 0,-1 3.28125,0 0,1 z m 3.90625,0 0,-1 2.34375,0 0,1 z" />
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3514);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
   <path
-     d="m 29,18.999999 a 6,6 0 1 1 -3.173929,-5.29276 L 23,18.999999 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate"
      id="path3035-5"
-     style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 29,19.999999 a 6,6 0 1 1 -3.173929,-5.29276 L 23,19.999999 Z" />
   <path
-     d="M 29,18.050444 A 6,6 0 1 1 25.826071,12.757683 L 23,18.050444 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4227);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3035"
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     d="M 29,19 A 6,6 0 1 1 25.826071,13.707239 L 23,19 Z" />
   <path
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+     d="m 29,19.017344 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 22.094125,25.493696 19.192988,24.333577 17.855125,22.10259 17.844525,22.11219 23,19.017344 23,19.017344 Z"
      id="path3964"
-     d="m 29,18.050444 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 22.094125,24.526796 19.192988,23.366677 17.855125,21.13569 17.844525,21.14529 23,18.050444 23,18.050444 z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4225);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
-     id="path4160-6-1"
-     d="m 6,28.500039 24.50004,0 0,-23.0000784 -24.50004,0"
-     style="fill:none;stroke:url(#linearGradient3976);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+     style="display:inline;fill:none;stroke:url(#linearGradient3976);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 6,29.500039 24.50004,0 0,-23.0000784 -24.50004,0"
+     id="path4160-6-1" />
   <path
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 6,29.5 -4.5,0 c 0,-7.093297 0.019448,-15.349915 0.019448,-22.867844 l 0.048743,-0.093529 0.1180346,-0.038626 0,0 4.3137739,0"
      id="path4530-2"
-     d="m 6,28.5 c -1.4379221,0 -2.8758452,0 -4.3137745,0 -0.3495006,-0.272334 -0.083736,-0.813022 -0.166777,-1.198561 0,-7.223095 0,-14.446189 0,-21.669283 l 0.048743,-0.093529 0.1180346,-0.038626 0,0 c 1.4965868,0 4.3137739,0 4.3137739,0" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.8;color:#000000;fill:url(#radialGradient3995-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+     d="m 29,19.003569 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 24.542464,24.775789 23,19.003569 23,19.003569 Z"
      id="path3962"
-     d="m 29,18.050444 c 0,2.601413 -1.892038,5.088408 -4.398956,5.78238 C 24.542464,23.822664 23,18.050444 23,18.050444 z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4223);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/48/x-office-presentation-rtl.svg
+++ b/mimes/48/x-office-presentation-rtl.svg
@@ -6,7 +6,6 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 48 48"
    id="svg4954"
    height="48"
    width="48"
@@ -22,7 +21,7 @@
       <stop
          id="stop4208"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
+         offset="0.04111167" />
       <stop
          id="stop4210"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
@@ -44,7 +43,7 @@
          id="stop3604-4-2-0" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-2.9300489)"
+       gradientTransform="matrix(1.6122259,0,0,1.0767345,-8.9958873,-2.3045777)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
        id="linearGradient6317-7-3-5-2"
@@ -64,7 +63,7 @@
          id="stop3604-4-2-0-2-4-2-1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-3.9956799)"
+       gradientTransform="matrix(1.3018673,0,0,1.0076631,86.786828,-3.504576)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
        id="linearGradient6319-8-6-9-3"
@@ -95,7 +94,7 @@
          id="stop3215-1-8-0-6-4" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.0351164,0,0,0.9866216,-0.70291674,-2.1699512)"
+       gradientTransform="matrix(1.6688415,0,0,1.1110264,-9.3246018,-1.3795603)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3211-8-8-0-0-9"
        id="linearGradient3074"
@@ -104,7 +103,7 @@
        y1="14.203104"
        x1="24" />
     <linearGradient
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-1.9300489)"
+       gradientTransform="matrix(1.3415124,0,0,1.1169998,-3.4942248,1.4805927)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600-3-2-2-6-8"
        id="linearGradient6767-4"
@@ -124,7 +123,7 @@
          id="stop3604-4-2-0-2-0" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-2.9956799)"
+       gradientTransform="matrix(1.083267,0,0,1.0453454,76.205338,0.23571965)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-9-7-3-9-6"
        id="linearGradient6769-8"
@@ -155,7 +154,7 @@
          id="stop3215-1-8-9" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.0178516,0,0,0.99517276,-0.35774965,-1.4378608)"
+       gradientTransform="matrix(1.3654605,0,0,1.1625635,-3.3046597,2.0555681)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3211-8-8-9"
        id="linearGradient3142"
@@ -189,13 +188,6 @@
          style="stop-color:#000000;stop-opacity:0"
          id="stop5064-7" />
     </linearGradient>
-    <clipPath
-       id="clipPath3877">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
-         id="path3879"
-         d="m 10.751345,-0.72641891 19.105374,0.0251951 V 9.7797336 L 10.751345,9.7545316 Z" />
-    </clipPath>
     <linearGradient
        id="linearGradient3104-5">
       <stop
@@ -208,7 +200,7 @@
          id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,57.345744,107.86293)"
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,57.354333,107.86293)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-5"
        id="linearGradient3091"
@@ -217,11 +209,11 @@
        y1="63.217903"
        x1="22.004084" />
     <linearGradient
-       gradientTransform="matrix(0.89189189,0,0,0.72972971,0.59459989,12.486494)"
+       gradientTransform="matrix(0.89189189,0,0,0.72972971,0.59369065,12.45287)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4204"
        id="linearGradient3076"
-       y2="41.814804"
+       y2="41.860882"
        x2="23.99999"
        y1="6.1347566"
        x1="23.99999" />
@@ -229,7 +221,7 @@
        xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient4420"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.93203892,0,0,0.58970161,64.116407,13.241682)"
+       gradientTransform="matrix(0.93203892,0,0,0.58970161,64.115498,13.208058)"
        x1="-51.786404"
        y1="50.786446"
        x2="-51.786404"
@@ -249,9 +241,9 @@
        xlink:href="#linearGradient4356-5"
        id="linearGradient3076-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.53513437,0,0,0.7297282,6.5567852,12.486532)"
-       x1="23.99999"
-       y1="6.1851358"
+       gradientTransform="matrix(0.53513437,0,0,0.7297282,6.555876,12.452908)"
+       x1="23.970793"
+       y1="6.2312131"
        x2="23.99999"
        y2="41.754993" />
     <linearGradient
@@ -263,7 +255,7 @@
       <stop
          id="stop4360-9"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0" />
+         offset="0.03857623" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
@@ -277,7 +269,7 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
        id="radialGradient4173-5-5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,151.99195,-49.851449)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,151.99104,-49.885073)"
        cx="6.7304144"
        cy="9.9571075"
        fx="6.2001843"
@@ -308,7 +300,7 @@
        fx="605.71429"
        cy="486.64789"
        cx="605.71429"
-       gradientTransform="matrix(0.02303995,0,0,0.01484079,28.360735,37.085015)"
+       gradientTransform="matrix(0.02303995,0,0,0.01484079,28.360735,36.954493)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4218"
        xlink:href="#linearGradient5060-2" />
@@ -318,7 +310,7 @@
        fx="605.71429"
        cy="486.64789"
        cx="605.71429"
-       gradientTransform="matrix(-0.02303994,0,0,0.01484079,19.622642,37.085015)"
+       gradientTransform="matrix(-0.02303994,0,0,0.01484079,19.622642,36.954493)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4221"
        xlink:href="#linearGradient5060-2" />
@@ -327,7 +319,7 @@
        x2="302.85715"
        y1="366.64789"
        x1="302.85715"
-       gradientTransform="matrix(0.06732488,0,0,0.01484079,-0.3411391,37.084985)"
+       gradientTransform="matrix(0.06732488,0,0,0.01484079,-0.3411391,36.954463)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4224"
        xlink:href="#linearGradient5048-9" />
@@ -346,7 +338,7 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43263,-56.130907)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43263,-56.201805)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4304"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
@@ -356,7 +348,7 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43263,-56.130907)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43262,-56.197677)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4306"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
@@ -366,7 +358,7 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43263,-56.130907)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.42313,-56.181569)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4308"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
@@ -387,53 +379,50 @@
      width="36.50787"
      height="3.6041925"
      x="5.7380605"
-     y="42.526329"
+     y="42.395809"
      id="rect2879"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4224);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 42.246,42.526486 c 0,0 0,3.603993 0,3.603993 1.1865,0.0067 2.86838,-0.807471 2.86838,-1.802229 0,-0.994755 -1.324045,-1.801763 -2.86838,-1.801764 z"
+     d="m 42.246,42.395964 c 0,0 0,3.603993 0,3.603993 1.1865,0.0067 2.86838,-0.807471 2.86838,-1.802229 0,-0.994755 -1.324045,-1.801763 -2.86838,-1.801764 z"
      id="path2883"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4218);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 5.7373795,42.526486 c 0,0 0,3.603993 0,3.603993 C 4.5508793,46.137208 2.869,45.323008 2.869,44.32825 c 0,-0.994755 1.3240446,-1.801763 2.8683795,-1.801764 z"
+     d="m 5.7373795,42.395964 c 0,0 0,3.603993 0,3.603993 C 4.5508793,46.006686 2.869,45.192486 2.869,44.197728 c 0,-0.994755 1.3240446,-1.801763 2.8683795,-1.801764 z"
      id="path2881"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4221);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <g
-     style="display:inline;opacity:0.5"
-     id="g6242-7-5"
-     clip-path="url(#clipPath3877)"
-     transform="matrix(1.6122259,0,0,1.1260917,-8.2886536,1.0154672)">
+     style="opacity:0.5"
+     id="g4235">
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6317-7-3-5-2);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6319-8-6-9-3);stroke-width:0.74210644;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6317-7-3-5-2);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6319-8-6-9-3);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-4-4"
-       d="M 13.531084,7.5891404 H 26.567616 V 32.490428 H 13.531084 Z" />
+       d="m 13.5,9.5 21,0 0,28 -21,0 z" />
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3074);stroke-width:0.74210638;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3074);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-1-6-5"
-       d="M 14.310274,9.4115011 H 25.723213 V 31.605021 H 14.310274 Z" />
+       d="m 14.5,10.5 19,0 0,26 -19,0 z" />
   </g>
   <g
-     style="display:inline;opacity:0.75"
-     id="g6242-7"
-     transform="matrix(1.3415124,0,0,1.1682027,-2.8238249,3.7689044)">
+     style="opacity:0.75"
+     id="g4239">
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6767-4);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6769-8);stroke-width:0.79874772;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6767-4);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6769-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-4"
-       d="M 8.4471178,7.4764285 31.567616,7.5339975 V 33.490428 H 8.5779586 Z" />
+       d="M 8.4999999,12.5 39.5,12.5 l 0,30 -31.0000001,0 z" />
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3142);stroke-width:0.79874766;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3142);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-1-6"
-       d="M 9.1879971,8.3371525 30.82315,8.3639025 30.716871,32.629843 H 9.3634851 Z" />
+       d="m 9.5,13.5 29,0 0,28 -29,0 z" />
   </g>
   <g
      style="stroke:none"
-     transform="matrix(0.94266573,0,0,1.0825124,3.8753566,7.7461952)"
+     transform="matrix(0.94266573,0,0,1.0825124,3.8744474,7.7125718)"
      id="g6242">
     <rect
        width="35.007107"
-       height="25.865755"
+       height="25.865753"
        x="6.4971528"
-       y="7.6246748"
+       y="7.655735"
        id="rect4964"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4296);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.89594334;marker:none;enable-background:accumulate" />
     <rect
@@ -444,51 +433,51 @@
        id="rect4964-1"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:none;stroke-width:0.89594322;marker:none;enable-background:accumulate" />
   </g>
-  <path
-     d="m 25.953164,32.925651 a 6.9531641,6.9531641 0 1 1 -3.678141,-6.133572 l -3.275022,6.133572 z"
-     id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
-     id="path3475-4"
-     d="m 38.991411,38 v -1 h -2.21875 v 1 z m -2.65625,0 v -1 h -6.34375 v 1 z m 2.65625,-4 v -1 h -2.96875 v 1 z m -3.71875,0 v -1 h -2.34375 v 1 z m -2.9375,0 v -1 h -1.1875 v 1 z m -1.8125,0 v -1 h -2.15625 v 1 z m 8.46875,-4 v -1 h -3.28125 v 1 z m -3.875,0 v -1 h -1.65625 v 1 z m -2.21875,0 v -1 h -3.71875 v 1 z m 6.09375,-4 v -1 h -3.28125 v 1 z m -3.90625,0 v -1 h -2.34375 v 1 z m -2.9375,0 v -1 h -3.6875 v 1 z" />
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="path3475"
-     d="m 33.741411,20 v 1 h -5.734375 v -1 z m -6.390625,0 v 1 h -2.640625 v -1 z m -3.359375,0 v 1 h -3.75 v -1 z" />
   <rect
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3076-9);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-2"
-     y="16.5"
-     x="9.5"
+     y="16.466377"
+     x="9.4990911"
      height="27"
      width="33" />
   <path
-     d="M 26,32.070896 A 7,7 0 1 1 22.297083,25.89601 l -3.297082,6.174886 z"
+     id="path4160-6-1"
+     d="m 10,44.500039 33.5,0 0,-29.000078 -33.5,0"
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     id="path4530"
+     d="m 10,44.5 -5.5,0 c 0,-9.5 0.012787,-20.492234 0,-29 2.0403847,0 3.5366952,0 5.5,0" />
+  <path
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1-5"
+     d="m 9.5,43.5 -3.9999546,0 -9.08e-5,-27 L 9.5,16.5" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path4530-2"
+     d="m 10,44.5 -5.5,0 c 0,-10.5 0,-20.30602 0,-29 1.2519464,0 3.6110688,-0.01205 5.5,0" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path3475-4"
+     d="m 39,38 0,-1 -2,0 0,1 z m -3,0 0,-1 -6,0 0,1 z m 3,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -2,0 0,1 z m 9,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -4,0 0,1 z m 6,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -4,0 0,1 z" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+     id="path3475"
+     d="m 34,20 0,1 -6,0 0,-1 z m -7,0 0,1 -2,0 0,-1 z m -3,0 0,1 -4,0 0,-1 z" />
+  <path
+     d="m 25.906328,33.046835 a 6.9531641,6.9531641 0 1 1 -3.678141,-6.133572 l -3.275022,6.133572 z"
+     id="path3035-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+  <path
+     d="m 26,31.999998 a 7,7 0 1 1 -3.702917,-6.174886 l -3.297082,6.174886 z"
      id="path3035-2"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4304);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4308);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3964"
-     d="m 26,32.070896 c 1e-6,3.034983 -2.207377,5.936477 -5.132115,6.746111 -2.924739,0.809634 -6.309398,-0.543838 -7.870239,-3.146656 -0.01238,0.01123 6.002355,-3.599455 6.002355,-3.599455 z" />
-  <path
-     id="path4160-6-1"
-     d="M 10,44.533663 H 43.443854 V 15.533585 H 10"
-     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     id="path4530"
-     d="m 10.035786,44.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.343376 -0.102163,-1.025114 -0.203479,-1.511228 0,-9.107382 0,-18.214763 0,-27.322142 l 0.05947,-0.117935 0.14401,-0.0487 v 0 c 1.825936,0 3.4110786,0 5.2370056,0" />
-  <path
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect6741-1-5"
-     d="m 9.5,43.5 h -4 v -27 h 4" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path4530-2"
-     d="m 10.035786,44.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.343376 -0.102163,-1.025114 -0.203479,-1.511228 0,-9.107382 0,-18.214763 0,-27.322142 l 0.05947,-0.117935 0.14401,-0.0487 v 0 c 1.825936,0 3.4110786,0 5.2370056,0" />
+     d="m 25.990502,32.020234 c 1e-6,3.034983 -2.207377,5.936477 -5.132115,6.746111 -2.924739,0.809634 -6.309398,-0.543838 -7.870239,-3.146656 -0.01238,0.01123 6.002355,-3.599455 6.002355,-3.599455 z" />
   <path
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4306);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3962"
-     d="m 26,32.070896 c 1e-6,3.034983 -2.207377,5.936477 -5.132115,6.746111 -0.06833,-0.01187 -1.867884,-6.746111 -1.867884,-6.746111 z" />
+     d="M 25.999999,32.004126 C 26,35.039109 23.792622,37.940603 20.867884,38.750237 20.799554,38.738367 19,32.004126 19,32.004126 Z" />
 </svg>

--- a/mimes/48/x-office-presentation-template-rtl.svg
+++ b/mimes/48/x-office-presentation-template-rtl.svg
@@ -6,7 +6,6 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 48 48"
    id="svg4954"
    height="48"
    width="48"
@@ -22,7 +21,7 @@
       <stop
          id="stop4208"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
+         offset="0.04111167" />
       <stop
          id="stop4210"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
@@ -44,7 +43,7 @@
          id="stop3604-4-2-0" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-2.9300489)"
+       gradientTransform="matrix(1.6122259,0,0,1.0767345,-8.9958873,-2.3045777)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
        id="linearGradient6317-7-3-5-2"
@@ -64,7 +63,7 @@
          id="stop3604-4-2-0-2-4-2-1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-3.9956799)"
+       gradientTransform="matrix(1.3018673,0,0,1.0076631,86.786828,-3.504576)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
        id="linearGradient6319-8-6-9-3"
@@ -95,7 +94,7 @@
          id="stop3215-1-8-0-6-4" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.0351164,0,0,0.9866216,-0.70291674,-2.1699512)"
+       gradientTransform="matrix(1.6688415,0,0,1.1110264,-9.3246018,-1.3795603)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3211-8-8-0-0-9"
        id="linearGradient3074"
@@ -104,7 +103,7 @@
        y1="14.203104"
        x1="24" />
     <linearGradient
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-1.9300489)"
+       gradientTransform="matrix(1.3415124,0,0,1.1169998,-3.4942248,1.4805927)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600-3-2-2-6-8"
        id="linearGradient6767-4"
@@ -124,7 +123,7 @@
          id="stop3604-4-2-0-2-0" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-2.9956799)"
+       gradientTransform="matrix(1.083267,0,0,1.0453454,76.205338,0.23571965)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-9-7-3-9-6"
        id="linearGradient6769-8"
@@ -155,7 +154,7 @@
          id="stop3215-1-8-9" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.0178516,0,0,0.99517276,-0.35774965,-1.4378608)"
+       gradientTransform="matrix(1.3654605,0,0,1.1625635,-3.3046597,2.0555681)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3211-8-8-9"
        id="linearGradient3142"
@@ -189,13 +188,6 @@
          style="stop-color:#000000;stop-opacity:0"
          id="stop5064-7" />
     </linearGradient>
-    <clipPath
-       id="clipPath3877">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
-         id="path3879"
-         d="m 10.751345,-0.72641891 19.105374,0.0251951 V 9.7797336 L 10.751345,9.7545316 Z" />
-    </clipPath>
     <linearGradient
        id="linearGradient3104-5">
       <stop
@@ -208,7 +200,7 @@
          id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,57.345744,107.86293)"
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,57.354333,107.86293)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-5"
        id="linearGradient3091"
@@ -217,11 +209,11 @@
        y1="63.217903"
        x1="22.004084" />
     <linearGradient
-       gradientTransform="matrix(0.89189189,0,0,0.72972971,0.59459989,12.486494)"
+       gradientTransform="matrix(0.89189189,0,0,0.72972971,0.59369065,12.45287)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4204"
        id="linearGradient3076"
-       y2="41.814804"
+       y2="41.860882"
        x2="23.99999"
        y1="6.1347566"
        x1="23.99999" />
@@ -229,7 +221,7 @@
        xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient4420"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.93203892,0,0,0.58970161,64.116407,13.241682)"
+       gradientTransform="matrix(0.93203892,0,0,0.58970161,64.115498,13.208058)"
        x1="-51.786404"
        y1="50.786446"
        x2="-51.786404"
@@ -249,9 +241,9 @@
        xlink:href="#linearGradient4356-5"
        id="linearGradient3076-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.53513437,0,0,0.7297282,6.5567852,12.486532)"
-       x1="23.99999"
-       y1="6.1851358"
+       gradientTransform="matrix(0.53513437,0,0,0.7297282,6.555876,12.452908)"
+       x1="23.970793"
+       y1="6.2312131"
        x2="23.99999"
        y2="41.754993" />
     <linearGradient
@@ -263,7 +255,7 @@
       <stop
          id="stop4360-9"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0" />
+         offset="0.03857623" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
@@ -277,7 +269,7 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
        id="radialGradient4173-5-5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,151.99195,-49.851449)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,151.99104,-49.885073)"
        cx="6.7304144"
        cy="9.9571075"
        fx="6.2001843"
@@ -308,7 +300,7 @@
        fx="605.71429"
        cy="486.64789"
        cx="605.71429"
-       gradientTransform="matrix(0.02303995,0,0,0.01484079,28.360735,37.085015)"
+       gradientTransform="matrix(0.02303995,0,0,0.01484079,28.360735,36.954493)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4218"
        xlink:href="#linearGradient5060-2" />
@@ -318,7 +310,7 @@
        fx="605.71429"
        cy="486.64789"
        cx="605.71429"
-       gradientTransform="matrix(-0.02303994,0,0,0.01484079,19.622642,37.085015)"
+       gradientTransform="matrix(-0.02303994,0,0,0.01484079,19.622642,36.954493)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4221"
        xlink:href="#linearGradient5060-2" />
@@ -327,7 +319,7 @@
        x2="302.85715"
        y1="366.64789"
        x1="302.85715"
-       gradientTransform="matrix(0.06732488,0,0,0.01484079,-0.3411391,37.084985)"
+       gradientTransform="matrix(0.06732488,0,0,0.01484079,-0.3411391,36.954463)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4224"
        xlink:href="#linearGradient5048-9" />
@@ -346,7 +338,7 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43263,-56.130907)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43263,-56.201805)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4304"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
@@ -356,7 +348,7 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43263,-56.130907)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43262,-56.197677)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4306"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
@@ -366,20 +358,10 @@
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.43263,-56.130907)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,199.42313,-56.181569)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4308"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
-    <radialGradient
-       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,36.963253)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060-2"
-       id="radialGradient3907"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
     <linearGradient
        gradientTransform="matrix(1.3333334,0,0,-1.3333334,-16.166666,70.166667)"
        gradientUnits="userSpaceOnUse"
@@ -401,7 +383,7 @@
          id="stop3416" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.33,0,0,-1.33,-16.064999,70.028077)"
+       gradientTransform="matrix(1.33,0,0,-1.33,-13.064999,106.02808)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3211-8-8-0-0-9"
        id="linearGradient3911"
@@ -426,53 +408,50 @@
      width="36.50787"
      height="3.6041925"
      x="5.7380605"
-     y="42.526329"
+     y="42.395809"
      id="rect2879"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4224);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 42.246,42.526486 c 0,0 0,3.603993 0,3.603993 1.1865,0.0067 2.86838,-0.807471 2.86838,-1.802229 0,-0.994755 -1.324045,-1.801763 -2.86838,-1.801764 z"
+     d="m 42.246,42.395964 c 0,0 0,3.603993 0,3.603993 1.1865,0.0067 2.86838,-0.807471 2.86838,-1.802229 0,-0.994755 -1.324045,-1.801763 -2.86838,-1.801764 z"
      id="path2883"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4218);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 5.7373795,42.526486 c 0,0 0,3.603993 0,3.603993 C 4.5508793,46.137208 2.869,45.323008 2.869,44.32825 c 0,-0.994755 1.3240446,-1.801763 2.8683795,-1.801764 z"
+     d="m 5.7373795,42.395964 c 0,0 0,3.603993 0,3.603993 C 4.5508793,46.006686 2.869,45.192486 2.869,44.197728 c 0,-0.994755 1.3240446,-1.801763 2.8683795,-1.801764 z"
      id="path2881"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4221);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <g
-     style="display:inline;opacity:0.5"
-     id="g6242-7-5"
-     clip-path="url(#clipPath3877)"
-     transform="matrix(1.6122259,0,0,1.1260917,-8.2886536,1.0154672)">
+     style="opacity:0.5"
+     id="g4235">
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6317-7-3-5-2);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6319-8-6-9-3);stroke-width:0.74210644;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6317-7-3-5-2);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6319-8-6-9-3);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-4-4"
-       d="M 13.531084,7.5891404 H 26.567616 V 32.490428 H 13.531084 Z" />
+       d="m 13.5,9.5 21,0 0,28 -21,0 z" />
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3074);stroke-width:0.74210638;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3074);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-1-6-5"
-       d="M 14.310274,9.4115011 H 25.723213 V 31.605021 H 14.310274 Z" />
+       d="m 14.5,10.5 19,0 0,26 -19,0 z" />
   </g>
   <g
-     style="display:inline;opacity:0.75"
-     id="g6242-7"
-     transform="matrix(1.3415124,0,0,1.1682027,-2.8238249,3.7689044)">
+     style="opacity:0.75"
+     id="g4239">
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6767-4);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6769-8);stroke-width:0.79874772;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6767-4);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6769-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-4"
-       d="M 8.4471178,7.4764285 31.567616,7.5339975 V 33.490428 H 8.5779586 Z" />
+       d="M 8.4999999,12.5 39.5,12.5 l 0,30 -31.0000001,0 z" />
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3142);stroke-width:0.79874766;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3142);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-1-6"
-       d="M 9.1879971,8.3371525 30.82315,8.3639025 30.716871,32.629843 H 9.3634851 Z" />
+       d="m 9.5,13.5 29,0 0,28 -29,0 z" />
   </g>
   <g
      style="stroke:none"
-     transform="matrix(0.94266573,0,0,1.0825124,3.8753566,7.7461952)"
+     transform="matrix(0.94266573,0,0,1.0825124,3.8744474,7.7125718)"
      id="g6242">
     <rect
        width="35.007107"
-       height="25.865755"
+       height="25.865753"
        x="6.4971528"
-       y="7.6246748"
+       y="7.655735"
        id="rect4964"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4296);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.89594334;marker:none;enable-background:accumulate" />
     <rect
@@ -483,90 +462,91 @@
        id="rect4964-1"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:none;stroke-width:0.89594322;marker:none;enable-background:accumulate" />
   </g>
-  <path
-     d="m 25.953164,32.925651 a 6.9531641,6.9531641 0 1 1 -3.678141,-6.133572 l -3.275022,6.133572 z"
-     id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
-     id="path3475-4"
-     d="m 38.991411,38 v -1 h -2.21875 v 1 z m -2.65625,0 v -1 h -6.34375 v 1 z m 2.65625,-4 v -1 h -2.96875 v 1 z m -3.71875,0 v -1 h -2.34375 v 1 z m -2.9375,0 v -1 h -1.1875 v 1 z m -1.8125,0 v -1 h -2.15625 v 1 z m 8.46875,-4 v -1 h -3.28125 v 1 z m -3.875,0 v -1 h -1.65625 v 1 z m -2.21875,0 v -1 h -3.71875 v 1 z m 6.09375,-4 v -1 h -3.28125 v 1 z m -3.90625,0 v -1 h -2.34375 v 1 z m -2.9375,0 v -1 h -3.6875 v 1 z" />
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="path3475"
-     d="m 33.741411,20 v 1 h -5.734375 v -1 z m -6.390625,0 v 1 h -2.640625 v -1 z m -3.359375,0 v 1 h -3.75 v -1 z" />
   <rect
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3076-9);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-2"
-     y="16.5"
-     x="9.5"
+     y="16.466377"
+     x="9.4990911"
      height="27"
      width="33" />
   <path
-     d="M 26,32.070896 A 7,7 0 1 1 22.297083,25.89601 l -3.297082,6.174886 z"
+     id="path4160-6-1"
+     d="m 10,44.500039 33.5,0 0,-29.000078 -33.5,0"
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     id="path4530"
+     d="m 10,44.5 -5.5,0 c 0,-9.5 0.012787,-20.492234 0,-29 2.0403847,0 3.5366952,0 5.5,0" />
+  <path
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1-5"
+     d="m 9.5,43.5 -3.9999546,0 -9.08e-5,-27 L 9.5,16.5" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path4530-2"
+     d="m 10,44.5 -5.5,0 c 0,-10.5 0,-20.30602 0,-29 1.2519464,0 3.6110688,-0.01205 5.5,0" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path3475-4"
+     d="m 39,38 0,-1 -2,0 0,1 z m -3,0 0,-1 -6,0 0,1 z m 3,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -2,0 0,1 z m 9,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -4,0 0,1 z m 6,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -4,0 0,1 z" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+     id="path3475"
+     d="m 34,20 0,1 -6,0 0,-1 z m -7,0 0,1 -2,0 0,-1 z m -3,0 0,1 -4,0 0,-1 z" />
+  <path
+     d="m 25.906328,33.046835 a 6.9531641,6.9531641 0 1 1 -3.678141,-6.133572 l -3.275022,6.133572 z"
+     id="path3035-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+  <path
+     d="m 26,31.999998 a 7,7 0 1 1 -3.702917,-6.174886 l -3.297082,6.174886 z"
      id="path3035-2"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4304);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4308);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3964"
-     d="m 26,32.070896 c 1e-6,3.034983 -2.207377,5.936477 -5.132115,6.746111 -2.924739,0.809634 -6.309398,-0.543838 -7.870239,-3.146656 -0.01238,0.01123 6.002355,-3.599455 6.002355,-3.599455 z" />
-  <path
-     id="path4160-6-1"
-     d="M 10,44.533663 H 43.443854 V 15.533585 H 10"
-     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     id="path4530"
-     d="m 10.035786,44.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.343376 -0.102163,-1.025114 -0.203479,-1.511228 0,-9.107382 0,-18.214763 0,-27.322142 l 0.05947,-0.117935 0.14401,-0.0487 v 0 c 1.825936,0 3.4110786,0 5.2370056,0" />
-  <path
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect6741-1-5"
-     d="m 9.5,43.5 h -4 v -27 h 4" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path4530-2"
-     d="m 10.035786,44.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.343376 -0.102163,-1.025114 -0.203479,-1.511228 0,-9.107382 0,-18.214763 0,-27.322142 l 0.05947,-0.117935 0.14401,-0.0487 v 0 c 1.825936,0 3.4110786,0 5.2370056,0" />
+     d="m 25.990502,32.020234 c 1e-6,3.034983 -2.207377,5.936477 -5.132115,6.746111 -2.924739,0.809634 -6.309398,-0.543838 -7.870239,-3.146656 -0.01238,0.01123 6.002355,-3.599455 6.002355,-3.599455 z" />
   <path
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4306);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3962"
-     d="m 26,32.070896 c 1e-6,3.034983 -2.207377,5.936477 -5.132115,6.746111 -0.06833,-0.01187 -1.867884,-6.746111 -1.867884,-6.746111 z" />
+     d="M 25.999999,32.004126 C 26,35.039109 23.792622,37.940603 20.867884,38.750237 20.799554,38.738367 19,32.004126 19,32.004126 Z" />
   <g
-     id="g3896">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2883-1"
-       d="m 40.246148,42.353179 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
-    <path
-       style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410"
-       d="M 24.500001,45.5 44.500002,25.499999 V 45.5 Z m 9.333333,-4.000001 h 6.666667 v -6.666666 z" />
+     transform="translate(-3.0027871,-36)"
+     id="g4286">
+    <g
+       id="g4242"
+       transform="translate(2.9999998,36)">
+      <path
+         d="m 24.502894,45.5 20,-20.000001 0,20.000001 z m 9.33044,-4.000001 6.666667,0 0,-6.666666 z"
+         id="path3410"
+         style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
     <path
        style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3424"
-       d="M 27.450938,44.217765 43.244688,28.424014 V 44.217765 Z" />
+       d="M 29.888625,80.5 46.499907,63.908389 46.500093,80.5 Z" />
     <path
        style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3082"
-       d="M 29.5,44.346154 V 45.5" />
+       d="m 32.5,80.5 0,1" />
     <path
        style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3854"
-       d="M 34.5,44.346154 V 45.5" />
+       d="m 37.5,80.5 0,1" />
     <path
        style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3856"
-       d="M 39.5,44.346154 V 45.5" />
+       d="m 42.5,80.5 0,1" />
     <path
        style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3858"
-       d="M 44.50049,35.423077 H 43.5" />
+       d="M 47.50049,71.5 46.5,71.5" />
     <path
        style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3860"
-       d="M 44.50049,40.423077 H 43.5" />
+       d="M 47.50049,76.5 46.5,76.5" />
     <path
        style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3862"
-       d="M 44.50049,30.423077 H 43.5" />
+       d="M 47.50049,66.5 46.5,66.5" />
   </g>
 </svg>

--- a/mimes/48/x-office-presentation-template.svg
+++ b/mimes/48/x-office-presentation-template.svg
@@ -6,408 +6,391 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="48"
+   id="svg4954"
    height="48"
-   id="svg4954">
+   width="48"
+   version="1.1">
   <defs
      id="defs4956">
     <linearGradient
        id="linearGradient4204">
       <stop
-         offset="0"
+         id="stop4206"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4206" />
+         offset="0" />
       <stop
-         offset="0"
+         id="stop4208"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4208" />
+         offset="0.04111167" />
       <stop
-         offset="1"
+         id="stop4210"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4210" />
+         offset="1" />
       <stop
-         offset="1"
+         id="stop4212"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4212" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2">
       <stop
-         id="stop3602-1-25-9"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9" />
       <stop
-         id="stop3604-4-2-0"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0" />
     </linearGradient>
     <linearGradient
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188"
-       id="linearGradient6317-7-3-5-2"
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
+       gradientTransform="matrix(1.6122259,0,0,1.0767345,-8.9958873,-2.3045777)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-2.9300489)" />
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
+       id="linearGradient6317-7-3-5-2"
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275" />
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         id="stop3602-1-25-9-9-6-5-6"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9-9-6-5-6" />
       <stop
-         id="stop3604-4-2-0-2-4-2-1"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0-2-4-2-1" />
     </linearGradient>
     <linearGradient
-       x1="-51.786404"
-       y1="41.797989"
-       x2="-51.786404"
-       y2="17.555471"
-       id="linearGradient6319-8-6-9-3"
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
+       gradientTransform="matrix(1.3018673,0,0,1.0076631,86.786828,-3.504576)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-3.9956799)" />
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
+       id="linearGradient6319-8-6-9-3"
+       y2="17.555471"
+       x2="-51.786404"
+       y1="41.797989"
+       x1="-51.786404" />
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         id="stop3106-1-5-9-3-1-7-1"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-1-5-9-3-1-7-1" />
       <stop
-         id="stop3108-1-5-5-7-2-4-5"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-1-5-5-7-2-4-5" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         id="stop3213-0-0-8-1-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3213-0-0-8-1-1" />
       <stop
-         id="stop3215-1-8-0-6-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3215-1-8-0-6-4" />
     </linearGradient>
     <linearGradient
-       x1="24"
-       y1="14.203104"
-       x2="24"
-       y2="35.721317"
-       id="linearGradient3074"
+       gradientTransform="matrix(1.6688415,0,0,1.1110264,-9.3246018,-1.3795603)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3211-8-8-0-0-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0351164,0,0,0.9866216,-0.70291674,-2.1699512)" />
+       id="linearGradient3074"
+       y2="35.721317"
+       x2="24"
+       y1="14.203104"
+       x1="24" />
     <linearGradient
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188"
-       id="linearGradient6767-4"
-       xlink:href="#linearGradient3600-3-2-2-6-8"
+       gradientTransform="matrix(1.3415124,0,0,1.1169998,-3.4942248,1.4805927)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-1.9300489)" />
+       xlink:href="#linearGradient3600-3-2-2-6-8"
+       id="linearGradient6767-4"
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275" />
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         id="stop3602-1-25-9-9-7"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9-9-7" />
       <stop
-         id="stop3604-4-2-0-2-0"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0-2-0" />
     </linearGradient>
     <linearGradient
-       x1="-51.786404"
-       y1="41.797989"
-       x2="-51.786404"
-       y2="17.555471"
-       id="linearGradient6769-8"
-       xlink:href="#linearGradient3104-9-7-3-9-6"
+       gradientTransform="matrix(1.083267,0,0,1.0453454,76.205338,0.23571965)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-2.9956799)" />
+       xlink:href="#linearGradient3104-9-7-3-9-6"
+       id="linearGradient6769-8"
+       y2="17.555471"
+       x2="-51.786404"
+       y1="41.797989"
+       x1="-51.786404" />
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         id="stop3106-1-5-9-3-2"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-1-5-9-3-2" />
       <stop
-         id="stop3108-1-5-5-7-4"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-1-5-5-7-4" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         id="stop3213-0-0-3"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3213-0-0-3" />
       <stop
-         id="stop3215-1-8-9"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3215-1-8-9" />
     </linearGradient>
     <linearGradient
-       x1="24"
-       y1="14.203104"
-       x2="24"
-       y2="35.721317"
-       id="linearGradient3142"
-       xlink:href="#linearGradient3211-8-8-9"
+       gradientTransform="matrix(1.3654605,0,0,1.1625635,-3.3046597,2.0555681)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0178516,0,0,0.99517276,-0.35774965,-1.4378608)" />
+       xlink:href="#linearGradient3211-8-8-9"
+       id="linearGradient3142"
+       y2="35.721317"
+       x2="24"
+       y1="14.203104"
+       x1="24" />
     <linearGradient
        id="linearGradient5048-9">
       <stop
-         id="stop5050-2"
+         offset="0"
          style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
+         id="stop5050-2" />
       <stop
-         id="stop5056-8"
+         offset="0.5"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
+         id="stop5056-8" />
       <stop
-         id="stop5052-1"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop5052-1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060-2">
       <stop
-         id="stop5062-4"
+         offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop5062-4" />
       <stop
-         id="stop5064-7"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop5064-7" />
     </linearGradient>
-    <clipPath
-       id="clipPath3877">
-      <path
-         d="m 10.751345,-0.72641891 19.105374,0.0251951 0,10.48095741 -19.105374,-0.025202 z"
-         id="path3879"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    </clipPath>
     <linearGradient
        id="linearGradient3104-5">
       <stop
-         id="stop3106-9"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-9" />
       <stop
-         id="stop3108-9"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       x1="22.004084"
-       y1="63.217903"
-       x2="22.004084"
-       y2="25.646791"
-       id="linearGradient3091"
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-6.3543331,107.86293)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-6.3543329,107.86293)" />
+       id="linearGradient3091"
+       y2="25.646791"
+       x2="22.004084"
+       y1="63.217903"
+       x1="22.004084" />
     <linearGradient
-       x1="23.99999"
-       y1="6.1347566"
-       x2="23.99999"
-       y2="41.814804"
-       id="linearGradient3076"
+       gradientTransform="matrix(0.89189189,0,0,0.72972971,0.59369065,12.45287)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4204"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189189,0,0,0.72972971,0.59459989,12.486494)" />
+       id="linearGradient3076"
+       y2="41.860882"
+       x2="23.99999"
+       y1="6.1347566"
+       x1="23.99999" />
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.93203892,0,0,0.58970161,64.116407,13.241682)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient4420"
-       xlink:href="#linearGradient3104-6-6-1" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93203892,0,0,0.58970161,64.115498,13.208058)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         offset="0"
+         id="stop3106-3-2"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8-3"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-8-3" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       y2="41.754993"
-       x2="23.99999"
-       y1="6.1851358"
-       x1="23.99999"
-       gradientTransform="matrix(0.53513437,0,0,0.7297282,6.5567852,12.486532)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4356-5"
        id="linearGradient3076-9"
-       xlink:href="#linearGradient4356-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53513437,0,0,0.7297282,6.555876,12.452908)"
+       x1="23.970793"
+       y1="6.2312131"
+       x2="23.99999"
+       y2="41.754993" />
     <linearGradient
        id="linearGradient4356-5">
       <stop
-         id="stop4358-6"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4358-6" />
+      <stop
+         id="stop4360-9"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.03857623" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop4362-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop4364-6" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
+       id="radialGradient4173-5-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,151.99104,-49.885073)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9-9-0-2"
+         style="stop-color:#ffcd7d;stop-opacity:1"
          offset="0" />
       <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop4360-9" />
+         id="stop3752-3-7-4-0-32-8-923-0-7-8-8"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
       <stop
-         id="stop4362-4"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="1" />
+         id="stop3754-1-8-5-2-7-6-7-1-8-0-9"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
       <stop
-         id="stop4364-6"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3756-1-6-2-6-6-1-96-6-1-1-0"
+         style="stop-color:#ac441f;stop-opacity:1"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.02303995,0,0,0.01484079,28.360735,36.954493)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4218"
+       xlink:href="#linearGradient5060-2" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.02303994,0,0,0.01484079,19.622642,36.954493)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4221"
+       xlink:href="#linearGradient5060-2" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.06732488,0,0,0.01484079,-0.3411391,36.954463)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4224"
+       xlink:href="#linearGradient5048-9" />
+    <linearGradient
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275"
+       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-1.9300489)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4296"
+       xlink:href="#linearGradient3600-3-2-2" />
     <radialGradient
        r="12.671875"
        fy="9.9571075"
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,151.99195,-49.851449)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.43263,-56.201805)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient4173-5-5"
+       id="radialGradient4304"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.43262,-56.197677)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4306"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.42313,-56.181569)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4308"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9">
-      <stop
-         offset="0"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-9-0-2" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7-8-8" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-8-0-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-1-1-0" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient5060-2"
-       id="radialGradient4218"
+       gradientTransform="matrix(1.3333334,0,0,-1.3333334,-16.166666,70.166667)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02303995,0,0,0.01484079,28.360735,37.085015)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       xlink:href="#linearGradient5060-2"
-       id="radialGradient4221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.02303994,0,0,0.01484079,19.622642,37.085015)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       xlink:href="#linearGradient5048-9"
-       id="linearGradient4224"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06732488,0,0,0.01484079,-0.3411391,37.084985)"
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507" />
-    <linearGradient
-       xlink:href="#linearGradient3600-3-2-2"
-       id="linearGradient4296"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-1.9300489)"
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188" />
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
-       id="radialGradient4304"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.42404,-56.130907)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
-       id="radialGradient4306"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.42404,-56.130907)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
-       id="radialGradient4308"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.42404,-56.130907)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3907"
-       xlink:href="#linearGradient5060-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,36.963253)" />
-    <linearGradient
-       x1="42.783993"
-       y1="32.537422"
-       x2="38.972309"
-       y2="18.12406"
-       id="linearGradient3909"
        xlink:href="#linearGradient3412"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3333334,0,0,-1.3333334,-16.166666,70.166667)" />
+       id="linearGradient3909"
+       y2="18.12406"
+       x2="38.972309"
+       y1="32.537422"
+       x1="42.783993" />
     <linearGradient
        id="linearGradient3412">
       <stop
-         id="stop3414"
+         offset="0"
          style="stop-color:#fcfcfc;stop-opacity:1"
-         offset="0" />
+         id="stop3414" />
       <stop
-         id="stop3416"
+         offset="1"
          style="stop-color:#cbcdd9;stop-opacity:1"
-         offset="1" />
+         id="stop3416" />
     </linearGradient>
     <linearGradient
-       x1="40.105618"
-       y1="31.65719"
-       x2="33.811069"
-       y2="18.353575"
-       id="linearGradient3911"
-       xlink:href="#linearGradient3211-8-8-0-0-9"
+       gradientTransform="matrix(1.33,0,0,-1.33,-13.064999,106.02808)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.33,0,0,-1.33,-16.064999,70.028077)" />
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       id="linearGradient3911"
+       y2="18.353575"
+       x2="33.811069"
+       y1="31.65719"
+       x1="40.105618" />
   </defs>
   <metadata
      id="metadata4959">
@@ -422,150 +405,148 @@
     </rdf:RDF>
   </metadata>
   <rect
-     style="opacity:0.3;fill:url(#linearGradient4224);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2879"
-     y="42.526329"
-     x="5.7380605"
+     width="36.50787"
      height="3.6041925"
-     width="36.50787" />
+     x="5.7380605"
+     y="42.395809"
+     id="rect2879"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4224);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="opacity:0.3;fill:url(#radialGradient4218);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     d="m 42.246,42.395964 c 0,0 0,3.603993 0,3.603993 1.1865,0.0067 2.86838,-0.807471 2.86838,-1.802229 0,-0.994755 -1.324045,-1.801763 -2.86838,-1.801764 z"
      id="path2883"
-     d="m 42.246,42.526486 c 0,0 0,3.603993 0,3.603993 1.1865,0.0067 2.86838,-0.807471 2.86838,-1.802229 0,-0.994755 -1.324045,-1.801763 -2.86838,-1.801764 z" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4218);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="opacity:0.3;fill:url(#radialGradient4221);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     d="m 5.7373795,42.395964 c 0,0 0,3.603993 0,3.603993 C 4.5508793,46.006686 2.869,45.192486 2.869,44.197728 c 0,-0.994755 1.3240446,-1.801763 2.8683795,-1.801764 z"
      id="path2881"
-     d="m 5.7373795,42.526486 c 0,0 0,3.603993 0,3.603993 C 4.5508793,46.137208 2.869,45.323008 2.869,44.32825 c 0,-0.994755 1.3240446,-1.801763 2.8683795,-1.801764 z" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4221);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <g
-     transform="matrix(1.6122259,0,0,1.1260917,-8.2886536,1.0154672)"
-     clip-path="url(#clipPath3877)"
-     id="g6242-7-5"
-     style="opacity:0.5;display:inline">
+     style="opacity:0.5"
+     id="g4235">
     <path
-       d="m 13.531084,7.5891404 13.036532,0 0,24.9012876 -13.036532,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6317-7-3-5-2);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6319-8-6-9-3);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-4-4"
-       style="color:#000000;fill:url(#linearGradient6317-7-3-5-2);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6319-8-6-9-3);stroke-width:0.74210644;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 13.5,9.5 21,0 0,28 -21,0 z" />
     <path
-       d="m 14.310274,9.4115011 11.412939,0 0,22.1935199 -11.412939,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3074);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-1-6-5"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3074);stroke-width:0.74210638;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 14.5,10.5 19,0 0,26 -19,0 z" />
   </g>
   <g
-     transform="matrix(1.3415124,0,0,1.1682027,-2.8238249,3.7689044)"
-     id="g6242-7"
-     style="opacity:0.75;display:inline">
+     style="opacity:0.75"
+     id="g4239">
     <path
-       d="m 8.4471178,7.4764285 23.1204982,0.057569 0,25.9564305 -22.9896574,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6767-4);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6769-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-4"
-       style="color:#000000;fill:url(#linearGradient6767-4);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6769-8);stroke-width:0.79874772;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="M 8.4999999,12.5 39.5,12.5 l 0,30 -31.0000001,0 z" />
     <path
-       d="m 9.1879971,8.3371525 21.6351529,0.02675 -0.106279,24.2659405 -21.3533859,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3142);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-1-6"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3142);stroke-width:0.79874766;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 9.5,13.5 29,0 0,28 -29,0 z" />
   </g>
   <g
-     id="g6242"
-     transform="matrix(0.94266573,0,0,1.0825124,3.8753566,7.7461952)"
-     style="stroke:none">
+     style="stroke:none"
+     transform="matrix(0.94266573,0,0,1.0825124,3.8744474,7.7125718)"
+     id="g6242">
     <rect
-       style="color:#000000;fill:url(#linearGradient4296);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.89594334;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4964"
-       y="7.6246748"
+       width="35.007107"
+       height="25.865753"
        x="6.4971528"
-       height="25.865755"
-       width="35.007107" />
+       y="7.655735"
+       id="rect4964"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4296);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.89594334;marker:none;enable-background:accumulate" />
     <rect
-       style="opacity:0.6;color:#000000;fill:none;stroke:none;stroke-width:0.89594322;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4964-1"
-       y="8.5135088"
-       x="7.3406267"
+       width="33.299141"
        height="24.083063"
-       width="33.299141" />
+       x="7.3406267"
+       y="8.5135088"
+       id="rect4964-1"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:none;stroke-width:0.89594322;marker:none;enable-background:accumulate" />
   </g>
   <path
-     style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 38.906328,33.046835 a 6.9531641,6.9531641 0 1 1 -3.678141,-6.133572 l -3.275022,6.133572 z"
      id="path3035-5"
-     d="m 38.944575,32.925651 a 6.9531641,6.9531641 0 1 1 -3.678141,-6.133572 l -3.275022,6.133572 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
   <path
-     d="m 12,38 0,-1 2.21875,0 0,1 z m 2.65625,0 0,-1 L 21,37 21,38 z M 12,34 l 0,-1 2.96875,0 0,1 z m 3.71875,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 1.1875,0 0,1 z m 1.8125,0 0,-1 2.15625,0 0,1 z M 12,30 l 0,-1 3.28125,0 0,1 z m 3.875,0 0,-1 1.65625,0 0,1 z m 2.21875,0 0,-1 3.71875,0 0,1 z M 12,26 l 0,-1 3.28125,0 0,1 z m 3.90625,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 3.6875,0 0,1 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path3475-4"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+     d="m 12,38 0,-1 2,0 0,1 z m 3,0 0,-1 6,0 0,1 z m -3,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 1,0 0,1 z m 2,0 0,-1 2,0 0,1 z m -9,-4 0,-1 3,0 0,1 z m 4,0 0,-1 1,0 0,1 z m 2,0 0,-1 4,0 0,1 z m -6,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 4,0 0,1 z" />
   <path
-     d="m 17.25,20 0,1 5.734375,0 0,-1 z m 6.390625,0 0,1 2.640625,0 0,-1 z M 27,20 l 0,1 3.75,0 0,-1 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
      id="path3475"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.28000004;color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+     d="m 17,20 0,1 6,0 0,-1 z m 7,0 0,1 2,0 0,-1 z m 3,0 0,1 4,0 0,-1 z" />
   <rect
-     width="33"
-     height="27"
-     x="9.5"
-     y="16.5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3076-9);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-2"
-     style="color:#000000;fill:none;stroke:url(#linearGradient3076-9);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     y="16.466377"
+     x="9.4990911"
+     height="27"
+     width="33" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4304);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 39,31.999998 a 7,7 0 1 1 -3.702917,-6.174886 l -3.297082,6.174886 z"
      id="path3035-2"
-     d="M 38.991411,32.070896 A 7,7 0 1 1 35.288494,25.89601 l -3.297082,6.174886 z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4304);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
-     d="m 38.991411,32.070896 c 10e-7,3.034983 -2.207377,5.936477 -5.132115,6.746111 -2.924739,0.809634 -6.309398,-0.543838 -7.870239,-3.146656 -0.01238,0.01123 6.002355,-3.599455 6.002355,-3.599455 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4308);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3964"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4308);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="m 38.990502,32.020234 c 10e-7,3.034983 -2.207377,5.936477 -5.132115,6.746111 -2.924739,0.809634 -6.309398,-0.543838 -7.870239,-3.146656 -0.01238,0.01123 6.002355,-3.599455 6.002355,-3.599455 z" />
   <path
-     style="fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-     d="m 10,44.533663 33.443854,0 0,-29.000078 -33.443854,0"
-     id="path4160-6-1" />
+     id="path4160-6-1"
+     d="m 10,44.500039 33.5,0 0,-29.000078 -33.5,0"
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 10.035786,44.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.343376 -0.102163,-1.025114 -0.203479,-1.511228 0,-9.107382 0,-18.214763 0,-27.322142 l 0.05947,-0.117935 0.14401,-0.0487 0,0 c 1.825936,0 3.4110786,0 5.2370056,0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530"
-     style="color:#000000;fill:url(#radialGradient4173-5-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 10,44.5 -5.5,0 c 0,-9.5 0.012787,-20.492234 0,-29 2.0403847,0 3.5366952,0 5.5,0" />
   <path
-     d="m 9.5,43.5 -4,0 0,-27 4,0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect6741-1-5"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="m 9.5,43.5 -3.9999546,0 -9.08e-5,-27 L 9.5,16.5" />
   <path
-     d="m 10.035786,44.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.343376 -0.102163,-1.025114 -0.203479,-1.511228 0,-9.107382 0,-18.214763 0,-27.322142 l 0.05947,-0.117935 0.14401,-0.0487 0,0 c 1.825936,0 3.4110786,0 5.2370056,0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path4530-2"
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 10,44.5 -5.5,0 c 0,-10.5 0,-20.30602 0,-29 1.2519464,0 3.6110688,-0.01205 5.5,0" />
   <path
-     d="m 38.991411,32.070896 c 10e-7,3.034983 -2.207377,5.936477 -5.132115,6.746111 -0.06833,-0.01187 -1.867884,-6.746111 -1.867884,-6.746111 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4306);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3962"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4306);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="M 38.999999,32.004126 C 39,35.039109 36.792622,37.940603 33.867884,38.750237 33.799554,38.738367 32,32.004126 32,32.004126 Z" />
   <g
-     id="g3896">
+     transform="translate(-3.0027871,-36)"
+     id="g4286">
+    <g
+       id="g4242"
+       transform="translate(2.9999998,36)">
+      <path
+         d="m 24.502894,45.5 20,-20.000001 0,20.000001 z m 9.33044,-4.000001 6.666667,0 0,-6.666666 z"
+         id="path3410"
+         style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
     <path
-       d="m 40.246148,42.353179 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
-       id="path2883-1"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-    <path
-       d="m 24.500001,45.5 20.000001,-20.000001 0,20.000001 -20.000001,0 z m 9.333333,-4.000001 6.666667,0 0,-6.666666 -6.666667,6.666666 z"
-       id="path3410"
-       style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       d="m 27.450938,44.217765 15.79375,-15.793751 0,15.793751 -15.79375,0 z"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3424"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       d="M 29.888625,80.5 46.499907,63.908389 46.500093,80.5 Z" />
     <path
-       d="M 29.5,44.346154 29.5,45.5"
+       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3082"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       d="m 32.5,80.5 0,1" />
     <path
-       d="M 34.5,44.346154 34.5,45.5"
+       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3854"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       d="m 37.5,80.5 0,1" />
     <path
-       d="M 39.5,44.346154 39.5,45.5"
+       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3856"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       d="m 42.5,80.5 0,1" />
     <path
-       d="m 44.50049,35.423077 -1.00049,0"
+       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3858"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       d="M 47.50049,71.5 46.5,71.5" />
     <path
-       d="m 44.50049,40.423077 -1.00049,0"
+       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3860"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       d="M 47.50049,76.5 46.5,76.5" />
     <path
-       d="m 44.50049,30.423077 -1.00049,0"
+       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path3862"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       d="M 47.50049,66.5 46.5,66.5" />
   </g>
 </svg>

--- a/mimes/48/x-office-presentation.svg
+++ b/mimes/48/x-office-presentation.svg
@@ -6,400 +6,362 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   width="48"
-   height="48"
    id="svg4954"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="application-vnd.ms-powerpoint.presentation.macroEnabled.12.svg">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1440"
-     inkscape:window-height="844"
-     id="namedview149"
-     showgrid="true"
-     inkscape:zoom="13.333333"
-     inkscape:cx="36.5625"
-     inkscape:cy="24"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4954">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4315" />
-  </sodipodi:namedview>
+   height="48"
+   width="48"
+   version="1.1">
   <defs
      id="defs4956">
     <linearGradient
        id="linearGradient4204">
       <stop
-         offset="0"
+         id="stop4206"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4206" />
+         offset="0" />
       <stop
-         offset="0"
+         id="stop4208"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4208" />
+         offset="0.04111167" />
       <stop
-         offset="1"
+         id="stop4210"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4210" />
+         offset="1" />
       <stop
-         offset="1"
+         id="stop4212"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4212" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2">
       <stop
-         id="stop3602-1-25-9"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9" />
       <stop
-         id="stop3604-4-2-0"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0" />
     </linearGradient>
     <linearGradient
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188"
-       id="linearGradient6317-7-3-5-2"
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
+       gradientTransform="matrix(1.6122259,0,0,1.0767345,-8.9958873,-2.3045777)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-2.9300489)" />
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
+       id="linearGradient6317-7-3-5-2"
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275" />
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         id="stop3602-1-25-9-9-6-5-6"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9-9-6-5-6" />
       <stop
-         id="stop3604-4-2-0-2-4-2-1"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0-2-4-2-1" />
     </linearGradient>
     <linearGradient
-       x1="-51.786404"
-       y1="41.797989"
-       x2="-51.786404"
-       y2="17.555471"
-       id="linearGradient6319-8-6-9-3"
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
+       gradientTransform="matrix(1.3018673,0,0,1.0076631,86.786828,-3.504576)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-3.9956799)" />
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
+       id="linearGradient6319-8-6-9-3"
+       y2="17.555471"
+       x2="-51.786404"
+       y1="41.797989"
+       x1="-51.786404" />
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         id="stop3106-1-5-9-3-1-7-1"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-1-5-9-3-1-7-1" />
       <stop
-         id="stop3108-1-5-5-7-2-4-5"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-1-5-5-7-2-4-5" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         id="stop3213-0-0-8-1-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3213-0-0-8-1-1" />
       <stop
-         id="stop3215-1-8-0-6-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3215-1-8-0-6-4" />
     </linearGradient>
     <linearGradient
-       x1="24"
-       y1="14.203104"
-       x2="24"
-       y2="35.721317"
-       id="linearGradient3074"
+       gradientTransform="matrix(1.6688415,0,0,1.1110264,-9.3246018,-1.3795603)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3211-8-8-0-0-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0351164,0,0,0.9866216,-0.70291674,-2.1699512)" />
+       id="linearGradient3074"
+       y2="35.721317"
+       x2="24"
+       y1="14.203104"
+       x1="24" />
     <linearGradient
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188"
-       id="linearGradient6767-4"
-       xlink:href="#linearGradient3600-3-2-2-6-8"
+       gradientTransform="matrix(1.3415124,0,0,1.1169998,-3.4942248,1.4805927)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-1.9300489)" />
+       xlink:href="#linearGradient3600-3-2-2-6-8"
+       id="linearGradient6767-4"
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275" />
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         id="stop3602-1-25-9-9-7"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9-9-7" />
       <stop
-         id="stop3604-4-2-0-2-0"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0-2-0" />
     </linearGradient>
     <linearGradient
-       x1="-51.786404"
-       y1="41.797989"
-       x2="-51.786404"
-       y2="17.555471"
-       id="linearGradient6769-8"
-       xlink:href="#linearGradient3104-9-7-3-9-6"
+       gradientTransform="matrix(1.083267,0,0,1.0453454,76.205338,0.23571965)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,58.911175,-2.9956799)" />
+       xlink:href="#linearGradient3104-9-7-3-9-6"
+       id="linearGradient6769-8"
+       y2="17.555471"
+       x2="-51.786404"
+       y1="41.797989"
+       x1="-51.786404" />
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         id="stop3106-1-5-9-3-2"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-1-5-9-3-2" />
       <stop
-         id="stop3108-1-5-5-7-4"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-1-5-5-7-4" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         id="stop3213-0-0-3"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3213-0-0-3" />
       <stop
-         id="stop3215-1-8-9"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3215-1-8-9" />
     </linearGradient>
     <linearGradient
-       x1="24"
-       y1="14.203104"
-       x2="24"
-       y2="35.721317"
-       id="linearGradient3142"
-       xlink:href="#linearGradient3211-8-8-9"
+       gradientTransform="matrix(1.3654605,0,0,1.1625635,-3.3046597,2.0555681)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0178516,0,0,0.99517276,-0.35774965,-1.4378608)" />
+       xlink:href="#linearGradient3211-8-8-9"
+       id="linearGradient3142"
+       y2="35.721317"
+       x2="24"
+       y1="14.203104"
+       x1="24" />
     <linearGradient
        id="linearGradient5048-9">
       <stop
-         id="stop5050-2"
+         offset="0"
          style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
+         id="stop5050-2" />
       <stop
-         id="stop5056-8"
+         offset="0.5"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
+         id="stop5056-8" />
       <stop
-         id="stop5052-1"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop5052-1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060-2">
       <stop
-         id="stop5062-4"
+         offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop5062-4" />
       <stop
-         id="stop5064-7"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop5064-7" />
     </linearGradient>
-    <clipPath
-       id="clipPath3877">
-      <path
-         d="m 10.751345,-0.72641891 19.105374,0.0251951 0,10.48095741 -19.105374,-0.025202 z"
-         id="path3879"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    </clipPath>
     <linearGradient
        id="linearGradient3104-5">
       <stop
-         id="stop3106-9"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-9" />
       <stop
-         id="stop3108-9"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       x1="22.004084"
-       y1="63.217903"
-       x2="22.004084"
-       y2="25.646791"
-       id="linearGradient3091"
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-6.3543331,107.86293)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-6.3543329,107.86293)" />
+       id="linearGradient3091"
+       y2="25.646791"
+       x2="22.004084"
+       y1="63.217903"
+       x1="22.004084" />
     <linearGradient
-       x1="23.99999"
-       y1="6.1347566"
-       x2="23.99999"
-       y2="41.814804"
-       id="linearGradient3076"
+       gradientTransform="matrix(0.89189189,0,0,0.72972971,0.59369065,12.45287)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4204"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189189,0,0,0.72972971,0.59459989,12.486494)" />
+       id="linearGradient3076"
+       y2="41.860882"
+       x2="23.99999"
+       y1="6.1347566"
+       x1="23.99999" />
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.93203892,0,0,0.58970161,64.116407,13.241682)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient4420"
-       xlink:href="#linearGradient3104-6-6-1" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93203892,0,0,0.58970161,64.115498,13.208058)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         offset="0"
+         id="stop3106-3-2"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8-3"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-8-3" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       y2="41.754993"
-       x2="23.99999"
-       y1="6.1851358"
-       x1="23.99999"
-       gradientTransform="matrix(0.53513437,0,0,0.7297282,6.5567852,12.486532)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4356-5"
        id="linearGradient3076-9"
-       xlink:href="#linearGradient4356-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53513437,0,0,0.7297282,6.555876,12.452908)"
+       x1="23.970793"
+       y1="6.2312131"
+       x2="23.99999"
+       y2="41.754993" />
     <linearGradient
        id="linearGradient4356-5">
       <stop
-         id="stop4358-6"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4358-6" />
+      <stop
+         id="stop4360-9"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.03857623" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop4362-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop4364-6" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
+       id="radialGradient4173-5-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,151.99104,-49.885073)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9-9-0-2"
+         style="stop-color:#ffcd7d;stop-opacity:1"
          offset="0" />
       <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop4360-9" />
+         id="stop3752-3-7-4-0-32-8-923-0-7-8-8"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
       <stop
-         id="stop4362-4"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="1" />
+         id="stop3754-1-8-5-2-7-6-7-1-8-0-9"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
       <stop
-         id="stop4364-6"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3756-1-6-2-6-6-1-96-6-1-1-0"
+         style="stop-color:#ac441f;stop-opacity:1"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.02303995,0,0,0.01484079,28.360735,36.954493)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4218"
+       xlink:href="#linearGradient5060-2" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.02303994,0,0,0.01484079,19.622642,36.954493)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4221"
+       xlink:href="#linearGradient5060-2" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.06732488,0,0,0.01484079,-0.3411391,36.954463)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4224"
+       xlink:href="#linearGradient5048-9" />
+    <linearGradient
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275"
+       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-1.9300489)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4296"
+       xlink:href="#linearGradient3600-3-2-2" />
     <radialGradient
        r="12.671875"
        fy="9.9571075"
        fx="6.2001843"
        cy="9.9571075"
        cx="6.7304144"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,151.99195,-49.851449)"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.43263,-56.201805)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient4173-5-5"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9">
-      <stop
-         offset="0"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-9-0-2" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7-8-8" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-8-0-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-1-1-0" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient5060-2"
-       id="radialGradient4218"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02303995,0,0,0.01484079,28.360735,37.085015)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       xlink:href="#linearGradient5060-2"
-       id="radialGradient4221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.02303994,0,0,0.01484079,19.622642,37.085015)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       xlink:href="#linearGradient5048-9"
-       id="linearGradient4224"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06732488,0,0,0.01484079,-0.3411391,37.084985)"
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507" />
-    <linearGradient
-       xlink:href="#linearGradient3600-3-2-2"
-       id="linearGradient4296"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-0.49905668,-1.9300489)"
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
        id="radialGradient4304"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.42404,-56.130907)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.43262,-56.197677)"
+       gradientUnits="userSpaceOnUse"
        id="radialGradient4306"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.42404,-56.130907)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9"
-       id="radialGradient4308"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.42404,-56.130907)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
+       r="12.671875"
        fy="9.9571075"
-       r="12.671875" />
+       fx="6.2001843"
+       cy="9.9571075"
+       cx="6.7304144"
+       gradientTransform="matrix(0,7.1534309,-12.55688,0,212.42313,-56.181569)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4308"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8-9" />
   </defs>
   <metadata
      id="metadata4959">
@@ -414,114 +376,108 @@
     </rdf:RDF>
   </metadata>
   <rect
-     style="opacity:0.3;fill:url(#linearGradient4224);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2879"
-     y="42.526329"
-     x="5.7380605"
+     width="36.50787"
      height="3.6041925"
-     width="36.50787" />
+     x="5.7380605"
+     y="42.395809"
+     id="rect2879"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4224);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="opacity:0.3;fill:url(#radialGradient4218);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     d="m 42.246,42.395964 c 0,0 0,3.603993 0,3.603993 1.1865,0.0067 2.86838,-0.807471 2.86838,-1.802229 0,-0.994755 -1.324045,-1.801763 -2.86838,-1.801764 z"
      id="path2883"
-     d="m 42.246,42.526486 c 0,0 0,3.603993 0,3.603993 1.1865,0.0067 2.86838,-0.807471 2.86838,-1.802229 0,-0.994755 -1.324045,-1.801763 -2.86838,-1.801764 z" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4218);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="opacity:0.3;fill:url(#radialGradient4221);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     d="m 5.7373795,42.395964 c 0,0 0,3.603993 0,3.603993 C 4.5508793,46.006686 2.869,45.192486 2.869,44.197728 c 0,-0.994755 1.3240446,-1.801763 2.8683795,-1.801764 z"
      id="path2881"
-     d="m 5.7373795,42.526486 c 0,0 0,3.603993 0,3.603993 C 4.5508793,46.137208 2.869,45.323008 2.869,44.32825 c 0,-0.994755 1.3240446,-1.801763 2.8683795,-1.801764 z" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4221);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <g
-     transform="matrix(1.6122259,0,0,1.1260917,-8.2886536,1.0154672)"
-     clip-path="url(#clipPath3877)"
-     id="g6242-7-5"
-     style="opacity:0.5;display:inline">
+     style="opacity:0.5"
+     id="g4235">
     <path
-       d="m 13.531084,7.5891404 13.036532,0 0,24.9012876 -13.036532,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6317-7-3-5-2);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6319-8-6-9-3);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-4-4"
-       style="color:#000000;fill:url(#linearGradient6317-7-3-5-2);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6319-8-6-9-3);stroke-width:0.74210644;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 13.5,9.5 21,0 0,28 -21,0 z" />
     <path
-       d="m 14.310274,9.4115011 11.412939,0 0,22.1935199 -11.412939,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3074);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-1-6-5"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3074);stroke-width:0.74210638;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 14.5,10.5 19,0 0,26 -19,0 z" />
   </g>
   <g
-     transform="matrix(1.3415124,0,0,1.1682027,-2.8238249,3.7689044)"
-     id="g6242-7"
-     style="opacity:0.75;display:inline">
+     style="opacity:0.75"
+     id="g4239">
     <path
-       d="m 8.4471178,7.4764285 23.1204982,0.057569 0,25.9564305 -22.9896574,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6767-4);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6769-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-4"
-       style="color:#000000;fill:url(#linearGradient6767-4);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6769-8);stroke-width:0.79874772;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="M 8.4999999,12.5 39.5,12.5 l 0,30 -31.0000001,0 z" />
     <path
-       d="m 9.1879971,8.3371525 21.6351529,0.02675 -0.106279,24.2659405 -21.3533859,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3142);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4964-1-6"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3142);stroke-width:0.79874766;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 9.5,13.5 29,0 0,28 -29,0 z" />
   </g>
   <g
-     id="g6242"
-     transform="matrix(0.94266573,0,0,1.0825124,3.8753566,7.7461952)"
-     style="stroke:none">
+     style="stroke:none"
+     transform="matrix(0.94266573,0,0,1.0825124,3.8744474,7.7125718)"
+     id="g6242">
     <rect
-       style="color:#000000;fill:url(#linearGradient4296);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.89594334;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4964"
-       y="7.6246748"
+       width="35.007107"
+       height="25.865753"
        x="6.4971528"
-       height="25.865755"
-       width="35.007107" />
+       y="7.655735"
+       id="rect4964"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4296);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.89594334;marker:none;enable-background:accumulate" />
     <rect
-       style="opacity:0.6;color:#000000;fill:none;stroke:none;stroke-width:0.89594322;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4964-1"
-       y="8.5135088"
-       x="7.3406267"
+       width="33.299141"
        height="24.083063"
-       width="33.299141" />
+       x="7.3406267"
+       y="8.5135088"
+       id="rect4964-1"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:none;stroke-width:0.89594322;marker:none;enable-background:accumulate" />
   </g>
   <path
-     style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 38.906328,33.046835 a 6.9531641,6.9531641 0 1 1 -3.678141,-6.133572 l -3.275022,6.133572 z"
      id="path3035-5"
-     d="m 38.944575,32.925651 a 6.9531641,6.9531641 0 1 1 -3.678141,-6.133572 l -3.275022,6.133572 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
   <path
-     d="m 12,38 0,-1 2.21875,0 0,1 z m 2.65625,0 0,-1 L 21,37 21,38 z M 12,34 l 0,-1 2.96875,0 0,1 z m 3.71875,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 1.1875,0 0,1 z m 1.8125,0 0,-1 2.15625,0 0,1 z M 12,30 l 0,-1 3.28125,0 0,1 z m 3.875,0 0,-1 1.65625,0 0,1 z m 2.21875,0 0,-1 3.71875,0 0,1 z M 12,26 l 0,-1 3.28125,0 0,1 z m 3.90625,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 3.6875,0 0,1 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
      id="path3475-4"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+     d="m 12,38 0,-1 2,0 0,1 z m 3,0 0,-1 6,0 0,1 z m -3,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 1,0 0,1 z m 2,0 0,-1 2,0 0,1 z m -9,-4 0,-1 3,0 0,1 z m 4,0 0,-1 1,0 0,1 z m 2,0 0,-1 4,0 0,1 z m -6,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 4,0 0,1 z" />
   <path
-     d="m 17.25,20 0,1 5.734375,0 0,-1 z m 6.390625,0 0,1 2.640625,0 0,-1 z M 27,20 l 0,1 3.75,0 0,-1 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
      id="path3475"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.28000004;color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+     d="m 17,20 0,1 6,0 0,-1 z m 7,0 0,1 2,0 0,-1 z m 3,0 0,1 4,0 0,-1 z" />
   <rect
-     width="33"
-     height="27"
-     x="9.5"
-     y="16.5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3076-9);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1-2"
-     style="color:#000000;fill:none;stroke:url(#linearGradient3076-9);stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     y="16.466377"
+     x="9.4990911"
+     height="27"
+     width="33" />
   <path
-     inkscape:connector-curvature="0"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4304);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 39,31.999998 a 7,7 0 1 1 -3.702917,-6.174886 l -3.297082,6.174886 z"
      id="path3035-2"
-     d="M 38.991411,32.070896 A 7,7 0 1 1 35.288494,25.89601 l -3.297082,6.174886 z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4304);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
-     inkscape:connector-curvature="0"
-     d="m 38.991411,32.070896 c 10e-7,3.034983 -2.207377,5.936477 -5.132115,6.746111 -2.924739,0.809634 -6.309398,-0.543838 -7.870239,-3.146656 -0.01238,0.01123 6.002355,-3.599455 6.002355,-3.599455 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4308);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3964"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4308);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="m 38.990502,32.020234 c 10e-7,3.034983 -2.207377,5.936477 -5.132115,6.746111 -2.924739,0.809634 -6.309398,-0.543838 -7.870239,-3.146656 -0.01238,0.01123 6.002355,-3.599455 6.002355,-3.599455 z" />
   <path
-     style="fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-     d="m 10,44.533663 33.443854,0 0,-29.000078 -33.443854,0"
-     id="path4160-6-1" />
+     id="path4160-6-1"
+     d="m 10,44.500039 33.5,0 0,-29.000078 -33.5,0"
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 10.035786,44.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.343376 -0.102163,-1.025114 -0.203479,-1.511228 0,-9.107382 0,-18.214763 0,-27.322142 l 0.05947,-0.117935 0.14401,-0.0487 0,0 c 1.825936,0 3.4110786,0 5.2370056,0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
      id="path4530"
-     style="color:#000000;fill:url(#radialGradient4173-5-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 10,44.5 -5.5,0 c 0,-9.5 0.012787,-20.492234 0,-29 2.0403847,0 3.5366952,0 5.5,0" />
   <path
-     d="m 9.5,43.5 -4,0 0,-27 4,0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect6741-1-5"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="m 9.5,43.5 -3.9999546,0 -9.08e-5,-27 L 9.5,16.5" />
   <path
-     d="m 10.035786,44.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.343376 -0.102163,-1.025114 -0.203479,-1.511228 0,-9.107382 0,-18.214763 0,-27.322142 l 0.05947,-0.117935 0.14401,-0.0487 0,0 c 1.825936,0 3.4110786,0 5.2370056,0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path4530-2"
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 10,44.5 -5.5,0 c 0,-10.5 0,-20.30602 0,-29 1.2519464,0 3.6110688,-0.01205 5.5,0" />
   <path
-     inkscape:connector-curvature="0"
-     d="m 38.991411,32.070896 c 10e-7,3.034983 -2.207377,5.936477 -5.132115,6.746111 -0.06833,-0.01187 -1.867884,-6.746111 -1.867884,-6.746111 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4306);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3962"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4306);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="M 38.999999,32.004126 C 39,35.039109 36.792622,37.940603 33.867884,38.750237 33.799554,38.738367 32,32.004126 32,32.004126 Z" />
 </svg>

--- a/mimes/64/x-office-presentation-rtl.svg
+++ b/mimes/64/x-office-presentation-rtl.svg
@@ -6,7 +6,6 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 64 64"
    id="svg4954"
    height="64"
    width="64"
@@ -121,7 +120,7 @@
          id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,73.354333,109.86293)"
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,73.354333,114.86293)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-5"
        id="linearGradient3091"
@@ -133,7 +132,7 @@
        xlink:href="#linearGradient4356"
        id="linearGradient3076"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,8.7027135)"
+       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,13.702713)"
        x1="23.99999"
        y1="5.9472284"
        x2="23.99999"
@@ -143,7 +142,7 @@
        x2="25.132275"
        y1="15.284525"
        x1="25.132275"
-       gradientTransform="matrix(1.456847,0,0,1.4786648,-1.1924073,-0.77586567)"
+       gradientTransform="matrix(1.456847,0,0,1.4786648,-1.1924073,4.2241341)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3917"
        xlink:href="#linearGradient3600-3-2-2" />
@@ -152,7 +151,7 @@
        x2="24"
        y1="14.203104"
        x1="24"
-       gradientTransform="matrix(2.1170825,0,0,1.1675323,-10.354736,0.0319621)"
+       gradientTransform="matrix(2.1170825,0,0,1.1675323,-10.354736,5.0319619)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3928"
        xlink:href="#linearGradient3211-8-8-9" />
@@ -161,7 +160,7 @@
        x2="25.132275"
        y1="15.284525"
        x1="25.132275"
-       gradientTransform="matrix(2.0328317,0,0,1.1210596,-9.6861059,-0.52865063)"
+       gradientTransform="matrix(2.0328317,0,0,1.1210596,-9.6861059,4.4713491)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3931"
        xlink:href="#linearGradient3600-3-2-2-6-8" />
@@ -170,7 +169,7 @@
        x2="-51.786404"
        y1="41.797989"
        x1="-51.786404"
-       gradientTransform="matrix(1.6415049,0,0,1.0491448,111.08489,-1.7780482)"
+       gradientTransform="matrix(1.6415049,0,0,1.0491448,111.08489,3.2219516)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3933"
        xlink:href="#linearGradient3104-9-7-3-9-6" />
@@ -179,7 +178,7 @@
        x2="24"
        y1="14.203104"
        x1="24"
-       gradientTransform="matrix(2.9929997,0,0,0.11114027,-27.91011,7.1953799)"
+       gradientTransform="matrix(2.9929997,0,0,0.11114027,-27.91011,12.19538)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3936"
        xlink:href="#linearGradient3211-8-8-0-0-9" />
@@ -188,7 +187,7 @@
        x2="25.132275"
        y1="15.284525"
        x1="25.132275"
-       gradientTransform="matrix(2.6847692,0,0,0.1535966,-23.167729,5.8101858)"
+       gradientTransform="matrix(2.6847692,0,0,0.1535966,-23.167729,10.810186)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3939"
        xlink:href="#linearGradient3600-3-2-2-6-5-8-7" />
@@ -197,7 +196,7 @@
        x2="-51.786404"
        y1="41.797989"
        x1="-51.786404"
-       gradientTransform="matrix(2.1679425,0,0,0.14374353,136.33503,5.6390056)"
+       gradientTransform="matrix(2.1679425,0,0,0.14374353,136.33503,10.639005)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3941"
        xlink:href="#linearGradient3104-9-7-3-9-2-6-2" />
@@ -206,7 +205,7 @@
        x2="22.004084"
        y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,73.354333,125.86293)"
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,73.354333,130.86293)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3968"
        xlink:href="#linearGradient3104-5" />
@@ -280,7 +279,7 @@
        x2="22.004084"
        y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,62.166833,109.86293)"
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,62.166833,114.86293)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4180"
        xlink:href="#linearGradient3104-5" />
@@ -289,7 +288,7 @@
        x2="22.004084"
        y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(-1.3394176,0,0,1.9826305,61.354333,-34.862932)"
+       gradientTransform="matrix(-1.3394176,0,0,1.9826305,61.354333,-29.862932)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4185"
        xlink:href="#linearGradient3104-5" />
@@ -316,7 +315,7 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8"
        id="radialGradient4173-5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,10.228133,-12.55688,0,151.01469,-80.173359)"
+       gradientTransform="matrix(0,10.228133,-12.55688,0,151.01469,-75.173359)"
        cx="6.7304144"
        cy="9.9571075"
        fx="6.2001843"
@@ -345,7 +344,7 @@
        xlink:href="#linearGradient4356-5"
        id="linearGradient3076-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,8.7027135)"
+       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,13.702713)"
        x1="23.99999"
        y1="5.9472284"
        x2="23.99999"
@@ -384,13 +383,13 @@
        xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient4420"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3150653,0,0,0.83371382,89.668048,10.259733)"
+       gradientTransform="matrix(1.3150653,0,0,0.83371382,89.668048,15.259733)"
        x1="-51.786404"
        y1="50.786446"
        x2="-51.786404"
        y2="2.9062471" />
     <radialGradient
-       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-88.47417)"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-83.287144)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient3029"
@@ -405,9 +404,9 @@
        fx="6.0330806"
        cy="9.9571075"
        cx="6.5633106"
-       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-88.47417)"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-83.316052)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient5858"
+       id="radialGradient4232"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
     <radialGradient
        r="12.671875"
@@ -415,9 +414,9 @@
        fx="6.0330806"
        cy="9.9571075"
        cx="6.5633106"
-       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-88.47417)"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-83.316805)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient5860"
+       id="radialGradient4234"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
   </defs>
   <metadata
@@ -435,7 +434,7 @@
   <g
      style="opacity:0.15"
      id="g3712"
-     transform="matrix(1.6842106,0,0,0.7142857,-8.4210536,23.428572)">
+     transform="matrix(1.6842106,0,0,0.7142857,-8.4210536,28.428572)">
     <rect
        style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none"
        id="rect2801"
@@ -446,7 +445,7 @@
     <rect
        style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none"
        id="rect3696"
-       transform="scale(-1)"
+       transform="scale(-1,-1)"
        y="-47"
        x="-10"
        height="7"
@@ -460,85 +459,85 @@
        width="28" />
   </g>
   <path
-     d="M 14.499961,7.4999612 H 49.50004 V 11.500039 H 14.499961 Z"
+     d="m 14.499961,12.499961 35.000079,0 0,4.000078 -35.000079,0 z"
      id="rect4964-4-4"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 15.499961,8.4999993 H 48.500039 V 11.000039 H 15.499961 Z"
+     d="m 15.499961,13.499999 33.000078,0 0,2.50004 -33.000078,0 z"
      id="rect4964-1-6-5"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 8.499961,10.499961 47.000079,0.0675 V 41.000042 H 8.7659383 Z"
+     d="M 8.499961,15.499961 55.50004,15.5 l 0,30 L 8.5,45.5 Z"
      id="rect4964-4"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 9.4999609,11.499965 45.0000801,0.03138 -0.221054,28.468694 H 9.8649669 Z"
+     d="M 9.4999609,16.499965 54.500041,16.5 54.5,44.5 l -45,0 z"
      id="rect4964-1-6"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <rect
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
      id="rect4964"
-     y="14"
+     y="19"
      x="9"
      height="40"
      width="51" />
   <rect
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1"
-     y="14.499959"
+     y="19.499958"
      x="4.4999599"
      height="39.00008"
      width="55.00008" />
   <path
-     d="m 34,37.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
-     id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
-  <path
-     d="M 34,36.84188 A 10,10 0 1 1 28.710119,28.020613 L 24.000001,36.84188 Z"
-     id="path3035"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
-     id="path3475-4"
-     d="m 55,39.999999 v -1 h -2.21875 v 1 z m -2.65625,0 v -1 H 46 v 1 z m 2.65625,-4 v -1 h -2.96875 v 1 z m -3.71875,0 v -1 H 48.9375 v 1 z m -2.9375,0 v -1 h -1.1875 v 1 z m -1.8125,0 v -1 H 44.375 v 1 z m 8.46875,-4 v -1 h -3.28125 v 1 z m -3.875,0 v -1 h -1.65625 v 1 z m -2.21875,0 v -1 H 45.1875 v 1 z m 6.09375,-4 v -1 h -3.28125 v 1 z m -3.90625,0 v -1 H 48.75 v 1 z m -2.9375,0 v -1 h -3.6875 v 1 z" />
-  <path
-     d="m 9.035786,54.5 c 0,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.485462 -0.102163,-1.449298 -0.203479,-2.136563 0,-12.875954 0,-25.751906 0,-38.627855 l 0.05947,-0.166735 0.14401,-0.06885 v 0 c 1.825936,0 5.2370056,0 5.2370056,0"
+     d="m 9,59.5 -5.5,0 c 0,-13.126119 0,-39.735582 0,-41 1.2542902,0 3.9373045,-3e-6 5.5,-3e-6"
      id="path4530"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
   <path
      id="rect6741-1-5"
-     d="m 8.5,53.499998 h -4 V 14.499999 h 4"
+     d="m 8.5,58.499998 -4,0 0,-38.999999 4,0"
      style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 32,18 v 1 l -0.984375,-1e-6 v -1 z m -1.640625,-1e-6 v 1 H 27.71875 v -1 z m -3.359375,0 v 1 L 24,19 v -1 z m 19.75,0 v 1 h -5.734375 v -1 z m -6.390625,0 v 1 H 37.71875 v -1 z m -3.359375,0 v 1 h -3.75 v -1 z"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="path3925" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5860);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3964"
-     d="m 34,36.84188 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -4.178198,1.15662 -9.013426,-0.776912 -11.243199,-4.495223 -0.01769,0.01604 8.574793,-5.142078 8.574793,-5.142078 z" />
-  <path
-     d="m 55,47.999999 v -1 h -3.28125 v 1 z m -3.875,0 v -1 h -1.65625 v 1 z m -2.21875,0 v -1 H 45.1875 v 1 z m 6.09375,-4 v -1 h -3.28125 v 1 z m -3.90625,0 v -1 H 48.75 v 1 z m -2.9375,0 v -1 h -3.6875 v 1 z"
-     id="path3966"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
-  <path
-     d="m 43.8125,40 v -1 h -2.21875 v 1 z m 0,-4 v -1 h -2.96875 v 1 z m 0.90625,-4 V 31 H 42 v 1 z m -1.375,-4 V 27 H 41 v 1 z"
-     id="path4178"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
-     id="path4183"
-     d="m 44,43 v 1 h -3.28125 v -1 z m -3.875,0 v 1 h -1.65625 v -1 z m 4.15625,4 v 1 H 41 V 47 Z M 40.375,47 v 1 h -2.34375 v -1 z m -2.9375,0 v 1 H 33.75 v -1 z" />
-  <path
-     d="m 9.035786,54.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.485462 -0.102163,-1.449298 -0.203479,-2.136563 0,-12.875954 0,-25.751906 0,-38.627855 l 0.05947,-0.166735 0.14401,-0.06885 v 0 c 1.825936,0 3.4110786,0 5.2370056,0"
+     d="m 9,59.5 -5.5,0 c 0,-1.5 0.00828,-27.437181 0,-41 l 5.5,-3e-6"
      id="path4530-3"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
      id="path4160-6-1"
-     d="m 9,54.5 h 51.5 v -41 H 9"
+     d="m 9,59.5 51.5,0 0,-41 -51.5,0"
      style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5858);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path3475-4"
+     d="m 55,44.999999 0,-1 -2,0 0,1 z m -3,0 0,-1 -6,0 0,1 z m 3,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -1,0 0,1 z m 9,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -4,0 0,1 z m 6,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -4,0 0,1 z" />
+  <path
+     d="m 32,23 0,1 -0.984375,-1e-6 0,-1 z m -1.640625,-1e-6 0,1 -2.640625,0 0,-1 z m -3.359375,0 0,1 -3,1e-6 0,-1 z m 19.75,0 0,1 -5.734375,0 0,-1 z m -6.390625,0 0,1 -2.640625,0 0,-1 z m -3.359375,0 0,1 -3.75,0 0,-1 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+     id="path3925" />
+  <path
+     d="m 55,52.999999 0,-1 -3,0 0,1 z m -4,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -4,0 0,1 z m 6,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -3,0 0,1 z"
+     id="path3966"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     d="m 44,45 0,-1 -2,0 0,1 z m 0,-4 0,-1 -3,0 0,1 z m 0,-4 0,-1 -2,0 0,1 z m -1,-4 0,-1 -2,0 0,1 z"
+     id="path4178"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path4183"
+     d="m 44,48 0,1 -3,0 0,-1 z m -4,0 0,1 -2,0 0,-1 z m 4,4 0,1 -3,0 0,-1 z m -4,0 0,1 -2,0 0,-1 z m -3,0 0,1 -3,0 0,-1 z" />
+  <path
+     d="m 34,42.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
+     id="path3035-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+  <path
+     d="m 34,41.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
+     id="path3035"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4232);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3964"
+     d="m 34,42.028906 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -4.178198,1.15662 -9.013426,-0.776912 -11.243199,-4.495223 -0.01769,0.01604 8.574793,-5.142078 8.574793,-5.142078 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4234);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3962"
-     d="m 34,36.84188 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -0.09762,-0.01695 -2.668406,-9.637301 -2.668406,-9.637301 z" />
+     d="m 34,41.999245 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -0.09762,-0.01695 -2.668406,-9.637301 -2.668406,-9.637301 z" />
 </svg>

--- a/mimes/64/x-office-presentation-template-rtl.svg
+++ b/mimes/64/x-office-presentation-template-rtl.svg
@@ -6,7 +6,6 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   viewBox="0 0 64 64"
    id="svg4954"
    height="64"
    width="64"
@@ -121,7 +120,7 @@
          id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,73.354333,109.86293)"
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,73.354333,114.86293)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-5"
        id="linearGradient3091"
@@ -133,7 +132,7 @@
        xlink:href="#linearGradient4356"
        id="linearGradient3076"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,8.7027135)"
+       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,13.702713)"
        x1="23.99999"
        y1="5.9472284"
        x2="23.99999"
@@ -143,7 +142,7 @@
        x2="25.132275"
        y1="15.284525"
        x1="25.132275"
-       gradientTransform="matrix(1.456847,0,0,1.4786648,-1.1924073,-0.77586567)"
+       gradientTransform="matrix(1.456847,0,0,1.4786648,-1.1924073,4.2241341)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3917"
        xlink:href="#linearGradient3600-3-2-2" />
@@ -152,7 +151,7 @@
        x2="24"
        y1="14.203104"
        x1="24"
-       gradientTransform="matrix(2.1170825,0,0,1.1675323,-10.354736,0.0319621)"
+       gradientTransform="matrix(2.1170825,0,0,1.1675323,-10.354736,5.0319619)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3928"
        xlink:href="#linearGradient3211-8-8-9" />
@@ -161,7 +160,7 @@
        x2="25.132275"
        y1="15.284525"
        x1="25.132275"
-       gradientTransform="matrix(2.0328317,0,0,1.1210596,-9.6861059,-0.52865063)"
+       gradientTransform="matrix(2.0328317,0,0,1.1210596,-9.6861059,4.4713491)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3931"
        xlink:href="#linearGradient3600-3-2-2-6-8" />
@@ -170,7 +169,7 @@
        x2="-51.786404"
        y1="41.797989"
        x1="-51.786404"
-       gradientTransform="matrix(1.6415049,0,0,1.0491448,111.08489,-1.7780482)"
+       gradientTransform="matrix(1.6415049,0,0,1.0491448,111.08489,3.2219516)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3933"
        xlink:href="#linearGradient3104-9-7-3-9-6" />
@@ -179,7 +178,7 @@
        x2="24"
        y1="14.203104"
        x1="24"
-       gradientTransform="matrix(2.9929997,0,0,0.11114027,-27.91011,7.1953799)"
+       gradientTransform="matrix(2.9929997,0,0,0.11114027,-27.91011,12.19538)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3936"
        xlink:href="#linearGradient3211-8-8-0-0-9" />
@@ -188,7 +187,7 @@
        x2="25.132275"
        y1="15.284525"
        x1="25.132275"
-       gradientTransform="matrix(2.6847692,0,0,0.1535966,-23.167729,5.8101858)"
+       gradientTransform="matrix(2.6847692,0,0,0.1535966,-23.167729,10.810186)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3939"
        xlink:href="#linearGradient3600-3-2-2-6-5-8-7" />
@@ -197,7 +196,7 @@
        x2="-51.786404"
        y1="41.797989"
        x1="-51.786404"
-       gradientTransform="matrix(2.1679425,0,0,0.14374353,136.33503,5.6390056)"
+       gradientTransform="matrix(2.1679425,0,0,0.14374353,136.33503,10.639005)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3941"
        xlink:href="#linearGradient3104-9-7-3-9-2-6-2" />
@@ -206,7 +205,7 @@
        x2="22.004084"
        y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,73.354333,125.86293)"
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,73.354333,130.86293)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3968"
        xlink:href="#linearGradient3104-5" />
@@ -280,7 +279,7 @@
        x2="22.004084"
        y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,62.166833,109.86293)"
+       gradientTransform="matrix(-1.3394176,0,0,-1.9826305,62.166833,114.86293)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4180"
        xlink:href="#linearGradient3104-5" />
@@ -289,7 +288,7 @@
        x2="22.004084"
        y1="63.217903"
        x1="22.004084"
-       gradientTransform="matrix(-1.3394176,0,0,1.9826305,61.354333,-34.862932)"
+       gradientTransform="matrix(-1.3394176,0,0,1.9826305,61.354333,-29.862932)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4185"
        xlink:href="#linearGradient3104-5" />
@@ -316,7 +315,7 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8"
        id="radialGradient4173-5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,10.228133,-12.55688,0,151.01469,-80.173359)"
+       gradientTransform="matrix(0,10.228133,-12.55688,0,151.01469,-75.173359)"
        cx="6.7304144"
        cy="9.9571075"
        fx="6.2001843"
@@ -345,7 +344,7 @@
        xlink:href="#linearGradient4356-5"
        id="linearGradient3076-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,8.7027135)"
+       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,13.702713)"
        x1="23.99999"
        y1="5.9472284"
        x2="23.99999"
@@ -384,13 +383,13 @@
        xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient4420"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3150653,0,0,0.83371382,89.668048,10.259733)"
+       gradientTransform="matrix(1.3150653,0,0,0.83371382,89.668048,15.259733)"
        x1="-51.786404"
        y1="50.786446"
        x2="-51.786404"
        y2="2.9062471" />
     <radialGradient
-       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-88.47417)"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-83.287144)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        id="radialGradient3029"
@@ -400,17 +399,27 @@
        cy="9.9571075"
        cx="6.5633106" />
     <radialGradient
-       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.0330806"
+       cy="9.9571075"
+       cx="6.5633106"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-83.316052)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-6-6-1"
-       id="radialGradient3479"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
+       id="radialGradient4232"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
     <radialGradient
-       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.0330806"
+       cy="9.9571075"
+       cx="6.5633106"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-83.316805)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4234"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
+    <radialGradient
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3688-464-309-604"
        id="radialGradient3481"
@@ -422,7 +431,7 @@
     <radialGradient
        gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-166-749-654"
+       xlink:href="#linearGradient3688-464-309-604"
        id="radialGradient3483"
        fy="39.464806"
        fx="7"
@@ -453,7 +462,7 @@
          id="stop22144" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0,2.7038931,-2.6535314,0,169.84848,922.24617)"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3412"
        id="linearGradient3487"
@@ -473,7 +482,7 @@
          id="stop3416" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-1,0,0,1,133.21779,919.36222)"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3211-8-8-0-0-9"
        id="linearGradient3489"
@@ -481,26 +490,6 @@
        x2="75.779678"
        y1="86"
        x1="75.779678" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
-       cx="6.5633106"
-       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-88.47417)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient5881"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
-    <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.0330806"
-       cy="9.9571075"
-       cx="6.5633106"
-       gradientTransform="matrix(0,10.035098,-12.319893,0,133.65609,-88.47417)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient5883"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
   </defs>
   <metadata
      id="metadata4959">
@@ -517,7 +506,7 @@
   <g
      style="opacity:0.15"
      id="g3712"
-     transform="matrix(1.6842106,0,0,0.7142857,-8.4210536,23.428572)">
+     transform="matrix(1.6842106,0,0,0.7142857,-8.4210536,28.428572)">
     <rect
        style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none"
        id="rect2801"
@@ -528,7 +517,7 @@
     <rect
        style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none"
        id="rect3696"
-       transform="scale(-1)"
+       transform="scale(-1,-1)"
        y="-47"
        x="-10"
        height="7"
@@ -542,109 +531,105 @@
        width="28" />
   </g>
   <path
-     d="M 14.499961,7.4999612 H 49.50004 V 11.500039 H 14.499961 Z"
+     d="m 14.499961,12.499961 35.000079,0 0,4.000078 -35.000079,0 z"
      id="rect4964-4-4"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 15.499961,8.4999993 H 48.500039 V 11.000039 H 15.499961 Z"
+     d="m 15.499961,13.499999 33.000078,0 0,2.50004 -33.000078,0 z"
      id="rect4964-1-6-5"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 8.499961,10.499961 47.000079,0.0675 V 41.000042 H 8.7659383 Z"
+     d="M 8.499961,15.499961 55.50004,15.5 l 0,30 L 8.5,45.5 Z"
      id="rect4964-4"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 9.4999609,11.499965 45.0000801,0.03138 -0.221054,28.468694 H 9.8649669 Z"
+     d="M 9.4999609,16.499965 54.500041,16.5 54.5,44.5 l -45,0 z"
      id="rect4964-1-6"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <rect
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
      id="rect4964"
-     y="14"
+     y="19"
      x="9"
      height="40"
      width="51" />
   <rect
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1"
-     y="14.499959"
+     y="19.499958"
      x="4.4999599"
      height="39.00008"
      width="55.00008" />
   <path
-     d="m 34,37.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
-     id="path3035-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
-  <path
-     d="M 34,36.84188 A 10,10 0 1 1 28.710119,28.020613 L 24.000001,36.84188 Z"
-     id="path3035"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
-     id="path3475-4"
-     d="m 55,39.999999 v -1 h -2.21875 v 1 z m -2.65625,0 v -1 H 46 v 1 z m 2.65625,-4 v -1 h -2.96875 v 1 z m -3.71875,0 v -1 H 48.9375 v 1 z m -2.9375,0 v -1 h -1.1875 v 1 z m -1.8125,0 v -1 H 44.375 v 1 z m 8.46875,-4 v -1 h -3.28125 v 1 z m -3.875,0 v -1 h -1.65625 v 1 z m -2.21875,0 v -1 H 45.1875 v 1 z m 6.09375,-4 v -1 h -3.28125 v 1 z m -3.90625,0 v -1 H 48.75 v 1 z m -2.9375,0 v -1 h -3.6875 v 1 z" />
-  <path
-     d="m 9.035786,54.5 c 0,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.485462 -0.102163,-1.449298 -0.203479,-2.136563 0,-12.875954 0,-25.751906 0,-38.627855 l 0.05947,-0.166735 0.14401,-0.06885 v 0 c 1.825936,0 5.2370056,0 5.2370056,0"
+     d="m 9,59.5 -5.5,0 c 0,-13.126119 0,-39.735582 0,-41 1.2542902,0 3.9373045,-3e-6 5.5,-3e-6"
      id="path4530"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
   <path
      id="rect6741-1-5"
-     d="m 8.5,53.499998 h -4 V 14.499999 h 4"
+     d="m 8.5,58.499998 -4,0 0,-38.999999 4,0"
      style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 32,18 v 1 l -0.984375,-1e-6 v -1 z m -1.640625,-1e-6 v 1 H 27.71875 v -1 z m -3.359375,0 v 1 L 24,19 v -1 z m 19.75,0 v 1 h -5.734375 v -1 z m -6.390625,0 v 1 H 37.71875 v -1 z m -3.359375,0 v 1 h -3.75 v -1 z"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="path3925" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5883);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3964"
-     d="m 34,36.84188 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -4.178198,1.15662 -9.013426,-0.776912 -11.243199,-4.495223 -0.01769,0.01604 8.574793,-5.142078 8.574793,-5.142078 z" />
-  <path
-     d="m 55,47.999999 v -1 h -3.28125 v 1 z m -3.875,0 v -1 h -1.65625 v 1 z m -2.21875,0 v -1 H 45.1875 v 1 z m 6.09375,-4 v -1 h -3.28125 v 1 z m -3.90625,0 v -1 H 48.75 v 1 z m -2.9375,0 v -1 h -3.6875 v 1 z"
-     id="path3966"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
-  <path
-     d="m 43.8125,40 v -1 h -2.21875 v 1 z m 0,-4 v -1 h -2.96875 v 1 z m 0.90625,-4 V 31 H 42 v 1 z m -1.375,-4 V 27 H 41 v 1 z"
-     id="path4178"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
-  <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
-     id="path4183"
-     d="m 44,43 v 1 h -3.28125 v -1 z m -3.875,0 v 1 h -1.65625 v -1 z m 4.15625,4 v 1 H 41 V 47 Z M 40.375,47 v 1 h -2.34375 v -1 z m -2.9375,0 v 1 H 33.75 v -1 z" />
-  <path
-     d="m 9.035786,54.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.485462 -0.102163,-1.449298 -0.203479,-2.136563 0,-12.875954 0,-25.751906 0,-38.627855 l 0.05947,-0.166735 0.14401,-0.06885 v 0 c 1.825936,0 3.4110786,0 5.2370056,0"
+     d="m 9,59.5 -5.5,0 c 0,-1.5 0.00828,-27.437181 0,-41 l 5.5,-3e-6"
      id="path4530-3"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
      id="path4160-6-1"
-     d="m 9,54.5 h 51.5 v -41 H 9"
+     d="m 9,59.5 51.5,0 0,-41 -51.5,0"
      style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient5881);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path3475-4"
+     d="m 55,44.999999 0,-1 -2,0 0,1 z m -3,0 0,-1 -6,0 0,1 z m 3,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -1,0 0,1 z m 9,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -4,0 0,1 z m 6,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -4,0 0,1 z" />
+  <path
+     d="m 32,23 0,1 -0.984375,-1e-6 0,-1 z m -1.640625,-1e-6 0,1 -2.640625,0 0,-1 z m -3.359375,0 0,1 -3,1e-6 0,-1 z m 19.75,0 0,1 -5.734375,0 0,-1 z m -6.390625,0 0,1 -2.640625,0 0,-1 z m -3.359375,0 0,1 -3.75,0 0,-1 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+     id="path3925" />
+  <path
+     d="m 55,52.999999 0,-1 -3,0 0,1 z m -4,0 0,-1 -1,0 0,1 z m -2,0 0,-1 -4,0 0,1 z m 6,-4 0,-1 -3,0 0,1 z m -4,0 0,-1 -2,0 0,1 z m -3,0 0,-1 -3,0 0,1 z"
+     id="path3966"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     d="m 44,45 0,-1 -2,0 0,1 z m 0,-4 0,-1 -3,0 0,1 z m 0,-4 0,-1 -2,0 0,1 z m -1,-4 0,-1 -2,0 0,1 z"
+     id="path4178"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path4183"
+     d="m 44,48 0,1 -3,0 0,-1 z m -4,0 0,1 -2,0 0,-1 z m 4,4 0,1 -3,0 0,-1 z m -4,0 0,1 -2,0 0,-1 z m -3,0 0,1 -3,0 0,-1 z" />
+  <path
+     d="m 34,42.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
+     id="path3035-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+  <path
+     d="m 34,41.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
+     id="path3035"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4232);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3964"
+     d="m 34,42.028906 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -4.178198,1.15662 -9.013426,-0.776912 -11.243199,-4.495223 -0.01769,0.01604 8.574793,-5.142078 8.574793,-5.142078 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4234);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3962"
-     d="m 34,36.84188 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -0.09762,-0.01695 -2.668406,-9.637301 -2.668406,-9.637301 z" />
+     d="m 34,41.999245 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -0.09762,-0.01695 -2.668406,-9.637301 -2.668406,-9.637301 z" />
   <g
-     id="g3138"
-     transform="translate(-13.217778,-983.36214)">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3479);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2881-3"
-       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+     id="g4309"
+     transform="translate(-3.4802179e-4,-4e-6)">
     <g
        style="opacity:0.3"
        id="g22150"
-       transform="matrix(-0.916667,0,0,0.714282,78.217794,1017.3623)">
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)">
       <rect
          style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none"
          id="rect22120"
          y="35"
-         x="0"
+         x="1.0905465"
          height="7"
-         width="4" />
+         width="2.9094534" />
       <rect
          style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none"
          id="rect22134"
-         transform="scale(-1)"
+         transform="scale(-1,-1)"
          y="-42"
          x="-48"
          height="7"
@@ -660,34 +645,62 @@
     <path
        style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="path2993"
-       d="m 75.717796,1005.8622 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 54.217794 Z" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3101"
-       d="m 70.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3103"
-       d="m 64.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3105"
-       d="m 58.717794,1044.8622 v -0.9881" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3107"
-       d="m 52.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3109"
-       d="m 46.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3091"
-       d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+       d="m 62.500018,22.50006 -39.999999,40 39.999999,0 0,-40 z m -7.999996,18.6666 0,13.3334 -13.500006,0 13.500006,-13.3334 z" />
+    <g
+       id="g4259"
+       transform="translate(-13.217778,-983.36214)">
+      <path
+         d="m 70.717794,1044.8622 0,-1"
+         id="path3101"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 64.717794,1044.8622 0,-1"
+         id="path3103"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 58.717794,1044.8622 0,-0.9881"
+         id="path3105"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 52.717794,1044.8622 0,-1"
+         id="path3107"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 46.717794,1044.8622 0,-1"
+         id="path3109"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 69.717794,1045.8622 0,-2 m -6,2 0,-2 m -6,2 0,-1.9762 m -6,1.9762 0,-2 m -6,2 0,-2"
+         id="path3091"
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
     <path
        style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="path3934"
-       d="m 74.717794,1008.2997 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z" />
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z" />
+    <path
+       d="m 61.50002,33.49995 -1,0"
+       id="path4269"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 61.50002,39.49995 -1,0"
+       id="path4271"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 61.49402,45.49995 -0.9881,0"
+       id="path4273"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 61.50002,51.49995 -1,0"
+       id="path4275"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 61.50002,57.49995 -1,0"
+       id="path4277"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 62.50002,32.5 -2.0119,0 m 2.0119,6 -2.0119,0 m 2.0119,6 -1.9881,0 m 1.9881,6 -2.0119,0 m 2.0119,6 -2.0119,0"
+       id="path4279"
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/mimes/64/x-office-presentation-template.svg
+++ b/mimes/64/x-office-presentation-template.svg
@@ -6,480 +6,490 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="64"
+   id="svg4954"
    height="64"
-   id="svg4954">
+   width="64"
+   version="1.1">
   <defs
      id="defs4956">
     <linearGradient
        id="linearGradient4356">
       <stop
-         id="stop4358"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
+         id="stop4358" />
       <stop
-         offset="0.01041535"
+         id="stop4360"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop4360" />
+         offset="0.01041535" />
       <stop
-         id="stop4362"
+         offset="0.98265791"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.98265791" />
+         id="stop4362" />
       <stop
-         id="stop4364"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop4364" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2">
       <stop
-         id="stop3602-1-25-9"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9" />
       <stop
-         id="stop3604-4-2-0"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         id="stop3602-1-25-9-9-6-5-6"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9-9-6-5-6" />
       <stop
-         id="stop3604-4-2-0-2-4-2-1"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0-2-4-2-1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         id="stop3106-1-5-9-3-1-7-1"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-1-5-9-3-1-7-1" />
       <stop
-         id="stop3108-1-5-5-7-2-4-5"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-1-5-5-7-2-4-5" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         id="stop3213-0-0-8-1-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3213-0-0-8-1-1" />
       <stop
-         id="stop3215-1-8-0-6-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3215-1-8-0-6-4" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         id="stop3602-1-25-9-9-7"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9-9-7" />
       <stop
-         id="stop3604-4-2-0-2-0"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0-2-0" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         id="stop3106-1-5-9-3-2"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-1-5-9-3-2" />
       <stop
-         id="stop3108-1-5-5-7-4"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-1-5-5-7-4" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         id="stop3213-0-0-3"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3213-0-0-3" />
       <stop
-         id="stop3215-1-8-9"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3215-1-8-9" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-5">
       <stop
-         id="stop3106-9"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-9" />
       <stop
-         id="stop3108-9"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       x1="22.004084"
-       y1="63.217903"
-       x2="22.004084"
-       y2="25.646791"
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-4.354333,114.86293)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-5"
        id="linearGradient3091"
-       xlink:href="#linearGradient3104-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-4.3543329,109.86293)" />
-    <linearGradient
-       y2="41.754993"
-       x2="23.99999"
-       y1="5.9472284"
-       x1="23.99999"
-       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,8.7027135)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3076"
-       xlink:href="#linearGradient4356" />
-    <linearGradient
-       xlink:href="#linearGradient3600-3-2-2"
-       id="linearGradient3917"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.456847,0,0,1.4786648,-1.1924073,-0.77586567)"
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188" />
-    <linearGradient
-       xlink:href="#linearGradient3211-8-8-9"
-       id="linearGradient3928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1170825,0,0,1.1675323,-10.354736,0.0319621)"
-       x1="24"
-       y1="14.203104"
-       x2="24"
-       y2="35.721317" />
-    <linearGradient
-       xlink:href="#linearGradient3600-3-2-2-6-8"
-       id="linearGradient3931"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0328317,0,0,1.1210596,-9.6861059,-0.52865063)"
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188" />
-    <linearGradient
-       xlink:href="#linearGradient3104-9-7-3-9-6"
-       id="linearGradient3933"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6415049,0,0,1.0491448,111.08489,-1.7780482)"
-       x1="-51.786404"
-       y1="41.797989"
-       x2="-51.786404"
-       y2="17.555471" />
-    <linearGradient
-       xlink:href="#linearGradient3211-8-8-0-0-9"
-       id="linearGradient3936"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.9929997,0,0,0.11114027,-27.91011,7.1953799)"
-       x1="24"
-       y1="14.203104"
-       x2="24"
-       y2="35.721317" />
-    <linearGradient
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
-       id="linearGradient3939"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6847692,0,0,0.1535966,-23.167729,5.8101858)"
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188" />
-    <linearGradient
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
-       id="linearGradient3941"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1679425,0,0,0.14374353,136.33503,5.6390056)"
-       x1="-51.786404"
-       y1="41.797989"
-       x2="-51.786404"
-       y2="17.555471" />
-    <linearGradient
-       xlink:href="#linearGradient3104-5"
-       id="linearGradient3968"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-4.3543329,125.86293)"
-       x1="22.004084"
-       y1="63.217903"
+       y2="25.646791"
        x2="22.004084"
-       y2="25.646791" />
+       y1="63.217903"
+       x1="22.004084" />
+    <linearGradient
+       xlink:href="#linearGradient4356"
+       id="linearGradient3076"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,13.702713)"
+       x1="23.99999"
+       y1="5.9472284"
+       x2="23.99999"
+       y2="41.754993" />
+    <linearGradient
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275"
+       gradientTransform="matrix(1.456847,0,0,1.4786648,-1.1924073,4.2241341)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3917"
+       xlink:href="#linearGradient3600-3-2-2" />
+    <linearGradient
+       y2="35.721317"
+       x2="24"
+       y1="14.203104"
+       x1="24"
+       gradientTransform="matrix(2.1170825,0,0,1.1675323,-10.354736,5.0319619)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3928"
+       xlink:href="#linearGradient3211-8-8-9" />
+    <linearGradient
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275"
+       gradientTransform="matrix(2.0328317,0,0,1.1210596,-9.6861059,4.4713491)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931"
+       xlink:href="#linearGradient3600-3-2-2-6-8" />
+    <linearGradient
+       y2="17.555471"
+       x2="-51.786404"
+       y1="41.797989"
+       x1="-51.786404"
+       gradientTransform="matrix(1.6415049,0,0,1.0491448,111.08489,3.2219516)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3933"
+       xlink:href="#linearGradient3104-9-7-3-9-6" />
+    <linearGradient
+       y2="35.721317"
+       x2="24"
+       y1="14.203104"
+       x1="24"
+       gradientTransform="matrix(2.9929997,0,0,0.11114027,-27.91011,12.19538)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3936"
+       xlink:href="#linearGradient3211-8-8-0-0-9" />
+    <linearGradient
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275"
+       gradientTransform="matrix(2.6847692,0,0,0.1535966,-23.167729,10.810186)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3939"
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7" />
+    <linearGradient
+       y2="17.555471"
+       x2="-51.786404"
+       y1="41.797989"
+       x1="-51.786404"
+       gradientTransform="matrix(2.1679425,0,0,0.14374353,136.33503,10.639005)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3941"
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2" />
+    <linearGradient
+       y2="25.646791"
+       x2="22.004084"
+       y1="63.217903"
+       x1="22.004084"
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-4.354333,130.86293)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3968"
+       xlink:href="#linearGradient3104-5" />
     <linearGradient
        id="linearGradient3702-501-757-795">
       <stop
-         offset="0"
+         id="stop3100"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3100" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop3102"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3102" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop3104"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3104" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309-604">
       <stop
-         offset="0"
+         id="stop3094"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3094" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3096"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3096" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-166-749-654">
       <stop
-         offset="0"
+         id="stop3088"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3088" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3090"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3090" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3688-166-749-654"
-       id="radialGradient4172"
-       gradientUnits="userSpaceOnUse"
+       r="2.5"
+       fy="43.5"
+       fx="4.9929786"
+       cy="43.5"
+       cx="4.9929786"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4172"
+       xlink:href="#linearGradient3688-166-749-654" />
     <radialGradient
-       xlink:href="#linearGradient3688-464-309-604"
-       id="radialGradient4174"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
+       r="2.5"
        fy="43.5"
-       r="2.5" />
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757-795"
-       id="linearGradient4176"
+       fx="4.9929786"
+       cy="43.5"
+       cx="4.9929786"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
+       id="radialGradient4174"
+       xlink:href="#linearGradient3688-464-309-604" />
+    <linearGradient
+       y2="39.999443"
        x2="25.058096"
-       y2="39.999443" />
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4176"
+       xlink:href="#linearGradient3702-501-757-795" />
     <linearGradient
-       xlink:href="#linearGradient3104-5"
+       y2="25.646791"
+       x2="22.004084"
+       y1="63.217903"
+       x1="22.004084"
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,6.833167,114.86293)"
+       gradientUnits="userSpaceOnUse"
        id="linearGradient4180"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,6.8331671,109.86293)"
-       x1="22.004084"
-       y1="63.217903"
-       x2="22.004084"
-       y2="25.646791" />
+       xlink:href="#linearGradient3104-5" />
     <linearGradient
-       xlink:href="#linearGradient3104-5"
-       id="linearGradient4185"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,1.9826305,7.6456671,-34.862932)"
-       x1="22.004084"
-       y1="63.217903"
+       y2="25.646791"
        x2="22.004084"
-       y2="25.646791" />
+       y1="63.217903"
+       x1="22.004084"
+       gradientTransform="matrix(1.3394176,0,0,1.9826305,7.645667,-29.862932)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4185"
+       xlink:href="#linearGradient3104-5" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
       <stop
-         offset="0"
+         id="stop3750-1-0-7-6-6-1-3-9"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9" />
+         offset="0" />
       <stop
-         offset="0.26238"
+         id="stop3752-3-7-4-0-32-8-923-0"
          style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0" />
+         offset="0.26238" />
       <stop
-         offset="0.704952"
+         id="stop3754-1-8-5-2-7-6-7-1"
          style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1" />
+         offset="0.704952" />
       <stop
-         offset="1"
+         id="stop3756-1-6-2-6-6-1-96-6"
          style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,10.228133,-12.55688,0,151.01469,-80.173359)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8"
        id="radialGradient4173-5"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,10.228133,-12.55688,0,151.01469,-75.173359)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8">
       <stop
-         offset="0"
+         id="stop3750-1-0-7-6-6-1-3-9-9-0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-9-0" />
+         offset="0" />
       <stop
-         offset="0.26238"
+         id="stop3752-3-7-4-0-32-8-923-0-7-8"
          style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7-8" />
+         offset="0.26238" />
       <stop
-         offset="0.704952"
+         id="stop3754-1-8-5-2-7-6-7-1-8-0"
          style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-8-0" />
+         offset="0.704952" />
       <stop
-         offset="1"
+         id="stop3756-1-6-2-6-6-1-96-6-1-1"
          style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-1-1" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       y2="41.754993"
-       x2="23.99999"
-       y1="5.9472284"
-       x1="23.99999"
-       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,8.7027135)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4356-5"
        id="linearGradient3076-9"
-       xlink:href="#linearGradient4356-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,13.702713)"
+       x1="23.99999"
+       y1="5.9472284"
+       x2="23.99999"
+       y2="41.754993" />
     <linearGradient
        id="linearGradient4356-5">
       <stop
-         id="stop4358-6"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
+         id="stop4358-6" />
       <stop
-         offset="0.01041535"
+         id="stop4360-9"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop4360-9" />
+         offset="0.01041535" />
       <stop
-         id="stop4362-4"
+         offset="0.98265791"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.98265791" />
+         id="stop4362-4" />
       <stop
-         id="stop4364-6"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop4364-6" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         offset="0"
+         id="stop3106-3-2"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8-3"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-8-3" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(1.3150653,0,0,0.83371382,89.668048,10.259733)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4420"
-       xlink:href="#linearGradient3104-6-6-1" />
-    <radialGradient
-       cx="6.5633106"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.0330806"
-       fy="9.9571075"
-       id="radialGradient3029"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,10.035098,-12.319893,0,154.65609,-88.47417)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3479"
        xlink:href="#linearGradient3104-6-6-1"
+       id="linearGradient4420"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)" />
+       gradientTransform="matrix(1.3150653,0,0,0.83371382,89.668048,15.259733)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
     <radialGradient
-       cx="7"
-       cy="39.464806"
-       r="3.5"
-       fx="7"
-       fy="39.464806"
-       id="radialGradient3481"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,154.65609,-83.287144)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       id="radialGradient3029"
+       fy="9.9571075"
+       fx="6.0330806"
+       r="12.671875"
+       cy="9.9571075"
+       cx="6.5633106" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.0330806"
+       cy="9.9571075"
+       cx="6.5633106"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,154.65609,-83.316052)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4232"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.0330806"
+       cy="9.9571075"
+       cx="6.5633106"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,154.65609,-83.316805)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4234"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
+    <radialGradient
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3688-464-309-604"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)" />
-    <radialGradient
-       cx="7"
-       cy="39.464806"
-       r="3.5"
-       fx="7"
+       id="radialGradient3481"
        fy="39.464806"
-       id="radialGradient3483"
-       xlink:href="#linearGradient3688-166-749-654"
+       fx="7"
+       r="3.5"
+       cy="39.464806"
+       cx="7" />
+    <radialGradient
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+       xlink:href="#linearGradient3688-464-309-604"
+       id="radialGradient3483"
+       fy="39.464806"
+       fx="7"
+       r="3.5"
+       cy="39.464806"
+       cx="7" />
     <linearGradient
-       x1="18.142136"
-       y1="35"
-       x2="18.142136"
-       y2="42.040661"
-       id="linearGradient3485"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient22140"
-       gradientUnits="userSpaceOnUse" />
+       id="linearGradient3485"
+       y2="42.040661"
+       x2="18.142136"
+       y1="35"
+       x1="18.142136" />
     <linearGradient
        id="linearGradient22140">
       <stop
-         id="stop22142"
+         offset="0"
          style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
+         id="stop22142" />
       <stop
-         id="stop22148"
+         offset="0.5"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
+         id="stop22148" />
       <stop
-         id="stop22144"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop22144" />
     </linearGradient>
     <linearGradient
-       x1="30.739399"
-       y1="35.285313"
-       x2="45.902721"
-       y2="50.73642"
-       id="linearGradient3487"
-       xlink:href="#linearGradient3412"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,2.7038931,-2.6535314,0,169.84848,922.24617)" />
+       xlink:href="#linearGradient3412"
+       id="linearGradient3487"
+       y2="50.73642"
+       x2="45.902721"
+       y1="35.285313"
+       x1="30.739399" />
     <linearGradient
        id="linearGradient3412">
       <stop
-         id="stop3414"
+         offset="0"
          style="stop-color:#f0f0f1;stop-opacity:1"
-         offset="0" />
+         id="stop3414" />
       <stop
-         id="stop3416"
+         offset="1"
          style="stop-color:#cbcdd9;stop-opacity:1"
-         offset="1" />
+         id="stop3416" />
     </linearGradient>
     <linearGradient
-       x1="75.779678"
-       y1="86"
-       x2="75.779678"
-       y2="127.03607"
-       id="linearGradient3489"
-       xlink:href="#linearGradient3211-8-8-0-0-9"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,133.21779,919.36222)" />
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       id="linearGradient3489"
+       y2="127.03607"
+       x2="75.779678"
+       y1="86"
+       x1="75.779678" />
   </defs>
   <metadata
      id="metadata4959">
@@ -494,179 +504,203 @@
     </rdf:RDF>
   </metadata>
   <g
-     transform="matrix(1.6842106,0,0,0.7142857,-8.4210536,23.428572)"
+     style="opacity:0.15"
      id="g3712"
-     style="opacity:0.15">
+     transform="matrix(1.6842106,0,0,0.7142857,-8.4210536,28.428572)">
     <rect
-       width="5"
-       height="7"
-       x="38"
-       y="40"
+       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none"
        id="rect2801"
-       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="7"
-       x="-10"
-       y="-47"
-       transform="scale(-1,-1)"
-       id="rect3696"
-       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none" />
-    <rect
-       width="28"
-       height="7.0000005"
-       x="10"
        y="40"
+       x="38"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1,-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none"
        id="rect3700"
-       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none" />
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
   <path
-     style="opacity:0.5;color:#000000;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 14.499961,12.499961 35.000079,0 0,4.000078 -35.000079,0 z"
      id="rect4964-4-4"
-     d="m 14.499961,7.4999612 35.000079,0 0,4.0000778 -35.000079,0 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.3;color:#000000;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 15.499961,13.499999 33.000078,0 0,2.50004 -33.000078,0 z"
      id="rect4964-1-6-5"
-     d="m 15.499961,8.4999993 33.000078,0 0,2.5000397 -33.000078,0 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.75;color:#000000;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="M 8.499961,15.499961 55.50004,15.5 l 0,30 L 8.5,45.5 Z"
      id="rect4964-4"
-     d="m 8.499961,10.499961 47.000079,0.0675 0,30.432581 -46.7341017,0 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.45;color:#000000;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="M 9.4999609,16.499965 54.500041,16.5 54.5,44.5 l -45,0 z"
      id="rect4964-1-6"
-     d="m 9.4999609,11.499965 45.0000801,0.03138 -0.221054,28.468694 -44.4140201,0 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <rect
-     width="51"
-     height="40"
-     x="9"
-     y="14"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
      id="rect4964"
-     style="color:#000000;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     y="19"
+     x="9"
+     height="40"
+     width="51" />
   <rect
-     width="55.00008"
-     height="39.00008"
-     x="4.4999599"
-     y="14.499959"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1"
-     style="opacity:1;color:#000000;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     y="19.499958"
+     x="4.4999599"
+     height="39.00008"
+     width="55.00008" />
   <path
-     style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path3035-5"
-     d="m 55,37.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z" />
-  <path
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="path3035"
-     d="M 55,36.84188 A 10,10 0 1 1 49.710119,28.020613 L 45.000001,36.84188 z" />
-  <path
-     d="m 14,39.999999 0,-1 2.21875,0 0,1 z m 2.65625,0 0,-1 6.34375,0 0,1 z m -2.65625,-4 0,-1 2.96875,0 0,1 z m 3.71875,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 1.1875,0 0,1 z m 1.8125,0 0,-1 2.15625,0 0,1 z m -8.46875,-4 0,-1 3.28125,0 0,1 z m 3.875,0 0,-1 1.65625,0 0,1 z m 2.21875,0 0,-1 3.71875,0 0,1 z m -6.09375,-4 0,-1 3.28125,0 0,1 z m 3.90625,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 3.6875,0 0,1 z"
-     id="path3475-4"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
-  <path
-     style="color:#000000;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 9,59.5 -5.5,0 c 0,-13.126119 0,-39.735582 0,-41 1.2542902,0 3.9373045,-3e-6 5.5,-3e-6"
      id="path4530"
-     d="m 9.035786,54.5 c 0,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.485462 -0.102163,-1.449298 -0.203479,-2.136563 0,-12.875954 0,-25.751906 0,-38.627855 l 0.05947,-0.166735 0.14401,-0.06885 0,0 c 1.825936,0 5.2370056,0 5.2370056,0" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.50000000000000000;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-     d="m 8.5,53.499998 -4,0 0,-38.999999 4,0"
-     id="rect6741-1-5" />
+     id="rect6741-1-5"
+     d="m 8.5,58.499998 -4,0 0,-38.999999 4,0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     id="path3925"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.28000004;color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="m 37,18 0,1 0.984375,-1e-6 0,-1 z m 1.640625,-1e-6 0,1 2.640625,0 0,-1 z m 3.359375,0 0,1 3,1e-6 0,-1 z m -19.75,0 0,1 5.734375,0 0,-1 z m 6.390625,0 0,1 2.640625,0 0,-1 z m 3.359375,0 0,1 3.75,0 0,-1 z" />
-  <path
-     d="m 55,36.84188 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -4.178198,1.15662 -9.013426,-0.776912 -11.243199,-4.495223 -0.01769,0.01604 8.574793,-5.142078 8.574793,-5.142078 z"
-     id="path3964"
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
-  <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     id="path3966"
-     d="m 14,47.999999 0,-1 3.28125,0 0,1 z m 3.875,0 0,-1 1.65625,0 0,1 z m 2.21875,0 0,-1 3.71875,0 0,1 z m -6.09375,-4 0,-1 3.28125,0 0,1 z m 3.90625,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 3.6875,0 0,1 z" />
-  <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     id="path4178"
-     d="m 25.1875,40 0,-1 2.21875,0 0,1 z m 0,-4 0,-1 2.96875,0 0,1 z m -0.90625,-4 0,-1 2.71875,0 0,1 z m 1.375,-4 0,-1 2.34375,0 0,1 z" />
-  <path
-     d="m 25,43 0,1 3.28125,0 0,-1 z m 3.875,0 0,1 1.65625,0 0,-1 z m -4.15625,4 0,1 L 28,48 28,47 z m 3.90625,0 0,1 2.34375,0 0,-1 z m 2.9375,0 0,1 3.6875,0 0,-1 z"
-     id="path4183"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
-  <path
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 9,59.5 -5.5,0 c 0,-1.5 0.00828,-27.437181 0,-41 l 5.5,-3e-6"
      id="path4530-3"
-     d="m 9.035786,54.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.485462 -0.102163,-1.449298 -0.203479,-2.136563 0,-12.875954 0,-25.751906 0,-38.627855 l 0.05947,-0.166735 0.14401,-0.06885 0,0 c 1.825936,0 3.4110786,0 5.2370056,0" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-     d="m 9,54.5 51.5,0 0,-41 -51.5,0"
-     id="path4160-6-1" />
+     id="path4160-6-1"
+     d="m 9,59.5 51.5,0 0,-41 -51.5,0"
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 55,36.84188 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -0.09762,-0.01695 -2.668406,-9.637301 -2.668406,-9.637301 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path3475-4"
+     d="m 14,44.999999 0,-1 2,0 0,1 z m 3,0 0,-1 6,0 0,1 z m -3,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 1,0 0,1 z m 2,0 0,-1 1,0 0,1 z m -9,-4 0,-1 3,0 0,1 z m 4,0 0,-1 1,0 0,1 z m 2,0 0,-1 4,0 0,1 z m -6,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 4,0 0,1 z" />
+  <path
+     d="m 37,23 0,1 0.984375,-1e-6 0,-1 z m 1.640625,-1e-6 0,1 2.640625,0 0,-1 z m 3.359375,0 0,1 3,1e-6 0,-1 z m -19.75,0 0,1 5.734375,0 0,-1 z m 6.390625,0 0,1 2.640625,0 0,-1 z m 3.359375,0 0,1 3.75,0 0,-1 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+     id="path3925" />
+  <path
+     d="m 14,52.999999 0,-1 3,0 0,1 z m 4,0 0,-1 1,0 0,1 z m 2,0 0,-1 4,0 0,1 z m -6,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 3,0 0,1 z"
+     id="path3966"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     d="m 25,45 0,-1 2,0 0,1 z m 0,-4 0,-1 3,0 0,1 z m 0,-4 0,-1 2,0 0,1 z m 1,-4 0,-1 2,0 0,1 z"
+     id="path4178"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path4183"
+     d="m 25,48 0,1 3,0 0,-1 z m 4,0 0,1 2,0 0,-1 z m -4,4 0,1 3,0 0,-1 z m 4,0 0,1 2,0 0,-1 z m 3,0 0,1 3,0 0,-1 z" />
+  <path
+     d="m 55,42.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
+     id="path3035-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+  <path
+     d="m 55,41.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
+     id="path3035"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4232);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3964"
+     d="m 55,42.028906 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -4.178198,1.15662 -9.013426,-0.776912 -11.243199,-4.495223 -0.01769,0.01604 8.574793,-5.142078 8.574793,-5.142078 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4234);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3962"
-     style="opacity:0.8;color:#000000;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     d="m 55,41.999245 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -0.09762,-0.01695 -2.668406,-9.637301 -2.668406,-9.637301 z" />
   <g
-     transform="translate(-13.217778,-983.36214)"
-     id="g3138">
-    <path
-       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z"
-       id="path2881-3"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3479);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     id="g4309"
+     transform="translate(-3.4802179e-4,-4e-6)">
     <g
-       transform="matrix(-0.916667,0,0,0.714282,78.217794,1017.3623)"
+       style="opacity:0.3"
        id="g22150"
-       style="opacity:0.3">
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)">
       <rect
-         width="4"
-         height="7"
-         x="0"
-         y="35"
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none"
          id="rect22120"
-         style="fill:url(#radialGradient3481);fill-opacity:1.0;stroke:none" />
-      <rect
-         width="4"
-         height="7"
-         x="-48"
-         y="-42"
-         transform="scale(-1,-1)"
-         id="rect22134"
-         style="fill:url(#radialGradient3483);fill-opacity:1.0;stroke:none" />
-      <rect
-         width="40"
-         height="7"
-         x="4"
          y="35"
+         x="1.0905465"
+         height="7"
+         width="2.9094534" />
+      <rect
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none"
+         id="rect22134"
+         transform="scale(-1,-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3485);fill-opacity:1;stroke:none"
          id="rect22138"
-         style="fill:url(#linearGradient3485);fill-opacity:1;stroke:none" />
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
     </g>
     <path
-       d="m 75.717796,1005.8622 -39.999999,40 39.999999,0 0,-40 z m -7.999996,18.6666 0,13.3334 -13.500006,0 13.500006,-13.3334 z"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="path2993"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       d="m 62.500018,22.50006 -39.999999,40 39.999999,0 0,-40 z m -7.999996,18.6666 0,13.3334 -13.500006,0 13.500006,-13.3334 z" />
+    <g
+       id="g4259"
+       transform="translate(-13.217778,-983.36214)">
+      <path
+         d="m 70.717794,1044.8622 0,-1"
+         id="path3101"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 64.717794,1044.8622 0,-1"
+         id="path3103"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 58.717794,1044.8622 0,-0.9881"
+         id="path3105"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 52.717794,1044.8622 0,-1"
+         id="path3107"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 46.717794,1044.8622 0,-1"
+         id="path3109"
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 69.717794,1045.8622 0,-2 m -6,2 0,-2 m -6,2 0,-1.9762 m -6,1.9762 0,-2 m -6,2 0,-2"
+         id="path3091"
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
     <path
-       d="m 70.717794,1044.8622 0,-1"
-       id="path3101"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 64.717794,1044.8622 0,-1"
-       id="path3103"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 58.717794,1044.8622 0,-0.9881"
-       id="path3105"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 52.717794,1044.8622 0,-1"
-       id="path3107"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 46.717794,1044.8622 0,-1"
-       id="path3109"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 69.717794,1045.8622 0,-2 m -6,2 0,-2 m -6,2 0,-1.9762 m -6,1.9762 0,-2 m -6,2 0,-2"
-       id="path3091"
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 74.717794,1008.2997 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="path3934"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z" />
+    <path
+       d="m 61.50002,33.49995 -1,0"
+       id="path4269"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 61.50002,39.49995 -1,0"
+       id="path4271"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 61.49402,45.49995 -0.9881,0"
+       id="path4273"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 61.50002,51.49995 -1,0"
+       id="path4275"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 61.50002,57.49995 -1,0"
+       id="path4277"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 62.50002,32.5 -2.0119,0 m 2.0119,6 -2.0119,0 m 2.0119,6 -1.9881,0 m 1.9881,6 -2.0119,0 m 2.0119,6 -2.0119,0"
+       id="path4279"
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/mimes/64/x-office-presentation.svg
+++ b/mimes/64/x-office-presentation.svg
@@ -6,398 +6,418 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="64"
+   id="svg4954"
    height="64"
-   id="svg4954">
+   width="64"
+   version="1.1">
   <defs
      id="defs4956">
     <linearGradient
        id="linearGradient4356">
       <stop
-         id="stop4358"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
+         id="stop4358" />
       <stop
-         offset="0.01041535"
+         id="stop4360"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop4360" />
+         offset="0.01041535" />
       <stop
-         id="stop4362"
+         offset="0.98265791"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.98265791" />
+         id="stop4362" />
       <stop
-         id="stop4364"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop4364" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2">
       <stop
-         id="stop3602-1-25-9"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9" />
       <stop
-         id="stop3604-4-2-0"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-5-8-7">
       <stop
-         id="stop3602-1-25-9-9-6-5-6"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9-9-6-5-6" />
       <stop
-         id="stop3604-4-2-0-2-4-2-1"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0-2-4-2-1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-2-6-2">
       <stop
-         id="stop3106-1-5-9-3-1-7-1"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-1-5-9-3-1-7-1" />
       <stop
-         id="stop3108-1-5-5-7-2-4-5"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-1-5-5-7-2-4-5" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-0-0-9">
       <stop
-         id="stop3213-0-0-8-1-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3213-0-0-8-1-1" />
       <stop
-         id="stop3215-1-8-0-6-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3215-1-8-0-6-4" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-3-2-2-6-8">
       <stop
-         id="stop3602-1-25-9-9-7"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602-1-25-9-9-7" />
       <stop
-         id="stop3604-4-2-0-2-0"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604-4-2-0-2-0" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-9-7-3-9-6">
       <stop
-         id="stop3106-1-5-9-3-2"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-1-5-9-3-2" />
       <stop
-         id="stop3108-1-5-5-7-4"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-1-5-5-7-4" />
     </linearGradient>
     <linearGradient
        id="linearGradient3211-8-8-9">
       <stop
-         id="stop3213-0-0-3"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3213-0-0-3" />
       <stop
-         id="stop3215-1-8-9"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3215-1-8-9" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-5">
       <stop
-         id="stop3106-9"
+         offset="0"
          style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
+         id="stop3106-9" />
       <stop
-         id="stop3108-9"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       x1="22.004084"
-       y1="63.217903"
-       x2="22.004084"
-       y2="25.646791"
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-4.354333,114.86293)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-5"
        id="linearGradient3091"
-       xlink:href="#linearGradient3104-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-4.3543329,109.86293)" />
-    <linearGradient
-       y2="41.754993"
-       x2="23.99999"
-       y1="5.9472284"
-       x1="23.99999"
-       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,8.7027135)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3076"
-       xlink:href="#linearGradient4356" />
-    <linearGradient
-       xlink:href="#linearGradient3600-3-2-2"
-       id="linearGradient3917"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.456847,0,0,1.4786648,-1.1924073,-0.77586567)"
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188" />
-    <linearGradient
-       xlink:href="#linearGradient3211-8-8-9"
-       id="linearGradient3928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1170825,0,0,1.1675323,-10.354736,0.0319621)"
-       x1="24"
-       y1="14.203104"
-       x2="24"
-       y2="35.721317" />
-    <linearGradient
-       xlink:href="#linearGradient3600-3-2-2-6-8"
-       id="linearGradient3931"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0328317,0,0,1.1210596,-9.6861059,-0.52865063)"
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188" />
-    <linearGradient
-       xlink:href="#linearGradient3104-9-7-3-9-6"
-       id="linearGradient3933"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6415049,0,0,1.0491448,111.08489,-1.7780482)"
-       x1="-51.786404"
-       y1="41.797989"
-       x2="-51.786404"
-       y2="17.555471" />
-    <linearGradient
-       xlink:href="#linearGradient3211-8-8-0-0-9"
-       id="linearGradient3936"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.9929997,0,0,0.11114027,-27.91011,7.1953799)"
-       x1="24"
-       y1="14.203104"
-       x2="24"
-       y2="35.721317" />
-    <linearGradient
-       xlink:href="#linearGradient3600-3-2-2-6-5-8-7"
-       id="linearGradient3939"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6847692,0,0,0.1535966,-23.167729,5.8101858)"
-       x1="25.132275"
-       y1="15.284525"
-       x2="25.132275"
-       y2="37.546188" />
-    <linearGradient
-       xlink:href="#linearGradient3104-9-7-3-9-2-6-2"
-       id="linearGradient3941"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1679425,0,0,0.14374353,136.33503,5.6390056)"
-       x1="-51.786404"
-       y1="41.797989"
-       x2="-51.786404"
-       y2="17.555471" />
-    <linearGradient
-       xlink:href="#linearGradient3104-5"
-       id="linearGradient3968"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-4.3543329,125.86293)"
-       x1="22.004084"
-       y1="63.217903"
+       y2="25.646791"
        x2="22.004084"
-       y2="25.646791" />
+       y1="63.217903"
+       x1="22.004084" />
+    <linearGradient
+       xlink:href="#linearGradient4356"
+       id="linearGradient3076"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,13.702713)"
+       x1="23.99999"
+       y1="5.9472284"
+       x2="23.99999"
+       y2="41.754993" />
+    <linearGradient
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275"
+       gradientTransform="matrix(1.456847,0,0,1.4786648,-1.1924073,4.2241341)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3917"
+       xlink:href="#linearGradient3600-3-2-2" />
+    <linearGradient
+       y2="35.721317"
+       x2="24"
+       y1="14.203104"
+       x1="24"
+       gradientTransform="matrix(2.1170825,0,0,1.1675323,-10.354736,5.0319619)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3928"
+       xlink:href="#linearGradient3211-8-8-9" />
+    <linearGradient
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275"
+       gradientTransform="matrix(2.0328317,0,0,1.1210596,-9.6861059,4.4713491)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931"
+       xlink:href="#linearGradient3600-3-2-2-6-8" />
+    <linearGradient
+       y2="17.555471"
+       x2="-51.786404"
+       y1="41.797989"
+       x1="-51.786404"
+       gradientTransform="matrix(1.6415049,0,0,1.0491448,111.08489,3.2219516)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3933"
+       xlink:href="#linearGradient3104-9-7-3-9-6" />
+    <linearGradient
+       y2="35.721317"
+       x2="24"
+       y1="14.203104"
+       x1="24"
+       gradientTransform="matrix(2.9929997,0,0,0.11114027,-27.91011,12.19538)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3936"
+       xlink:href="#linearGradient3211-8-8-0-0-9" />
+    <linearGradient
+       y2="37.546188"
+       x2="25.132275"
+       y1="15.284525"
+       x1="25.132275"
+       gradientTransform="matrix(2.6847692,0,0,0.1535966,-23.167729,10.810186)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3939"
+       xlink:href="#linearGradient3600-3-2-2-6-5-8-7" />
+    <linearGradient
+       y2="17.555471"
+       x2="-51.786404"
+       y1="41.797989"
+       x1="-51.786404"
+       gradientTransform="matrix(2.1679425,0,0,0.14374353,136.33503,10.639005)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3941"
+       xlink:href="#linearGradient3104-9-7-3-9-2-6-2" />
+    <linearGradient
+       y2="25.646791"
+       x2="22.004084"
+       y1="63.217903"
+       x1="22.004084"
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,-4.354333,130.86293)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3968"
+       xlink:href="#linearGradient3104-5" />
     <linearGradient
        id="linearGradient3702-501-757-795">
       <stop
-         offset="0"
+         id="stop3100"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3100" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop3102"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3102" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop3104"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3104" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309-604">
       <stop
-         offset="0"
+         id="stop3094"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3094" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3096"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3096" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-166-749-654">
       <stop
-         offset="0"
+         id="stop3088"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3088" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3090"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3090" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3688-166-749-654"
-       id="radialGradient4172"
-       gradientUnits="userSpaceOnUse"
+       r="2.5"
+       fy="43.5"
+       fx="4.9929786"
+       cy="43.5"
+       cx="4.9929786"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4172"
+       xlink:href="#linearGradient3688-166-749-654" />
     <radialGradient
-       xlink:href="#linearGradient3688-464-309-604"
-       id="radialGradient4174"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
+       r="2.5"
        fy="43.5"
-       r="2.5" />
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757-795"
-       id="linearGradient4176"
+       fx="4.9929786"
+       cy="43.5"
+       cx="4.9929786"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
+       id="radialGradient4174"
+       xlink:href="#linearGradient3688-464-309-604" />
+    <linearGradient
+       y2="39.999443"
        x2="25.058096"
-       y2="39.999443" />
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4176"
+       xlink:href="#linearGradient3702-501-757-795" />
     <linearGradient
-       xlink:href="#linearGradient3104-5"
+       y2="25.646791"
+       x2="22.004084"
+       y1="63.217903"
+       x1="22.004084"
+       gradientTransform="matrix(1.3394176,0,0,-1.9826305,6.833167,114.86293)"
+       gradientUnits="userSpaceOnUse"
        id="linearGradient4180"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,-1.9826305,6.8331671,109.86293)"
-       x1="22.004084"
-       y1="63.217903"
-       x2="22.004084"
-       y2="25.646791" />
+       xlink:href="#linearGradient3104-5" />
     <linearGradient
-       xlink:href="#linearGradient3104-5"
-       id="linearGradient4185"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3394176,0,0,1.9826305,7.6456671,-34.862932)"
-       x1="22.004084"
-       y1="63.217903"
+       y2="25.646791"
        x2="22.004084"
-       y2="25.646791" />
+       y1="63.217903"
+       x1="22.004084"
+       gradientTransform="matrix(1.3394176,0,0,1.9826305,7.645667,-29.862932)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4185"
+       xlink:href="#linearGradient3104-5" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
       <stop
-         offset="0"
+         id="stop3750-1-0-7-6-6-1-3-9"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9" />
+         offset="0" />
       <stop
-         offset="0.26238"
+         id="stop3752-3-7-4-0-32-8-923-0"
          style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0" />
+         offset="0.26238" />
       <stop
-         offset="0.704952"
+         id="stop3754-1-8-5-2-7-6-7-1"
          style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1" />
+         offset="0.704952" />
       <stop
-         offset="1"
+         id="stop3756-1-6-2-6-6-1-96-6"
          style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="12.671875"
-       fy="9.9571075"
-       fx="6.2001843"
-       cy="9.9571075"
-       cx="6.7304144"
-       gradientTransform="matrix(0,10.228133,-12.55688,0,151.01469,-80.173359)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8"
        id="radialGradient4173-5"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,10.228133,-12.55688,0,151.01469,-75.173359)"
+       cx="6.7304144"
+       cy="9.9571075"
+       fx="6.2001843"
+       fy="9.9571075"
+       r="12.671875" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-2-8">
       <stop
-         offset="0"
+         id="stop3750-1-0-7-6-6-1-3-9-9-0"
          style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-9-0" />
+         offset="0" />
       <stop
-         offset="0.26238"
+         id="stop3752-3-7-4-0-32-8-923-0-7-8"
          style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7-8" />
+         offset="0.26238" />
       <stop
-         offset="0.704952"
+         id="stop3754-1-8-5-2-7-6-7-1-8-0"
          style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-8-0" />
+         offset="0.704952" />
       <stop
-         offset="1"
+         id="stop3756-1-6-2-6-6-1-96-6-1-1"
          style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-1-1" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       y2="41.754993"
-       x2="23.99999"
-       y1="5.9472284"
-       x1="23.99999"
-       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,8.7027135)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4356-5"
        id="linearGradient3076-9"
-       xlink:href="#linearGradient4356-5" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.054054,-0.40540014,13.702713)"
+       x1="23.99999"
+       y1="5.9472284"
+       x2="23.99999"
+       y2="41.754993" />
     <linearGradient
        id="linearGradient4356-5">
       <stop
-         id="stop4358-6"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
+         id="stop4358-6" />
       <stop
-         offset="0.01041535"
+         id="stop4360-9"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop4360-9" />
+         offset="0.01041535" />
       <stop
-         id="stop4362-4"
+         offset="0.98265791"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.98265791" />
+         id="stop4362-4" />
       <stop
-         id="stop4364-6"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop4364-6" />
     </linearGradient>
     <linearGradient
        id="linearGradient3104-6-6-1">
       <stop
-         offset="0"
+         id="stop3106-3-2"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3-2" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3108-9-8-3"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9-8-3" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(1.3150653,0,0,0.83371382,89.668048,10.259733)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6-6-1"
        id="linearGradient4420"
-       xlink:href="#linearGradient3104-6-6-1" />
-    <radialGradient
-       cx="6.5633106"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.0330806"
-       fy="9.9571075"
-       id="radialGradient3029"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,10.035098,-12.319893,0,154.65609,-88.47417)" />
+       gradientTransform="matrix(1.3150653,0,0,0.83371382,89.668048,15.259733)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <radialGradient
+       gradientTransform="matrix(0,10.035098,-12.319893,0,154.65609,-83.287144)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       id="radialGradient3029"
+       fy="9.9571075"
+       fx="6.0330806"
+       r="12.671875"
+       cy="9.9571075"
+       cx="6.5633106" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.0330806"
+       cy="9.9571075"
+       cx="6.5633106"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,154.65609,-83.316052)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4232"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="6.0330806"
+       cy="9.9571075"
+       cx="6.5633106"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,154.65609,-83.316805)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4234"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8" />
   </defs>
   <metadata
      id="metadata4959">
@@ -412,112 +432,112 @@
     </rdf:RDF>
   </metadata>
   <g
-     transform="matrix(1.6842106,0,0,0.7142857,-8.4210536,23.428572)"
+     style="opacity:0.15"
      id="g3712"
-     style="opacity:0.15">
+     transform="matrix(1.6842106,0,0,0.7142857,-8.4210536,28.428572)">
     <rect
-       width="5"
-       height="7"
-       x="38"
-       y="40"
+       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none"
        id="rect2801"
-       style="fill:url(#radialGradient4172);fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="7"
-       x="-10"
-       y="-47"
-       transform="scale(-1,-1)"
-       id="rect3696"
-       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none" />
-    <rect
-       width="28"
-       height="7.0000005"
-       x="10"
        y="40"
+       x="38"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#radialGradient4174);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1,-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none"
        id="rect3700"
-       style="fill:url(#linearGradient4176);fill-opacity:1;stroke:none" />
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
   <path
-     style="opacity:0.5;color:#000000;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 14.499961,12.499961 35.000079,0 0,4.000078 -35.000079,0 z"
      id="rect4964-4-4"
-     d="m 14.499961,7.4999612 35.000079,0 0,4.0000778 -35.000079,0 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3939);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3941);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.3;color:#000000;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 15.499961,13.499999 33.000078,0 0,2.50004 -33.000078,0 z"
      id="rect4964-1-6-5"
-     d="m 15.499961,8.4999993 33.000078,0 0,2.5000397 -33.000078,0 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3936);stroke-width:0.99992162;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.75;color:#000000;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="M 8.499961,15.499961 55.50004,15.5 l 0,30 L 8.5,45.5 Z"
      id="rect4964-4"
-     d="m 8.499961,10.499961 47.000079,0.0675 0,30.432581 -46.7341017,0 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:url(#linearGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3933);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.45;color:#000000;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="M 9.4999609,16.499965 54.500041,16.5 54.5,44.5 l -45,0 z"
      id="rect4964-1-6"
-     d="m 9.4999609,11.499965 45.0000801,0.03138 -0.221054,28.468694 -44.4140201,0 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:none;stroke:url(#linearGradient3928);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <rect
-     width="51"
-     height="40"
-     x="9"
-     y="14"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;enable-background:accumulate"
      id="rect4964"
-     style="color:#000000;fill:url(#linearGradient3917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     y="19"
+     x="9"
+     height="40"
+     width="51" />
   <rect
-     width="55.00008"
-     height="39.00008"
-     x="4.4999599"
-     y="14.499959"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect4964-1"
-     style="opacity:1;color:#000000;fill:none;stroke:url(#linearGradient3076-9);stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     y="19.499958"
+     x="4.4999599"
+     height="39.00008"
+     width="55.00008" />
   <path
-     style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path3035-5"
-     d="m 55,37.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z" />
-  <path
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="path3035"
-     d="M 55,36.84188 A 10,10 0 1 1 49.710119,28.020613 L 45.000001,36.84188 z" />
-  <path
-     d="m 14,39.999999 0,-1 2.21875,0 0,1 z m 2.65625,0 0,-1 6.34375,0 0,1 z m -2.65625,-4 0,-1 2.96875,0 0,1 z m 3.71875,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 1.1875,0 0,1 z m 1.8125,0 0,-1 2.15625,0 0,1 z m -8.46875,-4 0,-1 3.28125,0 0,1 z m 3.875,0 0,-1 1.65625,0 0,1 z m 2.21875,0 0,-1 3.71875,0 0,1 z m -6.09375,-4 0,-1 3.28125,0 0,1 z m 3.90625,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 3.6875,0 0,1 z"
-     id="path3475-4"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
-  <path
-     style="color:#000000;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 9,59.5 -5.5,0 c 0,-13.126119 0,-39.735582 0,-41 1.2542902,0 3.9373045,-3e-6 5.5,-3e-6"
      id="path4530"
-     d="m 9.035786,54.5 c 0,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.485462 -0.102163,-1.449298 -0.203479,-2.136563 0,-12.875954 0,-25.751906 0,-38.627855 l 0.05947,-0.166735 0.14401,-0.06885 0,0 c 1.825936,0 5.2370056,0 5.2370056,0" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4173-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.50000000000000000;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-     d="m 8.5,53.499998 -4,0 0,-38.999999 4,0"
-     id="rect6741-1-5" />
+     id="rect6741-1-5"
+     d="m 8.5,58.499998 -4,0 0,-38.999999 4,0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3076);stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     id="path3925"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.28000004;color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="m 37,18 0,1 0.984375,-1e-6 0,-1 z m 1.640625,-1e-6 0,1 2.640625,0 0,-1 z m 3.359375,0 0,1 3,1e-6 0,-1 z m -19.75,0 0,1 5.734375,0 0,-1 z m 6.390625,0 0,1 2.640625,0 0,-1 z m 3.359375,0 0,1 3.75,0 0,-1 z" />
-  <path
-     d="m 55,36.84188 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -4.178198,1.15662 -9.013426,-0.776912 -11.243199,-4.495223 -0.01769,0.01604 8.574793,-5.142078 8.574793,-5.142078 z"
-     id="path3964"
-     style="opacity:0.4;color:#000000;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
-  <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     id="path3966"
-     d="m 14,47.999999 0,-1 3.28125,0 0,1 z m 3.875,0 0,-1 1.65625,0 0,1 z m 2.21875,0 0,-1 3.71875,0 0,1 z m -6.09375,-4 0,-1 3.28125,0 0,1 z m 3.90625,0 0,-1 2.34375,0 0,1 z m 2.9375,0 0,-1 3.6875,0 0,1 z" />
-  <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     id="path4178"
-     d="m 25.1875,40 0,-1 2.21875,0 0,1 z m 0,-4 0,-1 2.96875,0 0,1 z m -0.90625,-4 0,-1 2.71875,0 0,1 z m 1.375,-4 0,-1 2.34375,0 0,1 z" />
-  <path
-     d="m 25,43 0,1 3.28125,0 0,-1 z m 3.875,0 0,1 1.65625,0 0,-1 z m -4.15625,4 0,1 L 28,48 28,47 z m 3.90625,0 0,1 2.34375,0 0,-1 z m 2.9375,0 0,1 3.6875,0 0,-1 z"
-     id="path4183"
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
-  <path
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="m 9,59.5 -5.5,0 c 0,-1.5 0.00828,-27.437181 0,-41 l 5.5,-3e-6"
      id="path4530-3"
-     d="m 9.035786,54.5 c -1.754361,0 -3.5542086,0 -5.3085786,0 -0.426414,-0.485462 -0.102163,-1.449298 -0.203479,-2.136563 0,-12.875954 0,-25.751906 0,-38.627855 l 0.05947,-0.166735 0.14401,-0.06885 0,0 c 1.825936,0 3.4110786,0 5.2370056,0" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-     d="m 9,54.5 51.5,0 0,-41 -51.5,0"
-     id="path4160-6-1" />
+     id="path4160-6-1"
+     d="m 9,59.5 51.5,0 0,-41 -51.5,0"
+     style="display:inline;fill:none;stroke:url(#linearGradient4420);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 55,36.84188 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -0.09762,-0.01695 -2.668406,-9.637301 -2.668406,-9.637301 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3091);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path3475-4"
+     d="m 14,44.999999 0,-1 2,0 0,1 z m 3,0 0,-1 6,0 0,1 z m -3,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 1,0 0,1 z m 2,0 0,-1 1,0 0,1 z m -9,-4 0,-1 3,0 0,1 z m 4,0 0,-1 1,0 0,1 z m 2,0 0,-1 4,0 0,1 z m -6,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 4,0 0,1 z" />
+  <path
+     d="m 37,23 0,1 0.984375,-1e-6 0,-1 z m 1.640625,-1e-6 0,1 2.640625,0 0,-1 z m 3.359375,0 0,1 3,1e-6 0,-1 z m -19.75,0 0,1 5.734375,0 0,-1 z m 6.390625,0 0,1 2.640625,0 0,-1 z m 3.359375,0 0,1 3.75,0 0,-1 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.28000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+     id="path3925" />
+  <path
+     d="m 14,52.999999 0,-1 3,0 0,1 z m 4,0 0,-1 1,0 0,1 z m 2,0 0,-1 4,0 0,1 z m -6,-4 0,-1 3,0 0,1 z m 4,0 0,-1 2,0 0,1 z m 3,0 0,-1 3,0 0,1 z"
+     id="path3966"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3968);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     d="m 25,45 0,-1 2,0 0,1 z m 0,-4 0,-1 3,0 0,1 z m 0,-4 0,-1 2,0 0,1 z m 1,-4 0,-1 2,0 0,1 z"
+     id="path4178"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4180);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4185);fill-opacity:1;stroke:none;stroke-width:0.99999994px;marker:none;enable-background:accumulate"
+     id="path4183"
+     d="m 25,48 0,1 3,0 0,-1 z m 4,0 0,1 2,0 0,-1 z m -4,4 0,1 3,0 0,-1 z m 4,0 0,1 2,0 0,-1 z m 3,0 0,1 3,0 0,-1 z" />
+  <path
+     d="m 55,42.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
+     id="path3035-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.54960775;marker:none;enable-background:accumulate" />
+  <path
+     d="m 55,41.999998 a 10,10 0 1 1 -5.289881,-8.821267 l -4.710118,8.821267 z"
+     id="path3035"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4232);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3964"
+     d="m 55,42.028906 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -4.178198,1.15662 -9.013426,-0.776912 -11.243199,-4.495223 -0.01769,0.01604 8.574793,-5.142078 8.574793,-5.142078 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4234);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3962"
-     style="opacity:0.8;color:#000000;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     d="m 55,41.999245 c 10e-7,4.335689 -3.153395,8.480681 -7.331593,9.637301 -0.09762,-0.01695 -2.668406,-9.637301 -2.668406,-9.637301 z" />
 </svg>


### PR DESCRIPTION
I moved the baselines to match those in the HIG and cleaned up a bit. As the baselines go I checked with other icons and the changing the baseline does't seem to throw off the x-height. It appears to match up with the shorter icons like video-player or video-x-generic.