### PR TITLE
Add links for channel-secure

### DIFF
--- a/status/16/channel-secure.svg
+++ b/status/16/channel-secure.svg
@@ -1,0 +1,1 @@
+locked.svg

--- a/status/16/locked.svg
+++ b/status/16/locked.svg
@@ -6,238 +6,218 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="16"
+   id="svg4099"
    height="16"
-   id="svg4099">
+   width="16"
+   version="1.1">
   <defs
      id="defs4101">
     <linearGradient
-       x1="24"
-       y1="29"
-       x2="24"
-       y2="14"
-       id="linearGradient4144"
-       xlink:href="#linearGradient5475-8"
+       gradientTransform="matrix(0.66666666,0,0,0.46666666,-3.1666666,0.46666564)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666666,0,0,0.46666666,-3.1666666,0.46666564)" />
+       xlink:href="#linearGradient5475-8"
+       id="linearGradient4144"
+       y2="14"
+       x2="24"
+       y1="29"
+       x1="24" />
     <linearGradient
        id="linearGradient5475-8">
       <stop
-         id="stop5477-0"
+         offset="0"
          style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
+         id="stop5477-0" />
       <stop
-         id="stop5479-4"
+         offset="1"
          style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
+         id="stop5479-4" />
     </linearGradient>
     <linearGradient
-       x1="24"
-       y1="29"
-       x2="24"
-       y2="14"
-       id="linearGradient3976"
+       gradientTransform="matrix(0.66666666,0,0,0.46666666,-12.166666,0.46666564)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5475-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666666,0,0,0.46666666,-12.166666,0.46666564)" />
-    <linearGradient
-       id="linearGradient4043">
-      <stop
-         id="stop4045"
-         style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4047"
-         style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
+       id="linearGradient3976"
        y2="14"
-       id="linearGradient3065"
-       xlink:href="#linearGradient3966-0-4"
+       x2="24"
+       y1="29"
+       x1="24" />
+    <linearGradient
+       gradientTransform="matrix(0.66666664,0,0,0.46667556,-1.1666667,-20.533589)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666664,0,0,0.46667556,-1.1666667,-20.533589)" />
+       xlink:href="#linearGradient3966-0-4"
+       id="linearGradient3065"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
     <linearGradient
        id="linearGradient3966-0-4">
       <stop
-         id="stop3968-8-0"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0" />
       <stop
-         id="stop3970-7-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4" />
     </linearGradient>
     <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
-       y2="14"
-       id="linearGradient3062"
-       xlink:href="#linearGradient3966-0-4-2"
+       gradientTransform="matrix(0.66666664,0,0,0.46667556,5.8333347,-20.533589)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666664,0,0,0.46667556,5.8333347,-20.533589)" />
+       xlink:href="#linearGradient3966-0-4-2"
+       id="linearGradient3062"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
     <linearGradient
        id="linearGradient3966-0-4-2">
       <stop
-         id="stop3968-8-0-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0-1" />
       <stop
-         id="stop3970-7-4-2"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4-2" />
     </linearGradient>
     <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
-       y2="27.5"
-       id="linearGradient4158"
-       xlink:href="#linearGradient3865-4-8"
+       gradientTransform="matrix(-0.93357748,0,0,1,23.379997,-15)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.93357748,0,0,1,23.379997,-15)" />
+       xlink:href="#linearGradient3865-4-8"
+       id="linearGradient4158"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
     <linearGradient
        id="linearGradient3865-4-8">
       <stop
-         id="stop3867-110-9"
+         offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop3867-110-9" />
       <stop
-         id="stop3869-96-3"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop3869-96-3" />
     </linearGradient>
     <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
-       y2="27.5"
-       id="linearGradient3951"
-       xlink:href="#linearGradient6057-35-7"
+       gradientTransform="matrix(-0.93357745,0,0,1,23.379997,-22)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.93357745,0,0,1,23.379997,-22)" />
+       xlink:href="#linearGradient6057-35-7"
+       id="linearGradient3951"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
     <linearGradient
        id="linearGradient6057-35-7">
       <stop
-         id="stop6059-0-7"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop6059-0-7" />
       <stop
-         id="stop6061-4-9"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop6061-4-9" />
     </linearGradient>
     <linearGradient
-       x1="10.314445"
-       y1="7.0003052"
-       x2="10.314445"
-       y2="16.000305"
-       id="linearGradient3963"
-       xlink:href="#linearGradient3957"
+       gradientTransform="translate(0,-1.0003052)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-1.0003052)" />
+       xlink:href="#linearGradient3957"
+       id="linearGradient3963"
+       y2="16.000305"
+       x2="10.314445"
+       y1="7.0003052"
+       x1="10.314445" />
     <linearGradient
        id="linearGradient3957">
       <stop
-         id="stop3959"
+         offset="0"
          style="stop-color:#b19c7d;stop-opacity:1"
-         offset="0" />
+         id="stop3959" />
       <stop
-         id="stop3961"
+         offset="1"
          style="stop-color:#a08358;stop-opacity:1"
-         offset="1" />
+         id="stop3961" />
     </linearGradient>
     <linearGradient
-       x1="21.771429"
-       y1="14.871428"
-       x2="21.771429"
-       y2="27.924538"
-       id="linearGradient3059"
-       xlink:href="#linearGradient5443"
+       gradientTransform="matrix(0.47368427,0,0,0.42857142,0.4210521,1.2857141)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.47368427,0,0,0.42857142,0.4210521,1.2857141)" />
+       xlink:href="#linearGradient5443"
+       id="linearGradient3059"
+       y2="27.924538"
+       x2="21.771429"
+       y1="14.871428"
+       x1="21.771429" />
     <linearGradient
        id="linearGradient5443">
       <stop
-         id="stop5445"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop5445" />
       <stop
-         id="stop5447"
+         offset="0.03252051"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03252051" />
+         id="stop5447" />
       <stop
-         id="stop5449"
+         offset="0.98558509"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.98558509" />
+         id="stop5449" />
       <stop
-         id="stop5451"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop5451" />
     </linearGradient>
     <radialGradient
-       cx="16.823883"
-       cy="11.368058"
-       r="10.5"
-       fx="16.777113"
-       fy="11.597148"
-       id="radialGradient3074"
-       xlink:href="#linearGradient5409"
+       gradientTransform="matrix(0,0.80952382,-1.1390521,0,20.94881,-6.3693335)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.80952382,-1.1390521,0,20.94881,-6.3693335)" />
+       xlink:href="#linearGradient5409"
+       id="radialGradient3074"
+       fy="11.597148"
+       fx="16.777113"
+       r="10.5"
+       cy="11.368058"
+       cx="16.823883" />
     <linearGradient
        id="linearGradient5409">
       <stop
-         id="stop5411"
+         offset="0"
          style="stop-color:#f2e0c4;stop-opacity:1"
-         offset="0" />
+         id="stop5411" />
       <stop
-         id="stop5559"
+         offset="0.76470584"
          style="stop-color:#e5af5b;stop-opacity:1"
-         offset="0.76470584" />
+         id="stop5559" />
       <stop
-         id="stop5413"
+         offset="1"
          style="stop-color:#af6900;stop-opacity:1"
-         offset="1" />
+         id="stop5413" />
     </linearGradient>
-    <linearGradient
-       x1="10.650842"
-       y1="2.9136841"
-       x2="27.192274"
-       y2="17.470011"
-       id="linearGradient3996"
-       xlink:href="#linearGradient10591-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2606375,0,0,0.3148868,1.7267638,-0.04783173)" />
     <linearGradient
        id="linearGradient10591-0">
       <stop
-         id="stop10593-1"
+         offset="0"
          style="stop-color:#cad0c6;stop-opacity:1"
-         offset="0" />
+         id="stop10593-1" />
       <stop
-         id="stop10599-3"
+         offset="0.5"
          style="stop-color:#eaece9;stop-opacity:1"
-         offset="0.5" />
+         id="stop10599-3" />
       <stop
-         id="stop10595-3"
+         offset="1"
          style="stop-color:#c5cbc0;stop-opacity:1"
-         offset="1" />
+         id="stop10595-3" />
     </linearGradient>
     <linearGradient
-       x1="10.650842"
-       y1="2.9136841"
-       x2="27.192274"
-       y2="17.470011"
-       id="linearGradient4097"
-       xlink:href="#linearGradient10591-0"
+       gradientTransform="matrix(0.2606375,0,0,0.3148868,1.7267638,-0.0481369)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2606375,0,0,0.3148868,1.7267638,-0.0481369)" />
+       xlink:href="#linearGradient10591-0"
+       id="linearGradient4097"
+       y2="17.470011"
+       x2="27.192274"
+       y1="2.9136841"
+       x1="10.650842" />
   </defs>
   <metadata
      id="metadata4104">
@@ -254,87 +234,87 @@
   <g
      id="layer1">
     <path
-       d="m 4.4999998,8.4996391 0,-3.3753574 c 0,-2.4782011 1.3702785,-3.6555186 3.4872865,-3.62457 2.1285247,0.030949 3.5133857,1.1172142 3.5133857,3.62457 l 0,3.3753574 -1.431082,0 0,-2.7455829 c 0,-0.6297745 0.148159,-2.6676754 -2.0673917,-2.6676754 -2.1972832,0 -2.0371829,2.0504603 -2.0286629,2.6651649 l 0,2.7480934 z"
+       style="opacity:0.4;fill:url(#linearGradient4097);fill-opacity:1;fill-rule:evenodd;stroke:none"
        id="path2086-4"
-       style="opacity:0.4;fill:url(#linearGradient4097);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+       d="m 4.4999998,8.4996391 0,-3.3753574 c 0,-2.4782011 1.3702785,-3.6555186 3.4872865,-3.62457 2.1285247,0.030949 3.5133857,1.1172142 3.5133857,3.62457 l 0,3.3753574 -1.431082,0 0,-2.7455829 c 0,-0.6297745 0.148159,-2.6676754 -2.0673917,-2.6676754 -2.1972832,0 -2.0371829,2.0504603 -2.0286629,2.6651649 l 0,2.7480934 z" />
     <path
-       d="M 5.2,6 C 5.2,6 4.6101697,2.5 8,2.5 11.38983,2.5 10.8,6 10.8,6"
+       style="opacity:0.6;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
        id="path4161"
-       style="opacity:0.6;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+       d="M 5.2,6 C 5.2,6 4.6101697,2.5 8,2.5 11.38983,2.5 10.8,6 10.8,6" />
     <path
-       d="m 4.4999998,8.4996395 0,-3.3753574 c 0,-2.4782011 1.3702785,-3.6555186 3.4872865,-3.62457 2.1285247,0.030949 3.5133857,1.1172142 3.5133857,3.62457 l 0,3.3753574 -2.000672,0 0,-2.7455829 C 9.5,5.1242821 9.6514618,3.5 8.0021983,3.5 6.3529348,3.5 6.49148,5.1368415 6.5,5.7515461 l 0,2.7480934 z"
+       style="opacity:0.4;fill:none;stroke:#000000;stroke-width:0.99999952;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
        id="path2086-3"
-       style="opacity:0.4;fill:none;stroke:#000000;stroke-width:0.99999952;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       d="m 4.4999998,8.4996395 0,-3.3753574 c 0,-2.4782011 1.3702785,-3.6555186 3.4872865,-3.62457 2.1285247,0.030949 3.5133857,1.1172142 3.5133857,3.62457 l 0,3.3753574 -2.000672,0 0,-2.7455829 C 9.5,5.1242821 9.6514618,3.5 8.0021983,3.5 6.3529348,3.5 6.49148,5.1368415 6.5,5.7515461 l 0,2.7480934 z" />
     <rect
-       width="11"
-       height="8"
-       rx="1"
-       ry="1"
-       x="2.5"
-       y="6.4999995"
+       style="color:#000000;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect3186-2"
-       style="color:#000000;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="9"
-       height="6"
-       x="3.5"
-       y="7.500001"
-       id="rect3186-3"
-       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3059);stroke-width:1px;stroke-linejoin:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="11"
-       height="8"
-       rx="1"
-       ry="1"
+       y="6.4999995"
        x="2.5"
-       y="6.5"
+       ry="1"
+       rx="1"
+       height="8"
+       width="11" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3059);stroke-width:1px;stroke-linejoin:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3186-3"
+       y="7.500001"
+       x="3.5"
+       height="6"
+       width="9" />
+    <rect
+       style="color:#000000;fill:none;stroke:url(#linearGradient3963);stroke-width:0.99999994px;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect3186"
-       style="color:#000000;fill:none;stroke:url(#linearGradient3963);stroke-width:0.99999994px;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       y="6.5"
+       x="2.5"
+       ry="1"
+       rx="1"
+       height="8"
+       width="11" />
     <path
-       d="m 3.5,7.5 9,-3.79e-4 m -9,2.0003788 9,-3.79e-4 M 3.5,11.5 l 9,-3.79e-4"
+       style="opacity:0.2;fill:none;stroke:url(#linearGradient3951);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
        id="path3863-3-5"
-       style="opacity:0.2;fill:none;stroke:url(#linearGradient3951);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       d="m 3.5,7.5 9,-3.79e-4 m -9,2.0003788 9,-3.79e-4 M 3.5,11.5 l 9,-3.79e-4" />
     <path
-       d="m 3.5,12.5 9,0 m -9,-6 9,0 m -9,2 9,0 m -9,2 9,0"
+       style="opacity:0.05;fill:none;stroke:url(#linearGradient4158);stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
        id="path4156"
-       style="opacity:0.05;fill:none;stroke:url(#linearGradient4158);stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       d="m 3.5,12.5 9,0 m -9,-6 9,0 m -9,2 9,0 m -9,2 9,0" />
     <rect
-       width="1"
-       height="7.000133"
-       rx="2"
-       ry="1"
-       x="11"
-       y="-14.000134"
-       transform="scale(1,-1)"
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect5453-4-4"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="1"
-       height="7.000133"
-       rx="2"
-       ry="1"
-       x="4"
-       y="-14.000134"
        transform="scale(1,-1)"
+       y="-14.000134"
+       x="11"
+       ry="1"
+       rx="2"
+       height="7.000133"
+       width="1" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect5453-4"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       transform="scale(1,-1)"
+       y="-14.000134"
+       x="4"
+       ry="1"
+       rx="2"
+       height="7.000133"
+       width="1" />
     <rect
-       width="1"
-       height="7"
-       rx="1.6"
-       ry="0.49999997"
-       x="3"
-       y="7"
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3976);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect3333"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3976);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="1"
-       height="7"
-       rx="1.6"
-       ry="0.49999997"
-       x="12"
        y="7"
+       x="3"
+       ry="0.49999997"
+       rx="1.6"
+       height="7"
+       width="1" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient4144);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect5453-6"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient4144);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       y="7"
+       x="12"
+       ry="0.49999997"
+       rx="1.6"
+       height="7"
+       width="1" />
   </g>
 </svg>

--- a/status/24/channel-secure.svg
+++ b/status/24/channel-secure.svg
@@ -1,0 +1,1 @@
+locked.svg

--- a/status/24/locked.svg
+++ b/status/24/locked.svg
@@ -6,585 +6,295 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="24"
+   id="svg5833"
    height="24"
-   id="svg5833">
+   width="24"
+   version="1.1">
   <defs
      id="defs5835">
     <linearGradient
        id="linearGradient5443">
       <stop
-         id="stop5445"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop5445" />
       <stop
-         id="stop5447"
+         offset="0.03252051"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03252051" />
+         id="stop5447" />
       <stop
-         id="stop5449"
+         offset="0.98558509"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.98558509" />
+         id="stop5449" />
       <stop
-         id="stop5451"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop5451" />
     </linearGradient>
     <linearGradient
        id="linearGradient3966-0-4-2">
       <stop
-         id="stop3968-8-0-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0-1" />
       <stop
-         id="stop3970-7-4-2"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4-2" />
     </linearGradient>
     <linearGradient
        id="linearGradient3966-0-4">
       <stop
-         id="stop3968-8-0"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0" />
       <stop
-         id="stop3970-7-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4" />
     </linearGradient>
     <linearGradient
        id="linearGradient5475">
       <stop
-         id="stop5477"
+         offset="0"
          style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
+         id="stop5477" />
       <stop
-         id="stop5479"
+         offset="1"
          style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
+         id="stop5479" />
     </linearGradient>
     <linearGradient
        id="linearGradient5483">
       <stop
-         id="stop5485"
+         offset="0"
          style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
+         id="stop5485" />
       <stop
-         id="stop5487"
+         offset="1"
          style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
+         id="stop5487" />
     </linearGradient>
     <linearGradient
        id="linearGradient5409">
       <stop
-         id="stop5411"
+         offset="0"
          style="stop-color:#f2e0c4;stop-opacity:1"
-         offset="0" />
+         id="stop5411" />
       <stop
-         id="stop5559"
+         offset="0.76470584"
          style="stop-color:#e5af5b;stop-opacity:1"
-         offset="0.76470584" />
+         id="stop5559" />
       <stop
-         id="stop5413"
+         offset="1"
          style="stop-color:#af6900;stop-opacity:1"
-         offset="1" />
+         id="stop5413" />
     </linearGradient>
     <linearGradient
        id="linearGradient6057">
       <stop
-         id="stop6059"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop6059" />
       <stop
-         id="stop6061"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop6061" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient10591">
-      <stop
-         id="stop10593"
-         style="stop-color:#cad0c6;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop10599"
-         style="stop-color:#eaece9;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop10595"
-         style="stop-color:#c5cbc0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="35.004684"
-       y1="14.849737"
-       x2="33.004314"
-       y2="14.849737"
-       id="linearGradient2505"
-       xlink:href="#linearGradient6227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(1.6824037,1.125)" />
-    <linearGradient
-       id="linearGradient6227">
-      <stop
-         id="stop6229"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6231"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <filter
-       x="-0.24242526"
-       y="-0.047579072"
-       width="1.4848505"
-       height="1.0951581"
-       color-interpolation-filters="sRGB"
-       id="filter6251">
-      <feGaussianBlur
-         id="feGaussianBlur6253"
-         stdDeviation="0.24444548" />
-    </filter>
-    <linearGradient
-       x1="32.128025"
-       y1="13.789077"
-       x2="35.020981"
-       y2="13.789077"
-       id="linearGradient2507"
-       xlink:href="#linearGradient6227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-19.532826,1.7437184)" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309">
       <stop
-         id="stop2889"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <linearGradient
-       x1="21.771429"
-       y1="14.871428"
-       x2="21.771429"
-       y2="27.924538"
-       id="linearGradient3059"
+       gradientTransform="matrix(0.68421053,0,0,0.64285716,1.0526316,2.1785711)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5443"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.68421053,0,0,0.64285716,1.0526316,2.1785711)" />
+       id="linearGradient3059"
+       y2="27.924538"
+       x2="21.771429"
+       y1="14.871428"
+       x1="21.771429" />
     <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
-       y2="14"
-       id="linearGradient3062"
+       gradientTransform="matrix(0.66666669,0,0,0.66666664,12.833333,-30.333334)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3966-0-4-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666669,0,0,0.66666664,12.833333,-30.333334)" />
-    <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
+       id="linearGradient3062"
        y2="14"
-       id="linearGradient3065"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       gradientTransform="matrix(0.66666669,0,0,0.66666664,-0.16666671,-30.333334)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3966-0-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666669,0,0,0.66666664,-0.16666671,-30.333334)" />
-    <linearGradient
-       x1="24"
-       y1="29"
-       x2="24"
+       id="linearGradient3065"
        y2="14"
-       id="linearGradient3068"
-       xlink:href="#linearGradient5475"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666666,0,0,0.66666664,1.8333326,1.6666665)" />
-    <linearGradient
-       x1="9"
-       y1="29"
        x2="9"
-       y2="14"
-       id="linearGradient3071"
-       xlink:href="#linearGradient5483"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666666,0,0,0.66666664,0.83333346,1.6666665)" />
-    <radialGradient
-       cx="16.823883"
-       cy="11.368058"
-       r="10.5"
-       fx="16.777113"
-       fy="11.597148"
-       id="radialGradient3074"
-       xlink:href="#linearGradient5409"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1130951,-1.5532529,0,29.657471,-7.1953328)" />
-    <radialGradient
-       cx="18.031223"
-       cy="6.2806997"
-       r="3.1819806"
-       fx="18.031223"
-       fy="6.2806997"
-       id="radialGradient3079"
-       xlink:href="#linearGradient6057"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46988398,0,0,0.47066524,0.45058673,-0.08319115)" />
+       y1="29"
+       x1="9" />
     <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient3087"
+       gradientTransform="matrix(0.66666666,0,0,0.66666664,1.8333326,1.6666665)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5475"
+       id="linearGradient3068"
+       y2="14"
+       x2="24"
+       y1="29"
+       x1="24" />
+    <linearGradient
+       gradientTransform="matrix(0.66666666,0,0,0.66666664,0.83333346,1.6666665)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5483"
+       id="linearGradient3071"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <radialGradient
+       gradientTransform="matrix(0,1.1130951,-1.5532529,0,29.657471,-7.1953328)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5409"
+       id="radialGradient3074"
+       fy="11.597148"
+       fx="16.777113"
+       r="10.5"
+       cy="11.368058"
+       cx="16.823883" />
+    <radialGradient
+       gradientTransform="matrix(0.46988398,0,0,0.47066524,0.45058673,-0.08319115)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6057"
+       id="radialGradient3079"
+       fy="6.2806997"
+       fx="18.031223"
+       r="3.1819806"
+       cy="6.2806997"
+       cx="18.031223" />
+    <linearGradient
+       gradientTransform="matrix(0.48214367,0,0,0.32142905,0.42857218,7.8928331)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3702-501-757"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48214367,0,0,0.32142905,0.42857218,7.8928331)" />
+       id="linearGradient3087"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
     <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3090"
+       gradientTransform="matrix(0.90170441,0,0,0.45000068,-9.7553581,-41.450027)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3688-464-309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.90170441,0,0,0.45000068,-9.7553581,-41.450027)" />
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
+       id="radialGradient3090"
        fy="43.5"
-       id="radialGradient3093"
-       xlink:href="#linearGradient3688-166-749"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(0.90170441,0,0,0.45000068,14.244682,2.2999681)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.90170441,0,0,0.45000068,14.244682,2.2999681)" />
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
        id="linearGradient3865-4">
       <stop
-         id="stop3867-110"
+         offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop3867-110" />
       <stop
-         id="stop3869-96"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop3869-96" />
     </linearGradient>
     <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
-       y2="27.5"
-       id="linearGradient3927-6"
+       gradientTransform="matrix(-0.87866114,0,0,0.69999996,25.533474,-5.7499988)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3865-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.87866114,0,0,0.69999996,25.533474,-5.7499988)" />
-    <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
+       id="linearGradient3927-6"
        y2="27.5"
-       id="linearGradient3888-76-7"
-       xlink:href="#linearGradient6057-35-4"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
+    <linearGradient
+       gradientTransform="matrix(-0.93357899,0,0,0.75000126,25.99446,-9.2500535)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.93357899,0,0,0.75000126,25.99446,-9.2500535)" />
+       xlink:href="#linearGradient6057-35-4"
+       id="linearGradient3888-76-7"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
     <linearGradient
        id="linearGradient6057-35-4">
       <stop
-         id="stop6059-0-5"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop6059-0-5" />
       <stop
-         id="stop6061-4-5"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop6061-4-5" />
     </linearGradient>
     <linearGradient
-       x1="10.650842"
-       y1="2.9136841"
-       x2="27.192274"
-       y2="17.470011"
-       id="linearGradient3543"
-       xlink:href="#linearGradient10591"
+       gradientTransform="matrix(0.41893991,0,0,0.47066524,1.8366141,-0.21869707)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.41893991,0,0,0.47066524,15.490757,0.78130283)" />
-    <linearGradient
-       x1="11.276111"
-       y1="8.9632645"
-       x2="31.420702"
-       y2="17.461874"
-       id="linearGradient3560-2"
        xlink:href="#linearGradient10591-3-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.41893991,0,0,0.47066524,1.8366141,-0.21869707)" />
+       id="linearGradient3560-2"
+       y2="17.461874"
+       x2="31.420702"
+       y1="8.9632645"
+       x1="11.276111" />
     <linearGradient
        id="linearGradient10591-3-5">
       <stop
-         id="stop10593-9-2"
+         offset="0"
          style="stop-color:#cad0c6;stop-opacity:1"
-         offset="0" />
+         id="stop10593-9-2" />
       <stop
-         id="stop10599-4-4"
+         offset="0.5"
          style="stop-color:#eaece9;stop-opacity:1"
-         offset="0.5" />
+         id="stop10599-4-4" />
       <stop
-         id="stop10595-6-6"
+         offset="1"
          style="stop-color:#c5cbc0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <filter
-       color-interpolation-filters="sRGB"
-       id="filter5745">
-      <feGaussianBlur
-         stdDeviation="0.8362597"
-         id="feGaussianBlur5747" />
-    </filter>
-    <linearGradient
-       x1="32.128025"
-       y1="13.789077"
-       x2="35.020981"
-       y2="13.789077"
-       id="linearGradient2625"
-       xlink:href="#linearGradient6227-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-19.532826,1.7437184)" />
-    <linearGradient
-       id="linearGradient6227-0">
-      <stop
-         id="stop6229-4"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6231-7"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <filter
-       x="-0.24242526"
-       y="-0.047579072"
-       width="1.4848505"
-       height="1.0951581"
-       color-interpolation-filters="sRGB"
-       id="filter6251-0">
-      <feGaussianBlur
-         stdDeviation="0.24444548"
-         id="feGaussianBlur6253-3" />
-    </filter>
-    <linearGradient
-       x1="35.004684"
-       y1="14.849737"
-       x2="33.004314"
-       y2="14.849737"
-       id="linearGradient2623"
-       xlink:href="#linearGradient6227-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(1.6824037,1.125)" />
-    <linearGradient
-       x1="10.650842"
-       y1="2.9136841"
-       x2="27.192274"
-       y2="17.470011"
-       id="linearGradient2638"
-       xlink:href="#linearGradient10591-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4093677,0,0,0.4715246,2.1464793,-1.8100287)" />
-    <linearGradient
-       id="linearGradient10591-4">
-      <stop
-         id="stop10593-5"
-         style="stop-color:#cad0c6;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop10599-9"
-         style="stop-color:#eaece9;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop10595-7"
-         style="stop-color:#c5cbc0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="15.9375"
-       cy="20.3125"
-       r="3.3125"
-       fx="15.9375"
-       fy="20.3125"
-       id="radialGradient3444"
-       xlink:href="#linearGradient6075"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7547175,0,0,0.3773584,4.4716931,1.5849059)" />
-    <linearGradient
-       id="linearGradient6075">
-      <stop
-         id="stop6077"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6079"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="15.9375"
-       cy="20.3125"
-       r="3.3125"
-       fx="15.9375"
-       fy="20.3125"
-       id="radialGradient3446"
-       xlink:href="#linearGradient6075"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7547171,0,0,0.3773584,-4.5283014,1.5849059)" />
-    <filter
-       x="-0.49411765"
-       y="-0.082352944"
-       width="1.9882354"
-       height="1.1647059"
-       color-interpolation-filters="sRGB"
-       id="filter5957">
-      <feGaussianBlur
-         stdDeviation="0.69878785"
-         id="feGaussianBlur5959" />
-    </filter>
-    <linearGradient
-       x1="21.941509"
-       y1="21.550869"
-       x2="21.941509"
-       y2="18.037588"
-       id="linearGradient2648"
-       xlink:href="#linearGradient12071"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4545455,0,0,0.2515938,1.0909094,6.0971074)" />
-    <linearGradient
-       id="linearGradient12071">
-      <stop
-         id="stop12073"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop12075"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="24.875"
-       y1="21"
-       x2="24.75"
-       y2="17"
-       id="linearGradient2651"
-       xlink:href="#linearGradient5881"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4705882,0,0,0.807484,0.7058823,-5.1887076)" />
-    <linearGradient
-       id="linearGradient5881">
-      <stop
-         id="stop5883"
-         style="stop-color:#d6c8a7;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5885"
-         style="stop-color:#d0bd99;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="10.907269"
-       y1="25.002281"
-       x2="30.875446"
-       y2="36.127281"
-       id="linearGradient2654"
-       xlink:href="#linearGradient9845"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4541292,0,0,0.5078849,1.1075579,-0.9931171)" />
-    <linearGradient
-       id="linearGradient9845">
-      <stop
-         id="stop9847"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop9849"
-         style="stop-color:#ffffff;stop-opacity:0.49484536"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="6.72682"
-       y1="32.161697"
-       x2="40.938126"
-       y2="32.161697"
-       id="linearGradient2667"
-       xlink:href="#linearGradient2411"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4857987,0,0,0.5667573,0.342308,-3.7557638)" />
-    <linearGradient
-       id="linearGradient2411">
-      <stop
-         id="stop2413"
-         style="stop-color:#fee7b1;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2419"
-         style="stop-color:#ebd4b4;stop-opacity:1"
-         offset="0.25796592" />
-      <stop
-         id="stop2421"
-         style="stop-color:#c8a775;stop-opacity:1"
-         offset="0.50796592" />
-      <stop
-         id="stop2423"
-         style="stop-color:#b0935b;stop-opacity:1"
-         offset="0.74009573" />
-      <stop
-         id="stop2415"
-         style="stop-color:#fcebbf;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="24.45439"
-       cy="46.869949"
-       r="19.61445"
-       fx="24.45439"
-       fy="46.869949"
-       id="radialGradient2670"
-       xlink:href="#linearGradient3437"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5098238,0,0,0.1027415,-0.4674316,17.131943)" />
-    <linearGradient
-       id="linearGradient3437">
-      <stop
-         id="stop3439"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3441"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop10595-6-6" />
     </linearGradient>
   </defs>
   <metadata
@@ -600,119 +310,119 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="M 11.90625,1.4999997 C 8.9151278,1.4999997 6.5,3.9151275 6.5,6.9062497 L 6.5,11.5 l 2,-0.03644 0,-4.4635563 c 0,-1.939 1.561,-3.5 3.5,-3.5 1.939,0 3.5,1.561 3.5,3.5 l 0,4.5617883 2,-0.06179 0,-4.5937503 c 0,-2.9911202 -2.415128,-5.406248 -5.40625,-5.406248 z"
+     style="color:#000000;fill:url(#linearGradient3560-2);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.9999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect3174-8"
-     style="color:#000000;fill:url(#linearGradient3560-2);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.9999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 11.90625,1.4999997 C 8.9151278,1.4999997 6.5,3.9151275 6.5,6.9062497 L 6.5,11.5 l 2,-0.03644 0,-4.4635563 c 0,-1.939 1.561,-3.5 3.5,-3.5 1.939,0 3.5,1.561 3.5,3.5 l 0,4.5617883 2,-0.06179 0,-4.5937503 c 0,-2.9911202 -2.415128,-5.406248 -5.40625,-5.406248 z" />
   <path
-     d="M 11.90625,1.1758534 C 8.9151278,1.1758534 6.5,3.5909812 6.5,6.5821034 l 0,4.5937496 2,-0.03644 0,-4.4635556 c 0,-1.939 1.561,-3.5 3.5,-3.5 1.939,0 3.5,1.561 3.5,3.5 l 0,4.5617876 2,-0.06179 0,-4.5937496 c 0,-2.9911202 -2.415128,-5.406248 -5.40625,-5.406248 z"
+     style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.9999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect3174-8-5"
-     style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.9999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 11.90625,1.1758534 C 8.9151278,1.1758534 6.5,3.5909812 6.5,6.5821034 l 0,4.5937496 2,-0.03644 0,-4.4635556 c 0,-1.939 1.561,-3.5 3.5,-3.5 1.939,0 3.5,1.561 3.5,3.5 l 0,4.5617876 2,-0.06179 0,-4.5937496 c 0,-2.9911202 -2.415128,-5.406248 -5.40625,-5.406248 z" />
   <path
-     d="M 11.90625,1.5 C 8.9151278,1.5 6.5,3.9151278 6.5,6.90625 L 6.5,11.5 8.5,11.463556 8.5,7 c 0,-1.939 1.561,-3.5 3.5,-3.5 1.939,0 3.5,1.561 3.5,3.5 l 0,4.561788 2,-0.06179 0,-4.59375 C 17.5,3.9151278 15.084872,1.5 12.09375,1.5 z"
+     style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.9999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect3174"
-     style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.9999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 11.90625,1.5 C 8.9151278,1.5 6.5,3.9151278 6.5,6.90625 L 6.5,11.5 8.5,11.463556 8.5,7 c 0,-1.939 1.561,-3.5 3.5,-3.5 1.939,0 3.5,1.561 3.5,3.5 l 0,4.561788 2,-0.06179 0,-4.59375 C 17.5,3.9151278 15.084872,1.5 12.09375,1.5 z" />
   <path
-     d="m 10.418331,2.8729151 c 2.07e-4,0.827275 -0.6692601,1.498024 -1.4951617,1.498024 -0.8259006,0 -1.4953686,-0.670749 -1.4951614,-1.498024 -2.072e-4,-0.827274 0.6692608,-1.498023 1.4951614,-1.498023 0.8259016,0 1.4953687,0.670749 1.4951617,1.498023 l 0,0 z"
+     style="opacity:0.5;fill:url(#radialGradient3079);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path6055"
-     style="opacity:0.5;fill:url(#radialGradient3079);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 10.418331,2.8729151 c 2.07e-4,0.827275 -0.6692601,1.498024 -1.4951617,1.498024 -0.8259006,0 -1.4953686,-0.670749 -1.4951614,-1.498024 -2.072e-4,-0.827274 0.6692608,-1.498023 1.4951614,-1.498023 0.8259016,0 1.4953687,0.670749 1.4951617,1.498023 l 0,0 z" />
   <path
-     d="m 9.5725691,2.8729151 c 9.01e-5,0.359315 -0.2906824,0.650644 -0.6493998,0.650644 -0.3587173,0 -0.6494898,-0.291329 -0.6493998,-0.650644 -9e-5,-0.359312 0.2906825,-0.650643 0.6493998,-0.650643 0.3587174,0 0.6494899,0.291331 0.6493998,0.650643 l 0,0 z"
+     style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path6065"
-     style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 9.5725691,2.8729151 c 9.01e-5,0.359315 -0.2906824,0.650644 -0.6493998,0.650644 -0.3587173,0 -0.6494898,-0.291329 -0.6493998,-0.650644 -9e-5,-0.359312 0.2906825,-0.650643 0.6493998,-0.650643 0.3587174,0 0.6494899,0.291331 0.6493998,0.650643 l 0,0 z" />
   <g
      id="g4366">
     <rect
-       width="2.2500038"
-       height="2.2500033"
-       x="18.750032"
-       y="20.749996"
+       style="opacity:0.3;fill:url(#radialGradient3093);fill-opacity:1;stroke:none"
        id="rect2801"
-       style="opacity:0.3;fill:url(#radialGradient3093);fill-opacity:1;stroke:none" />
-    <rect
-       width="2.2500038"
-       height="2.2500033"
-       x="-5.2500086"
-       y="-23"
-       transform="scale(-1,-1)"
-       id="rect3696"
-       style="opacity:0.3;fill:url(#radialGradient3090);fill-opacity:1;stroke:none" />
-    <rect
-       width="13.500024"
-       height="2.2500036"
-       x="5.2500086"
        y="20.749996"
+       x="18.750032"
+       height="2.2500033"
+       width="2.2500038" />
+    <rect
+       style="opacity:0.3;fill:url(#radialGradient3090);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1,-1)"
+       y="-23"
+       x="-5.2500086"
+       height="2.2500033"
+       width="2.2500038" />
+    <rect
+       style="opacity:0.3;fill:url(#linearGradient3087);fill-opacity:1;stroke:none"
        id="rect3700"
-       style="opacity:0.3;fill:url(#linearGradient3087);fill-opacity:1;stroke:none" />
+       y="20.749996"
+       x="5.2500086"
+       height="2.2500036"
+       width="13.500024" />
     <rect
-       width="15"
-       height="11"
-       rx="0.99999994"
-       ry="0.99999994"
-       x="4.5"
-       y="10.5"
+       style="color:#000000;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect3186-2"
-       style="color:#000000;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="1"
-       height="10"
-       rx="2"
-       ry="1"
-       x="6"
-       y="11"
-       id="rect5453"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3071);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="1"
-       height="10"
-       rx="2"
-       ry="1"
-       x="17"
-       y="11"
-       id="rect5453-6"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3068);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="1"
-       height="10"
-       rx="2"
-       ry="1"
-       x="5"
-       y="-21"
-       transform="scale(1,-1)"
-       id="rect5453-4"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="1"
-       height="10"
-       rx="2"
-       ry="1"
-       x="18"
-       y="-21"
-       transform="scale(1,-1)"
-       id="rect5453-4-4"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="13"
-       height="9"
-       x="5.5"
-       y="11.5"
-       id="rect3186-3"
-       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3059);stroke-width:0.99999988px;stroke-linejoin:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="15"
-       height="11"
-       rx="1"
-       ry="0.99999994"
-       x="4.5"
        y="10.5"
+       x="4.5"
+       ry="0.99999994"
+       rx="0.99999994"
+       height="11"
+       width="15" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3071);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5453"
+       y="11"
+       x="6"
+       ry="1"
+       rx="2"
+       height="10"
+       width="1" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3068);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5453-6"
+       y="11"
+       x="17"
+       ry="1"
+       rx="2"
+       height="10"
+       width="1" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5453-4"
+       transform="scale(1,-1)"
+       y="-21"
+       x="5"
+       ry="1"
+       rx="2"
+       height="10"
+       width="1" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5453-4-4"
+       transform="scale(1,-1)"
+       y="-21"
+       x="18"
+       ry="1"
+       rx="2"
+       height="10"
+       width="1" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3059);stroke-width:0.99999988px;stroke-linejoin:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3186-3"
+       y="11.5"
+       x="5.5"
+       height="9"
+       width="13" />
+    <rect
+       style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:1px;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect3186"
-       style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:1px;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       y="10.5"
+       x="4.5"
+       ry="0.99999994"
+       rx="1"
+       height="11"
+       width="15" />
     <path
-       d="m 5.5,12.5 12,0 m -12,2 12,0 m -12,2 12,0 m -12,2 12,0 m -12,2 12,0"
+       style="opacity:0.05;fill:none;stroke:url(#linearGradient3927-6);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        id="path3863-6"
-       style="opacity:0.05;fill:none;stroke:url(#linearGradient3927-6);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       d="m 5.5,12.5 12,0 m -12,2 12,0 m -12,2 12,0 m -12,2 12,0 m -12,2 12,0" />
     <path
-       d="m 5.5,11.5 12,0 m -12,2 12,0 m -12,2 12,0 m -12,2 12,0 m -12,2 12,0"
+       style="opacity:0.2;color:#000000;fill:none;stroke:url(#linearGradient3888-76-7);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="path3863-6-1"
-       style="opacity:0.2;color:#000000;fill:none;stroke:url(#linearGradient3888-76-7);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 5.5,11.5 12,0 m -12,2 12,0 m -12,2 12,0 m -12,2 12,0 m -12,2 12,0" />
   </g>
 </svg>

--- a/status/32/channel-secure.svg
+++ b/status/32/channel-secure.svg
@@ -1,0 +1,1 @@
+locked.svg

--- a/status/32/locked.svg
+++ b/status/32/locked.svg
@@ -6,352 +6,336 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   width="32"
-   height="32"
    id="svg5833"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="preferences-system-privacy.svg">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="640"
-     inkscape:window-height="480"
-     id="namedview1663" />
+   height="32"
+   width="32"
+   version="1.1">
   <defs
      id="defs5835">
     <linearGradient
        id="linearGradient5443">
       <stop
-         id="stop5445"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop5445" />
       <stop
-         id="stop5447"
+         offset="0.03252051"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03252051" />
+         id="stop5447" />
       <stop
-         id="stop5449"
+         offset="0.98558509"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.98558509" />
+         id="stop5449" />
       <stop
-         id="stop5451"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop5451" />
     </linearGradient>
     <linearGradient
        id="linearGradient3966-0-4-2">
       <stop
-         id="stop3968-8-0-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0-1" />
       <stop
-         id="stop3970-7-4-2"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4-2" />
     </linearGradient>
     <linearGradient
        id="linearGradient3966-0-4">
       <stop
-         id="stop3968-8-0"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0" />
       <stop
-         id="stop3970-7-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4" />
     </linearGradient>
     <linearGradient
        id="linearGradient5475">
       <stop
-         id="stop5477"
+         offset="0"
          style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
+         id="stop5477" />
       <stop
-         id="stop5479"
+         offset="1"
          style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
+         id="stop5479" />
     </linearGradient>
     <linearGradient
        id="linearGradient5483">
       <stop
-         id="stop5485"
+         offset="0"
          style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
+         id="stop5485" />
       <stop
-         id="stop5487"
+         offset="1"
          style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
+         id="stop5487" />
     </linearGradient>
     <linearGradient
        id="linearGradient5409">
       <stop
-         id="stop5411"
+         offset="0"
          style="stop-color:#f2e0c4;stop-opacity:1"
-         offset="0" />
+         id="stop5411" />
       <stop
-         id="stop5559"
+         offset="0.76470584"
          style="stop-color:#e5af5b;stop-opacity:1"
-         offset="0.76470584" />
+         id="stop5559" />
       <stop
-         id="stop5413"
+         offset="1"
          style="stop-color:#af6900;stop-opacity:1"
-         offset="1" />
+         id="stop5413" />
     </linearGradient>
     <linearGradient
        id="linearGradient6057">
       <stop
-         id="stop6059"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop6059" />
       <stop
-         id="stop6061"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop6061" />
     </linearGradient>
     <linearGradient
-       x1="10.650842"
-       y1="2.9136841"
-       x2="27.192274"
-       y2="17.470011"
-       id="linearGradient2503"
-       xlink:href="#linearGradient10591"
+       gradientTransform="translate(0,-1.926279)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-1.926279)" />
+       xlink:href="#linearGradient10591"
+       id="linearGradient2503"
+       y2="17.470011"
+       x2="27.192274"
+       y1="2.9136841"
+       x1="10.650842" />
     <linearGradient
        id="linearGradient10591">
       <stop
-         id="stop10593"
+         offset="0"
          style="stop-color:#cad0c6;stop-opacity:1"
-         offset="0" />
+         id="stop10593" />
       <stop
-         id="stop10599"
+         offset="0.5"
          style="stop-color:#eaece9;stop-opacity:1"
-         offset="0.5" />
+         id="stop10599" />
       <stop
-         id="stop10595"
+         offset="1"
          style="stop-color:#c5cbc0;stop-opacity:1"
-         offset="1" />
+         id="stop10595" />
     </linearGradient>
     <linearGradient
-       x1="35.004684"
-       y1="14.849737"
-       x2="33.004314"
-       y2="14.849737"
-       id="linearGradient2505"
-       xlink:href="#linearGradient6227"
+       gradientTransform="translate(1.6824037,1.125)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(1.6824037,1.125)" />
+       xlink:href="#linearGradient6227"
+       id="linearGradient2505"
+       y2="14.849737"
+       x2="33.004314"
+       y1="14.849737"
+       x1="35.004684" />
     <linearGradient
        id="linearGradient6227">
       <stop
-         id="stop6229"
+         offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop6229" />
       <stop
-         id="stop6231"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop6231" />
     </linearGradient>
     <filter
-       x="-0.24242526"
-       y="-0.047579072"
-       width="1.4848505"
-       height="1.0951581"
+       id="filter6251"
        color-interpolation-filters="sRGB"
-       id="filter6251">
+       height="1.0951581"
+       width="1.4848505"
+       y="-0.047579072"
+       x="-0.24242526">
       <feGaussianBlur
-         stdDeviation="0.24444548"
-         id="feGaussianBlur6253" />
+         id="feGaussianBlur6253"
+         stdDeviation="0.24444548" />
     </filter>
     <linearGradient
-       x1="32.128025"
-       y1="13.789077"
-       x2="35.020981"
-       y2="13.789077"
-       id="linearGradient2507"
-       xlink:href="#linearGradient6227"
+       gradientTransform="translate(-19.532826,1.7437184)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-19.532826,1.7437184)" />
+       xlink:href="#linearGradient6227"
+       id="linearGradient2507"
+       y2="13.789077"
+       x2="35.020981"
+       y1="13.789077"
+       x1="32.128025" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309">
       <stop
-         id="stop2889"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <linearGradient
-       x1="21.771429"
-       y1="14.871428"
-       x2="21.771429"
-       y2="27.924538"
-       id="linearGradient3059"
+       gradientTransform="matrix(1,0,0,0.92857143,0,2.0357143)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5443"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.92857143,0,2.0357143)" />
+       id="linearGradient3059"
+       y2="27.924538"
+       x2="21.771429"
+       y1="14.871428"
+       x1="21.771429" />
     <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
-       y2="14"
-       id="linearGradient3062"
+       gradientTransform="matrix(0.66666667,0,0,0.93333333,19.333333,-42.066667)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3966-0-4-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666667,0,0,0.93333333,19.333333,-42.066667)" />
-    <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
+       id="linearGradient3062"
        y2="14"
-       id="linearGradient3065"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       gradientTransform="matrix(0.66666667,0,0,0.93333333,1.3333333,-42.066667)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3966-0-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666667,0,0,0.93333333,1.3333333,-42.066667)" />
-    <linearGradient
-       x1="24"
-       y1="29"
-       x2="24"
+       id="linearGradient3065"
        y2="14"
-       id="linearGradient3068"
-       xlink:href="#linearGradient5475"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.83333333,0,0,0.93333333,4.2916667,1.9333333)" />
-    <linearGradient
-       x1="9"
-       y1="29"
        x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       gradientTransform="matrix(0.83333333,0,0,0.93333333,4.2916667,1.9333333)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5475"
+       id="linearGradient3068"
        y2="14"
-       id="linearGradient3071"
+       x2="24"
+       y1="29"
+       x1="24" />
+    <linearGradient
+       gradientTransform="matrix(0.83333333,0,0,0.93333333,1.0416667,1.9333333)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5483"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.83333333,0,0,0.93333333,1.0416667,1.9333333)" />
+       id="linearGradient3071"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
     <radialGradient
-       cx="16.823883"
-       cy="11.368058"
-       r="10.5"
-       fx="16.777113"
-       fy="11.597148"
-       id="radialGradient3074"
+       gradientTransform="matrix(0,1.5178571,-2.1745542,0,40.720459,-9.63)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5409"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.5178571,-2.1745542,0,40.720459,-9.63)" />
+       id="radialGradient3074"
+       fy="11.597148"
+       fx="16.777113"
+       r="10.5"
+       cy="11.368058"
+       cx="16.823883" />
     <radialGradient
-       cx="18.031223"
-       cy="6.2806997"
-       r="3.1819806"
-       fx="18.031223"
-       fy="6.2806997"
-       id="radialGradient3079"
+       gradientTransform="matrix(0.6265109,0,0,0.6275526,0.6007813,1.2224623)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient6057"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6265109,0,0,0.6275526,0.6007813,1.2224623)" />
+       id="radialGradient3079"
+       fy="6.2806997"
+       fx="18.031223"
+       r="3.1819806"
+       cy="6.2806997"
+       cx="18.031223" />
     <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient3087"
+       gradientTransform="matrix(0.64285714,0,0,0.42857134,0.5714286,10.857146)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3702-501-757"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64285714,0,0,0.42857134,0.5714286,10.857146)" />
+       id="linearGradient3087"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
     <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3090"
+       gradientTransform="matrix(1.2022705,0,0,0.59999988,-13.007122,-55.599994)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3688-464-309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2022705,0,0,0.59999988,-13.007122,-55.599994)" />
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
+       id="radialGradient3090"
        fy="43.5"
-       id="radialGradient3093"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(1.2022705,0,0,0.59999988,18.992878,3.4000047)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3688-166-749"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2022705,0,0,0.59999988,18.992878,3.4000047)" />
+       id="radialGradient3093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
-       y2="27.5"
-       id="linearGradient3888-76"
-       xlink:href="#linearGradient6057-35"
+       gradientTransform="matrix(-1.2447699,0,0,1,35.523611,-11)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.2447699,0,0,1,35.523611,-11)" />
+       xlink:href="#linearGradient6057-35"
+       id="linearGradient3888-76"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
     <linearGradient
        id="linearGradient6057-35">
       <stop
-         id="stop6059-0"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop6059-0" />
       <stop
-         id="stop6061-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop6061-4" />
     </linearGradient>
     <linearGradient
        id="linearGradient3865-4">
       <stop
-         id="stop3867-110"
+         offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop3867-110" />
       <stop
-         id="stop3869-96"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop3869-96" />
     </linearGradient>
     <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
-       y2="27.5"
-       id="linearGradient3927-6"
-       xlink:href="#linearGradient3865-4"
+       gradientTransform="matrix(-1.2447699,0,0,1,35.523611,-10)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.2447699,0,0,1,35.523611,-10)" />
+       xlink:href="#linearGradient3865-4"
+       id="linearGradient3927-6"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
   </defs>
   <metadata
      id="metadata5838">
@@ -366,130 +350,130 @@
     </rdf:RDF>
   </metadata>
   <rect
-     width="3"
-     height="2.9999993"
-     x="25"
-     y="28"
+     style="opacity:0.3;fill:url(#radialGradient3093);fill-opacity:1;stroke:none"
      id="rect2801"
-     style="opacity:0.3;fill:url(#radialGradient3093);fill-opacity:1;stroke:none" />
-  <rect
-     width="3"
-     height="2.9999993"
-     x="-7"
-     y="-30.999998"
-     transform="scale(-1,-1)"
-     id="rect3696"
-     style="opacity:0.3;fill:url(#radialGradient3090);fill-opacity:1;stroke:none" />
-  <rect
-     width="18"
-     height="2.9999995"
-     x="7"
      y="28"
+     x="25"
+     height="2.9999993"
+     width="3" />
+  <rect
+     style="opacity:0.3;fill:url(#radialGradient3090);fill-opacity:1;stroke:none"
+     id="rect3696"
+     transform="scale(-1,-1)"
+     y="-30.999998"
+     x="-7"
+     height="2.9999993"
+     width="3" />
+  <rect
+     style="opacity:0.3;fill:url(#linearGradient3087);fill-opacity:1;stroke:none"
      id="rect3700"
-     style="opacity:0.3;fill:url(#linearGradient3087);fill-opacity:1;stroke:none" />
+     y="28"
+     x="7"
+     height="2.9999995"
+     width="18" />
   <g
-     transform="matrix(0.5585856,0,0,0.6275526,2.5797896,1.2464895)"
+     style="stroke:none"
      id="g1387"
-     style="stroke:none">
+     transform="matrix(0.5585856,0,0,0.6275526,2.5797896,1.2464895)">
     <path
-       d="m 10.6402,20.234846 0,-5.734846 C 10.6402,6.6298666 15.897609,2.8910066 24.020027,2.9892921 32.18664,3.0875777 37.5,6.5372782 37.5,14.5 l 0,5.984846 c 0,1.954229 -5.490701,2.202951 -5.490701,0 l 0,-3.984846 c 0,-2 0.568453,-8.471853 -7.932058,-8.471853 -8.430413,0 -7.81615,6.511738 -7.783459,8.463879 l 0,3.776498 c 0,2.35462 -5.653582,2.344609 -5.653582,-0.03368 z"
+       style="fill:url(#linearGradient2503);fill-opacity:1;fill-rule:evenodd;stroke:none"
        id="path2086"
-       style="fill:url(#linearGradient2503);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+       d="m 10.6402,20.234846 0,-5.734846 C 10.6402,6.6298666 15.897609,2.8910066 24.020027,2.9892921 32.18664,3.0875777 37.5,6.5372782 37.5,14.5 l 0,5.984846 c 0,1.954229 -5.490701,2.202951 -5.490701,0 l 0,-3.984846 c 0,-2 0.568453,-8.471853 -7.932058,-8.471853 -8.430413,0 -7.81615,6.511738 -7.783459,8.463879 l 0,3.776498 c 0,2.35462 -5.653582,2.344609 -5.653582,-0.03368 z" />
     <path
-       d="m 34.687087,10.837069 1.263948,0.125 c 0.927239,2.822733 0.736052,9.510413 0.736052,9.510413 -0.0625,1.125 -2.03125,0.53125 -2,0 l 0,-9.635413 z"
+       style="opacity:0.18235294;fill:url(#linearGradient2505);fill-opacity:1;fill-rule:evenodd;stroke:none;filter:url(#filter6251)"
        id="rect1345"
-       style="opacity:0.18235294;fill:url(#linearGradient2505);fill-opacity:1;fill-rule:evenodd;stroke:none;filter:url(#filter6251)" />
+       d="m 34.687087,10.837069 1.263948,0.125 c 0.927239,2.822733 0.736052,9.510413 0.736052,9.510413 -0.0625,1.125 -2.03125,0.53125 -2,0 l 0,-9.635413 z" />
     <path
-       d="m 12.926606,11.544175 0.371719,0.169195 c 1.720331,1.054966 2.173532,9.37783 2.173532,9.37783 -0.0625,1.125 -2.03125,0.53125 -2,0 0,0 0.37822,-6.87064 -0.545251,-9.547025 z"
-       transform="matrix(-1,0,0,1,29.05878,-0.6187184)"
+       style="opacity:0.14117647;fill:url(#linearGradient2507);fill-opacity:1;fill-rule:evenodd;stroke:none;filter:url(#filter6251)"
        id="path6332"
-       style="opacity:0.14117647;fill:url(#linearGradient2507);fill-opacity:1;fill-rule:evenodd;stroke:none;filter:url(#filter6251)" />
+       transform="matrix(-1,0,0,1,29.05878,-0.6187184)"
+       d="m 12.926606,11.544175 0.371719,0.169195 c 1.720331,1.054966 2.173532,9.37783 2.173532,9.37783 -0.0625,1.125 -2.03125,0.53125 -2,0 0,0 0.37822,-6.87064 -0.545251,-9.547025 z" />
   </g>
   <path
-     d="m 9.6796242,13.870992 0.078313,-4.7066446 c 0,-6.1979434 11.7079228,-6.7000025 11.7079228,0.5491086 l 0,4.314424"
+     style="opacity:0.62352941;fill:none;stroke:#ffffff;stroke-width:1.99999964;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path5675"
-     style="opacity:0.62352941;fill:none;stroke:#ffffff;stroke-width:1.99999964;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 9.6796242,13.870992 0.078313,-4.7066446 c 0,-6.1979434 11.7079228,-6.7000025 11.7079228,0.5491086 l 0,4.314424" />
   <path
-     d="m 13.891085,5.1639317 c 2.76e-4,1.103031 -0.892346,1.9973608 -1.993546,1.9973608 -1.101199,0 -1.9938214,-0.8943298 -1.9935451,-1.9973608 -2.763e-4,-1.1030309 0.8923461,-1.9973608 1.9935451,-1.9973608 1.1012,0 1.993822,0.8943299 1.993546,1.9973608 l 0,0 z"
+     style="fill:url(#radialGradient3079);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path6055"
-     style="fill:url(#radialGradient3079);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 13.891085,5.1639317 c 2.76e-4,1.103031 -0.892346,1.9973608 -1.993546,1.9973608 -1.101199,0 -1.9938214,-0.8943298 -1.9935451,-1.9973608 -2.763e-4,-1.1030309 0.8923461,-1.9973608 1.9935451,-1.9973608 1.1012,0 1.993822,0.8943299 1.993546,1.9973608 l 0,0 z" />
   <path
-     d="m 12.763404,5.1639316 c 1.2e-4,0.4790843 -0.387576,0.8675225 -0.865865,0.8675225 -0.478289,0 -0.865985,-0.3884382 -0.865865,-0.8675225 -1.2e-4,-0.4790842 0.387576,-0.8675225 0.865865,-0.8675225 0.478289,0 0.865985,0.3884383 0.865865,0.8675225 l 0,0 z"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path6065"
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 12.763404,5.1639316 c 1.2e-4,0.4790843 -0.387576,0.8675225 -0.865865,0.8675225 -0.478289,0 -0.865985,-0.3884382 -0.865865,-0.8675225 -1.2e-4,-0.4790842 0.387576,-0.8675225 0.865865,-0.8675225 0.478289,0 0.865985,0.3884383 0.865865,0.8675225 l 0,0 z" />
   <path
-     d="m 8.5232521,15.944919 0,-5.598917 c 0,-4.9389228 2.9367129,-7.2852541 7.4737789,-7.2235748 4.561752,0.061679 7.529719,2.2265479 7.529719,7.2235748 l 0,5.755806 -3.067027,0 0,-4.500701 c 0,-1.255105 0.31753,-5.3165333 -4.430733,-5.3165333 -4.709108,0 -4.365989,4.0864583 -4.347728,5.3115293 l 0,4.369951 z"
+     style="opacity:0.4;fill:none;stroke:#000000;stroke-width:0.99999946;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
      id="path2086-1"
-     style="opacity:0.4;fill:none;stroke:#000000;stroke-width:0.99999946;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     d="m 8.5232521,15.944919 0,-5.598917 c 0,-4.9389228 2.9367129,-7.2852541 7.4737789,-7.2235748 4.561752,0.061679 7.529719,2.2265479 7.529719,7.2235748 l 0,5.755806 -3.067027,0 0,-4.500701 c 0,-1.255105 0.31753,-5.3165333 -4.430733,-5.3165333 -4.709108,0 -4.365989,4.0864583 -4.347728,5.3115293 l 0,4.369951 z" />
   <rect
-     width="21"
-     height="15"
-     rx="1"
-     ry="1"
-     x="5.5"
-     y="14.500001"
+     style="color:#000000;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect3186-2"
-     style="color:#000000;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <rect
-     width="1.25"
-     height="14"
-     rx="2"
-     ry="0.99999994"
-     x="7.5"
-     y="15.000001"
-     id="rect5453"
-     style="opacity:0.5;color:#000000;fill:url(#linearGradient3071);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <rect
-     width="1.25"
-     height="14"
-     rx="2"
-     ry="0.99999994"
-     x="23.25"
-     y="15.000001"
-     id="rect5453-6"
-     style="opacity:0.5;color:#000000;fill:url(#linearGradient3068);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <rect
-     width="1"
-     height="14"
-     rx="2"
-     ry="0.99999994"
-     x="6.5"
-     y="-29"
-     transform="scale(1,-1)"
-     id="rect5453-4"
-     style="opacity:0.5;color:#000000;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <rect
-     width="1"
-     height="14"
-     rx="2"
-     ry="0.99999994"
-     x="24.5"
-     y="-29"
-     transform="scale(1,-1)"
-     id="rect5453-4-4"
-     style="opacity:0.5;color:#000000;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <rect
-     width="19"
-     height="13"
-     x="6.5"
-     y="15.500001"
-     id="rect3186-3"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3059);stroke-width:1px;stroke-linejoin:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <rect
-     width="21"
-     height="15"
-     rx="1"
-     ry="1"
-     x="5.5"
      y="14.500001"
+     x="5.5"
+     ry="1"
+     rx="1"
+     height="15"
+     width="21" />
+  <rect
+     style="opacity:0.5;color:#000000;fill:url(#linearGradient3071);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="rect5453"
+     y="15.000001"
+     x="7.5"
+     ry="0.99999994"
+     rx="2"
+     height="14"
+     width="1.25" />
+  <rect
+     style="opacity:0.5;color:#000000;fill:url(#linearGradient3068);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="rect5453-6"
+     y="15.000001"
+     x="23.25"
+     ry="0.99999994"
+     rx="2"
+     height="14"
+     width="1.25" />
+  <rect
+     style="opacity:0.5;color:#000000;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="rect5453-4"
+     transform="scale(1,-1)"
+     y="-29"
+     x="6.5"
+     ry="0.99999994"
+     rx="2"
+     height="14"
+     width="1" />
+  <rect
+     style="opacity:0.5;color:#000000;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="rect5453-4-4"
+     transform="scale(1,-1)"
+     y="-29"
+     x="24.5"
+     ry="0.99999994"
+     rx="2"
+     height="14"
+     width="1" />
+  <rect
+     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3059);stroke-width:1px;stroke-linejoin:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="rect3186-3"
+     y="15.500001"
+     x="6.5"
+     height="13"
+     width="19" />
+  <rect
+     style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:1px;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect3186"
-     style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:1px;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     y="14.500001"
+     x="5.5"
+     ry="1"
+     rx="1"
+     height="15"
+     width="21" />
   <path
-     d="m 7.1428574,17.5 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0"
+     style="opacity:0.05;fill:none;stroke:url(#linearGradient3927-6);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path3863-6"
-     style="opacity:0.05;fill:none;stroke:url(#linearGradient3927-6);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 7.1428574,17.5 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0" />
   <path
-     d="m 7.1428574,16.5 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0"
+     style="opacity:0.2;fill:none;stroke:url(#linearGradient3888-76);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path3863-3-5"
-     style="opacity:0.2;fill:none;stroke:url(#linearGradient3888-76);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 7.1428574,16.5 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0 m -17.0000006,2 17.0000006,0" />
 </svg>

--- a/status/48/channel-secure.svg
+++ b/status/48/channel-secure.svg
@@ -1,0 +1,1 @@
+locked.svg

--- a/status/48/locked.svg
+++ b/status/48/locked.svg
@@ -6,324 +6,324 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="48"
+   id="svg4078"
    height="48"
-   id="svg4078">
+   width="48"
+   version="1.1">
   <defs
      id="defs4080">
     <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
-       y2="27.5"
-       id="linearGradient3888-76"
-       xlink:href="#linearGradient6057-35"
+       gradientTransform="matrix(-1.8671693,0,0,1.5000117,53.285829,-15.750435)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.8671693,0,0,1.5000117,53.285829,-15.750435)" />
+       xlink:href="#linearGradient6057-35"
+       id="linearGradient3888-76"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
     <linearGradient
        id="linearGradient6057-35">
       <stop
-         id="stop6059-0"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop6059-0" />
       <stop
-         id="stop6061-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop6061-4" />
     </linearGradient>
     <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
-       y2="27.5"
-       id="linearGradient3927-6"
-       xlink:href="#linearGradient3865-4"
+       gradientTransform="matrix(-1.8671693,0,0,1.5000117,53.285829,-14.750435)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.8671693,0,0,1.5000117,53.285829,-14.750435)" />
+       xlink:href="#linearGradient3865-4"
+       id="linearGradient3927-6"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
     <linearGradient
        id="linearGradient3865-4">
       <stop
-         id="stop3867-110"
+         offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop3867-110" />
       <stop
-         id="stop3869-96"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop3869-96" />
     </linearGradient>
     <linearGradient
-       x1="21.771429"
-       y1="14.871428"
-       x2="21.771429"
-       y2="27.924538"
-       id="linearGradient3059"
-       xlink:href="#linearGradient5443"
+       gradientTransform="matrix(1.5263159,0,0,1.4285714,-0.4210539,2.7857126)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5263159,0,0,1.4285714,-0.4210539,2.7857126)" />
+       xlink:href="#linearGradient5443"
+       id="linearGradient3059"
+       y2="27.924538"
+       x2="21.771429"
+       y1="14.871428"
+       x1="21.771429" />
     <linearGradient
        id="linearGradient5443">
       <stop
-         id="stop5445"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop5445" />
       <stop
-         id="stop5447"
+         offset="0.03252051"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03252051" />
+         id="stop5447" />
       <stop
-         id="stop5449"
+         offset="0.98558509"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.98558509" />
+         id="stop5449" />
       <stop
-         id="stop5451"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop5451" />
     </linearGradient>
     <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
-       y2="14"
-       id="linearGradient3062"
-       xlink:href="#linearGradient3966-0-4-2"
+       gradientTransform="matrix(1.0000078,0,0,1.4000109,29.000225,-63.600154)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0000078,0,0,1.4000109,29.000225,-63.600154)" />
+       xlink:href="#linearGradient3966-0-4-2"
+       id="linearGradient3062"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
     <linearGradient
        id="linearGradient3966-0-4-2">
       <stop
-         id="stop3968-8-0-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0-1" />
       <stop
-         id="stop3970-7-4-2"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4-2" />
     </linearGradient>
     <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
-       y2="14"
-       id="linearGradient3065"
-       xlink:href="#linearGradient3966-0-4"
+       gradientTransform="matrix(1.0000078,0,0,1.4000109,2.0000155,-63.600154)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0000078,0,0,1.4000109,2.0000155,-63.600154)" />
+       xlink:href="#linearGradient3966-0-4"
+       id="linearGradient3065"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
     <linearGradient
        id="linearGradient3966-0-4">
       <stop
-         id="stop3968-8-0"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0" />
       <stop
-         id="stop3970-7-4"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4" />
     </linearGradient>
     <linearGradient
-       x1="24"
-       y1="29"
-       x2="24"
-       y2="14"
-       id="linearGradient3068"
-       xlink:href="#linearGradient5475"
+       gradientTransform="matrix(1.3333334,0,0,1.4000109,4.6666646,3.3996844)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3333334,0,0,1.4000109,4.6666646,3.3996844)" />
+       xlink:href="#linearGradient5475"
+       id="linearGradient3068"
+       y2="14"
+       x2="24"
+       y1="29"
+       x1="24" />
     <linearGradient
        id="linearGradient5475">
       <stop
-         id="stop5477"
+         offset="0"
          style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
+         id="stop5477" />
       <stop
-         id="stop5479"
+         offset="1"
          style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
+         id="stop5479" />
     </linearGradient>
     <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
-       y2="14"
-       id="linearGradient3071"
-       xlink:href="#linearGradient5483"
+       gradientTransform="matrix(1.3333334,0,0,1.4000109,0.6666657,3.3996844)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3333334,0,0,1.4000109,0.6666657,3.3996844)" />
+       xlink:href="#linearGradient5483"
+       id="linearGradient3071"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
     <linearGradient
        id="linearGradient5483">
       <stop
-         id="stop5485"
+         offset="0"
          style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
+         id="stop5485" />
       <stop
-         id="stop5487"
+         offset="1"
          style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
+         id="stop5487" />
     </linearGradient>
     <radialGradient
-       cx="16.823883"
-       cy="11.368058"
-       r="10.5"
-       fx="16.777113"
-       fy="11.597148"
-       id="radialGradient3074"
-       xlink:href="#linearGradient5409"
+       gradientTransform="matrix(0,2.2261905,-3.2100562,0,60.492107,-12.89067)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,2.2261905,-3.2100562,0,60.492107,-12.89067)" />
+       xlink:href="#linearGradient5409"
+       id="radialGradient3074"
+       fy="11.597148"
+       fx="16.777113"
+       r="10.5"
+       cy="11.368058"
+       cx="16.823883" />
     <linearGradient
        id="linearGradient5409">
       <stop
-         id="stop5411"
+         offset="0"
          style="stop-color:#f2e0c4;stop-opacity:1"
-         offset="0" />
+         id="stop5411" />
       <stop
-         id="stop5559"
+         offset="0.76470584"
          style="stop-color:#e5af5b;stop-opacity:1"
-         offset="0.76470584" />
+         id="stop5559" />
       <stop
-         id="stop5413"
+         offset="1"
          style="stop-color:#af6900;stop-opacity:1"
-         offset="1" />
+         id="stop5413" />
     </linearGradient>
     <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient3087"
-       xlink:href="#linearGradient3702-501-757"
+       gradientTransform="matrix(0.96429319,0,0,0.642862,0.8571496,16.285475)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.96429319,0,0,0.642862,0.8571496,16.285475)" />
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient3087"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
     <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3090"
-       xlink:href="#linearGradient3688-464-309"
+       gradientTransform="matrix(1.8034197,0,0,0.9000068,-19.510834,-83.400268)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.8034197,0,0,0.9000068,-19.510834,-83.400268)" />
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3090"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
        id="linearGradient3688-464-309">
       <stop
-         id="stop2889"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
     <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3093"
-       xlink:href="#linearGradient3688-166-749"
+       gradientTransform="matrix(1.8034197,0,0,0.9000068,28.489539,5.099676)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.8034197,0,0,0.9000068,28.489539,5.099676)" />
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
-       cx="18.031223"
-       cy="6.2806997"
-       r="3.1819806"
-       fx="18.031223"
-       fy="6.2806997"
-       id="radialGradient3328"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient6057-31"
-       gradientUnits="userSpaceOnUse" />
+       id="radialGradient3328"
+       fy="6.2806997"
+       fx="18.031223"
+       r="3.1819806"
+       cy="6.2806997"
+       cx="18.031223" />
     <linearGradient
        id="linearGradient6057-31">
       <stop
-         id="stop6059-15"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop6059-15" />
       <stop
-         id="stop6061-2"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop6061-2" />
     </linearGradient>
     <linearGradient
-       x1="32.128025"
-       y1="13.789077"
-       x2="35.020981"
-       y2="13.789077"
-       id="linearGradient3326"
-       xlink:href="#linearGradient6227-1"
+       gradientTransform="matrix(-0.8563683,0,0,0.9968005,45.000381,2.6467529)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.8563683,0,0,0.9968005,45.000381,2.6467529)" />
+       xlink:href="#linearGradient6227-1"
+       id="linearGradient3326"
+       y2="13.789077"
+       x2="35.020981"
+       y1="13.789077"
+       x1="32.128025" />
     <linearGradient
        id="linearGradient6227-1">
       <stop
-         id="stop6229-8"
+         offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop6229-8" />
       <stop
-         id="stop6231-9"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         id="stop6231-9" />
     </linearGradient>
     <linearGradient
-       x1="35.004684"
-       y1="14.849737"
-       x2="33.004314"
-       y2="14.849737"
-       id="linearGradient3324"
-       xlink:href="#linearGradient6227-1"
+       gradientTransform="matrix(0.8563683,0,0,0.9968005,4.828827,2.6467529)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8563683,0,0,0.9968005,4.828827,2.6467529)" />
+       xlink:href="#linearGradient6227-1"
+       id="linearGradient3324"
+       y2="14.849737"
+       x2="33.004314"
+       y1="14.849737"
+       x1="35.004684" />
     <linearGradient
        id="linearGradient10591-4">
       <stop
-         id="stop10593-3"
+         offset="0"
          style="stop-color:#cad0c6;stop-opacity:1"
-         offset="0" />
+         id="stop10593-3" />
       <stop
-         id="stop10599-8"
+         offset="0.5"
          style="stop-color:#eaece9;stop-opacity:1"
-         offset="0.5" />
+         id="stop10599-8" />
       <stop
-         id="stop10595-4"
+         offset="1"
          style="stop-color:#c5cbc0;stop-opacity:1"
-         offset="1" />
+         id="stop10595-4" />
     </linearGradient>
     <linearGradient
-       x1="10.650842"
-       y1="2.9136841"
-       x2="27.192274"
-       y2="17.470011"
-       id="linearGradient4076"
-       xlink:href="#linearGradient10591-4"
+       gradientTransform="matrix(0.8563683,0,0,0.9968005,3.38807,-0.3947636)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8563683,0,0,0.9968005,3.38807,-0.3947636)" />
+       xlink:href="#linearGradient10591-4"
+       id="linearGradient4076"
+       y2="17.470011"
+       x2="27.192274"
+       y1="2.9136841"
+       x1="10.650842" />
   </defs>
   <metadata
      id="metadata4083">
@@ -340,130 +340,130 @@
   <g
      id="layer1">
     <path
-       d="m 12.5,23.695457 0,-7.716497 C 12.5,8.1340066 17.002278,4.4071091 23.958059,4.5050801 30.951688,4.6030513 35.501881,8.0417145 35.501881,15.97896 l 0,7.965697 -4.702062,0 0,-5.972096 c 0,-1.993601 0.486805,-8.4447478 -6.792763,-8.4447478 -7.219539,0 -6.693503,6.4909038 -6.665508,8.4367988 l 0,5.764416 z"
+       style="fill:url(#linearGradient4076);fill-opacity:1;fill-rule:evenodd;stroke:none"
        id="path2086-6"
-       style="fill:url(#linearGradient4076);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+       d="m 12.5,23.695457 0,-7.716497 C 12.5,8.1340066 17.002278,4.4071091 23.958059,4.5050801 30.951688,4.6030513 35.501881,8.0417145 35.501881,15.97896 l 0,7.965697 -4.702062,0 0,-5.972096 c 0,-1.993601 0.486805,-8.4447478 -6.792763,-8.4447478 -7.219539,0 -6.693503,6.4909038 -6.665508,8.4367988 l 0,5.764416 z" />
     <path
-       d="m 33.092992,12.327748 1.082405,0.1246 c 0.794058,2.813702 0.630331,9.479985 0.630331,9.479985 -0.05352,1.1214 -1.739498,0.52955 -1.712736,0 l 0,-9.604585 z"
+       style="opacity:0.18235294;fill:url(#linearGradient3324);fill-opacity:1;fill-rule:evenodd;stroke:none"
        id="rect1345-3"
-       style="opacity:0.18235294;fill:url(#linearGradient3324);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+       d="m 33.092992,12.327748 1.082405,0.1246 c 0.794058,2.813702 0.630331,9.479985 0.630331,9.479985 -0.05352,1.1214 -1.739498,0.52955 -1.712736,0 l 0,-9.604585 z" />
     <path
-       d="m 17.203152,12.415853 -0.318328,0.168654 c -1.473237,1.05159 -1.861344,9.347825 -1.861344,9.347825 0.05352,1.121401 1.739498,0.52955 1.712737,0 0,0 -0.323896,-6.848657 0.466935,-9.516479 z"
+       style="opacity:0.14117647;fill:url(#linearGradient3326);fill-opacity:1;fill-rule:evenodd;stroke:none"
        id="path6332-4"
-       style="opacity:0.14117647;fill:url(#linearGradient3326);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+       d="m 17.203152,12.415853 -0.318328,0.168654 c -1.473237,1.05159 -1.861344,9.347825 -1.861344,9.347825 0.05352,1.121401 1.739498,0.52955 1.712737,0 0,0 -0.323896,-6.848657 0.466935,-9.516479 z" />
     <path
-       d="M 14.272838,21.57803 14.3929,14.102027 c 0,-9.8447736 17.949433,-10.6422411 17.949433,0.8722 l 0,6.853004"
+       style="opacity:0.62352941;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="path5675-7"
-       style="opacity:0.62352941;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="M 14.272838,21.57803 14.3929,14.102027 c 0,-9.8447736 17.949433,-10.6422411 17.949433,0.8722 l 0,6.853004" />
     <g
-       transform="matrix(0.9605048,0,0,0.9968005,0.35405,1.4871877)"
-       id="g6067">
+       id="g6067"
+       transform="matrix(0.9605048,0,0,0.9968005,0.35405,1.4871877)">
       <path
-         d="m 21.213204,6.2806997 c 4.41e-4,1.7576709 -1.42431,3.1827783 -3.181981,3.1827783 -1.75767,0 -3.182421,-1.4251074 -3.18198,-3.1827783 -4.41e-4,-1.7576709 1.42431,-3.1827783 3.18198,-3.1827783 1.757671,0 3.182422,1.4251074 3.181981,3.1827783 l 0,0 z"
+         style="fill:url(#radialGradient3328);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="path6055-4"
-         style="fill:url(#radialGradient3328);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         d="m 21.213204,6.2806997 c 4.41e-4,1.7576709 -1.42431,3.1827783 -3.181981,3.1827783 -1.75767,0 -3.182421,-1.4251074 -3.18198,-3.1827783 -4.41e-4,-1.7576709 1.42431,-3.1827783 3.18198,-3.1827783 1.757671,0 3.182422,1.4251074 3.181981,3.1827783 l 0,0 z" />
       <path
-         d="m 21.213204,6.2806997 c 4.41e-4,1.7576709 -1.42431,3.1827783 -3.181981,3.1827783 -1.75767,0 -3.182421,-1.4251074 -3.18198,-3.1827783 -4.41e-4,-1.7576709 1.42431,-3.1827783 3.18198,-3.1827783 1.757671,0 3.182422,1.4251074 3.181981,3.1827783 l 0,0 z"
-         transform="matrix(0.4343344,0,0,0.4343344,10.199642,3.5527756)"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="path6065-9"
-         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         transform="matrix(0.4343344,0,0,0.4343344,10.199642,3.5527756)"
+         d="m 21.213204,6.2806997 c 4.41e-4,1.7576709 -1.42431,3.1827783 -3.181981,3.1827783 -1.75767,0 -3.182421,-1.4251074 -3.18198,-3.1827783 -4.41e-4,-1.7576709 1.42431,-3.1827783 3.18198,-3.1827783 1.757671,0 3.182422,1.4251074 3.181981,3.1827783 l 0,0 z" />
     </g>
     <path
-       d="m 12.5,23.695457 0,-7.716497 C 12.5,8.1340067 17.002278,4.4071092 23.958059,4.5050802 30.951688,4.6030514 35.501881,8.0417146 35.501881,15.97896 l 0,7.965697 -4.702062,0 0,-5.972096 c 0,-1.993601 0.486805,-8.4447477 -6.792763,-8.4447477 -7.219539,0 -6.693503,6.4909037 -6.665508,8.4367987 l 0,5.764416 z"
+       style="opacity:0.4;fill:none;stroke:#000000;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
        id="path2086-6-4"
-       style="opacity:0.4;fill:none;stroke:#000000;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       d="m 12.5,23.695457 0,-7.716497 C 12.5,8.1340067 17.002278,4.4071092 23.958059,4.5050802 30.951688,4.6030514 35.501881,8.0417146 35.501881,15.97896 l 0,7.965697 -4.702062,0 0,-5.972096 c 0,-1.993601 0.486805,-8.4447477 -6.792763,-8.4447477 -7.219539,0 -6.693503,6.4909037 -6.665508,8.4367987 l 0,5.764416 z" />
     <rect
-       width="4.5000348"
-       height="4.5000339"
-       x="37.500294"
-       y="41.999954"
+       style="opacity:0.3;fill:url(#radialGradient3093);fill-opacity:1;stroke:none"
        id="rect2801"
-       style="opacity:0.3;fill:url(#radialGradient3093);fill-opacity:1;stroke:none" />
-    <rect
-       width="4.5000348"
-       height="4.5000339"
-       x="-10.500081"
-       y="-46.499989"
-       transform="scale(-1,-1)"
-       id="rect3696"
-       style="opacity:0.3;fill:url(#radialGradient3090);fill-opacity:1;stroke:none" />
-    <rect
-       width="27.000208"
-       height="4.5000343"
-       x="10.500081"
        y="41.999954"
+       x="37.500294"
+       height="4.5000339"
+       width="4.5000348" />
+    <rect
+       style="opacity:0.3;fill:url(#radialGradient3090);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1,-1)"
+       y="-46.499989"
+       x="-10.500081"
+       height="4.5000339"
+       width="4.5000348" />
+    <rect
+       style="opacity:0.3;fill:url(#linearGradient3087);fill-opacity:1;stroke:none"
        id="rect3700"
-       style="opacity:0.3;fill:url(#linearGradient3087);fill-opacity:1;stroke:none" />
+       y="41.999954"
+       x="10.500081"
+       height="4.5000343"
+       width="27.000208" />
     <rect
-       width="31"
-       height="22"
-       rx="1"
-       ry="0.99999994"
-       x="8.5"
-       y="22.5"
+       style="color:#000000;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect3186-2"
-       style="color:#000000;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="2"
-       height="21.000162"
-       rx="2"
-       ry="0.99999994"
-       x="11"
-       y="22.999838"
-       id="rect5453"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3071);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="2"
-       height="21.000162"
-       rx="2"
-       ry="0.99999994"
-       x="35"
-       y="22.999838"
-       id="rect5453-6"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3068);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="1.5000116"
-       height="21.000162"
-       rx="2"
-       ry="0.99999994"
-       x="9.7500763"
-       y="-44"
-       transform="scale(1,-1)"
-       id="rect5453-4"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="1.5000116"
-       height="21.000162"
-       rx="2"
-       ry="0.99999994"
-       x="36.750286"
-       y="-44"
-       transform="scale(1,-1)"
-       id="rect5453-4-4"
-       style="opacity:0.5;color:#000000;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="29"
-       height="20"
-       x="9.5"
-       y="23.5"
-       id="rect3186-3"
-       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3059);stroke-width:0.99999994px;stroke-linejoin:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="31"
-       height="22"
-       rx="1"
-       ry="0.99999994"
-       x="8.5"
        y="22.5"
+       x="8.5"
+       ry="0.99999994"
+       rx="1"
+       height="22"
+       width="31" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3071);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5453"
+       y="22.999838"
+       x="11"
+       ry="0.99999994"
+       rx="2"
+       height="21.000162"
+       width="2" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3068);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5453-6"
+       y="22.999838"
+       x="35"
+       ry="0.99999994"
+       rx="2"
+       height="21.000162"
+       width="2" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5453-4"
+       transform="scale(1,-1)"
+       y="-44"
+       x="9.7500763"
+       ry="0.99999994"
+       rx="2"
+       height="21.000162"
+       width="1.5000116" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5453-4-4"
+       transform="scale(1,-1)"
+       y="-44"
+       x="36.750286"
+       ry="0.99999994"
+       rx="2"
+       height="21.000162"
+       width="1.5000116" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3059);stroke-width:0.99999994px;stroke-linejoin:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3186-3"
+       y="23.5"
+       x="9.5"
+       height="20"
+       width="29" />
+    <rect
+       style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:1px;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="rect3186"
-       style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:1px;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       y="22.5"
+       x="8.5"
+       ry="0.99999994"
+       rx="1"
+       height="22"
+       width="31" />
     <path
-       d="m 10.714369,26.499885 25.500199,0 m -25.500199,3.000024 25.500199,0 m -25.500199,3.000021 25.500199,0 m -25.500199,3.000024 25.500199,0 m -25.500199,3.000024 25.500199,0 M 10.714369,41.5 l 25.500199,0"
+       style="opacity:0.05;fill:none;stroke:url(#linearGradient3927-6);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        id="path3863-6"
-       style="opacity:0.05;fill:none;stroke:url(#linearGradient3927-6);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       d="m 10.714369,26.499885 25.500199,0 m -25.500199,3.000024 25.500199,0 m -25.500199,3.000021 25.500199,0 m -25.500199,3.000024 25.500199,0 m -25.500199,3.000024 25.500199,0 M 10.714369,41.5 l 25.500199,0" />
     <path
-       d="m 10.714369,25.499884 25.500199,0 m -25.500199,3.000024 25.500199,0 m -25.500199,3.000021 25.500199,0 m -25.500199,3.000024 25.500199,0 m -25.500199,3.000024 25.500199,0 M 10.714369,40.5 l 25.500199,0"
+       style="opacity:0.2;fill:none;stroke:url(#linearGradient3888-76);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        id="path3863-3-5"
-       style="opacity:0.2;fill:none;stroke:url(#linearGradient3888-76);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       d="m 10.714369,25.499884 25.500199,0 m -25.500199,3.000024 25.500199,0 m -25.500199,3.000021 25.500199,0 m -25.500199,3.000024 25.500199,0 m -25.500199,3.000024 25.500199,0 M 10.714369,40.5 l 25.500199,0" />
   </g>
 </svg>


### PR DESCRIPTION
To go along with `channel-secure-symbolic`

original icons are vacuumed by the pre-commit hook. No other changes