### PR TITLE
Rebase harddisk on removable media

### DIFF
--- a/devices/16/drive-harddisk.svg
+++ b/devices/16/drive-harddisk.svg
@@ -6,10 +6,10 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
-   width="16"
+   id="svg3297"
    height="16"
-   id="svg3297">
+   width="16"
+   version="1.0">
   <metadata
      id="metadata58">
     <rdf:RDF>
@@ -27,106 +27,90 @@
     <linearGradient
        id="linearGradient4472">
       <stop
-         id="stop4474"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop4474" />
       <stop
-         id="stop4476"
+         offset="0.02116842"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.02116842" />
+         id="stop4476" />
       <stop
-         id="stop4478"
+         offset="0.99223143"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99223143" />
+         id="stop4478" />
       <stop
-         id="stop4480"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop4480" />
     </linearGradient>
     <linearGradient
        id="linearGradient2215-9">
       <stop
-         id="stop2223-6"
+         offset="0"
          style="stop-color:#7a7a7a;stop-opacity:1"
-         offset="0" />
+         id="stop2223-6" />
       <stop
-         id="stop2219-1"
+         offset="1"
          style="stop-color:#474747;stop-opacity:1"
-         offset="1" />
+         id="stop2219-1" />
     </linearGradient>
     <linearGradient
        id="linearGradient7056-0">
       <stop
-         id="stop7064-4"
+         offset="0"
          style="stop-color:#e6e6e6;stop-opacity:1"
-         offset="0" />
+         id="stop7064-4" />
       <stop
-         id="stop7060-2"
+         offset="1"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
+         id="stop7060-2" />
     </linearGradient>
     <radialGradient
-       cx="4.1993008"
-       cy="2.3117516"
-       r="7.9999995"
-       fx="4.1993008"
-       fy="2.3117516"
-       id="radialGradient8215"
+       gradientTransform="matrix(1.1767008,1.0376968,-0.76927742,0.87232541,1.0363585,-3.2771526)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient7056-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1767008,1.0376968,-0.76927742,0.87232541,1.0363585,-3.2771526)" />
+       id="radialGradient8215"
+       fy="2.3117516"
+       fx="4.1993008"
+       r="7.9999995"
+       cy="2.3117516"
+       cx="4.1993008" />
     <linearGradient
-       x1="53.99139"
-       y1="87.89592"
-       x2="53.99139"
-       y2="104.28131"
-       id="linearGradient8226"
+       gradientTransform="matrix(0.1242128,0,0,0.1863981,0.233129,-3.9907482)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient2215-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.1242128,0,0,0.1863981,0.233129,-3.9907482)" />
+       id="linearGradient8226"
+       y2="104.28131"
+       x2="53.99139"
+       y1="87.89592"
+       x1="53.99139" />
     <linearGradient
+       x1="23.99999"
+       y1="7.3399634"
+       x2="23.99999"
+       y2="41.03442"
+       id="linearGradient4161"
+       xlink:href="#linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26751495,0,0,0.26751495,4.7162587,-0.01354682)" />
+    <linearGradient
+       y2="54.887066"
+       x2="23.99999"
+       y1="50.676285"
+       x1="23.99999"
        gradientTransform="matrix(0.26751495,0,0,0.26751495,4.7162587,-0.01354682)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4472"
-       id="linearGradient4161"
-       y2="41.03442"
-       x2="23.99999"
-       y1="7.3399634"
-       x1="23.99999" />
+       id="linearGradient4525"
+       xlink:href="#linearGradient4472" />
     <linearGradient
-       id="linearGradient8105">
-      <stop
-         id="stop8107"
-         style="stop-color:#f5f5f5;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8109"
-         style="stop-color:#e7e7e7;stop-opacity:1"
-         offset="0.25027597" />
-      <stop
-         id="stop8111"
-         style="stop-color:#8c8c8c;stop-opacity:1"
-         offset="0.69348532" />
-      <stop
-         id="stop8113"
-         style="stop-color:#dddddd;stop-opacity:1"
-         offset="0.83542866" />
-      <stop
-         id="stop8115"
-         style="stop-color:#a8a8a8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4236-0">
-      <stop
-         id="stop4238-4"
-         style="stop-color:#eeeeee;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4240-3"
-         style="stop-color:#eeeeee;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       x1="7.0625"
+       y1="35.28125"
+       x2="24.6875"
+       y2="35.28125"
+       id="linearGradient8223"
+       xlink:href="#linearGradient6309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5545779,0,0,0.35955055,-1.6911436,1.3146057)" />
     <linearGradient
        id="linearGradient6309">
       <stop
@@ -138,6 +122,36 @@
          style="stop-color:#bbbbbb;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient8220"
+       xlink:href="#linearGradient4236-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5545779,0,0,0.35955055,-2.132306,1.7913054)" />
+    <linearGradient
+       id="linearGradient4236-0">
+      <stop
+         id="stop4238-4"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240-3"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="141.74666"
+       cy="206.42612"
+       r="78.728165"
+       fx="141.74666"
+       fy="206.42612"
+       id="radialGradient8211"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12708936,-0.00212891,9.4059438e-4,0.12249323,-10.298148,-14.500064)" />
     <linearGradient
        id="linearGradient4035">
       <stop
@@ -161,37 +175,6 @@
          style="stop-color:#a8a8a8;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient6310-8">
-      <stop
-         id="stop6312-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6314-6"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="127.31733"
-       cy="143.82751"
-       r="78.728165"
-       fx="127.31733"
-       fy="143.82751"
-       id="radialGradient8198"
-       xlink:href="#linearGradient8105"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.04179653,-0.01388393,0.00338688,0.03797545,-0.54190607,-0.79595187)" />
-    <radialGradient
-       cx="24"
-       cy="42"
-       r="21"
-       fx="24"
-       fy="42"
-       id="radialGradient8201"
-       xlink:href="#linearGradient6310-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.33333332,0,0,0.14285711,6.5e-7,8.0000015)" />
     <radialGradient
        cx="142.62215"
        cy="191.85428"
@@ -203,66 +186,71 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.06165082,0,0,-0.0653716,-1.0370648,17.524179)" />
     <radialGradient
-       cx="141.74666"
-       cy="206.42612"
+       cx="127.31733"
+       cy="143.82751"
        r="78.728165"
-       fx="141.74666"
-       fy="206.42612"
-       id="radialGradient8211"
-       xlink:href="#linearGradient4035"
+       fx="127.31733"
+       fy="143.82751"
+       id="radialGradient8198"
+       xlink:href="#linearGradient8105"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.12708936,-0.00212891,9.4059438e-4,0.12249323,-10.298148,-14.500064)" />
+       gradientTransform="matrix(0.04179653,-0.01388393,0.00338688,0.03797545,-0.54190609,-0.7959519)" />
     <linearGradient
-       x1="12.277412"
-       y1="37.205811"
-       x2="12.221823"
-       y2="33.758667"
-       id="linearGradient8220"
-       xlink:href="#linearGradient4236-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5545779,0,0,0.35955055,-2.132306,1.7913054)" />
-    <linearGradient
-       x1="7.0625"
-       y1="35.28125"
-       x2="24.6875"
-       y2="35.28125"
-       id="linearGradient8223"
-       xlink:href="#linearGradient6309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5545779,0,0,0.35955055,-1.6911436,1.3146057)" />
+       id="linearGradient8105">
+      <stop
+         id="stop8107"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8109"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.25027597" />
+      <stop
+         id="stop8111"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.69348532" />
+      <stop
+         id="stop8113"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop8115"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
   </defs>
   <path
-     d="M 1.4897093,1.4657632 0.514749,12.488885 C 0.505,12.488885 0.5,12.491788 0.5,12.499999 l 14.999999,0 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478485 c 0,0 -0.187746,-0.74340135 -0.909635,-0.74340135 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576325 -0.8205124,0.96576325 z"
+     style="fill:url(#radialGradient8215);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect2990"
-     style="fill:url(#radialGradient8215);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 1.4897093,1.4657632 0.514749,12.488885 C 0.505,12.488885 0.5,12.491788 0.5,12.499999 l 14.999999,0 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478485 c 0,0 -0.187746,-0.74340135 -0.909635,-0.74340135 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576325 -0.8205124,0.96576325 z" />
   <path
-     d="M 15.485249,12.488885 14.479867,1.2478483 c 0,0 -0.187746,-0.74340136 -0.909635,-0.74340136 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576326 -0.8205124,0.96576306 L 0.514749,12.488885"
+     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;opacity:0.35"
      id="rect2990-0"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="M 1.4897093,1.465763 0.514749,12.488885 C 0.505,12.488885 0.5,12.491785 0.5,12.499995 l 14.999999,0 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478483 c 0,0 -0.187746,-0.74340136 -0.909635,-0.74340136 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576326 -0.8205124,0.96576326 z" />
   <path
-     d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect2992"
-     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
   <path
-     d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5"
+     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;opacity:0.5"
      id="rect2992-2"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
+  <path
+     d="m 1.578125,13.476562 c 0.035324,0.3836 0.082771,0.870078 0.1015625,1.03125 2.352568,8.41e-4 5.411826,0.0094 8.015625,0.01367 1.3716895,0.0023 2.6003495,0.0036 3.4980465,0.002 0.448849,-8.46e-4 0.815103,-0.0034 1.072266,-0.0059 0.0025,-2.4e-5 0.0034,2.4e-5 0.0059,0 0.02745,-0.171355 0.08454,-0.677932 0.125,-1.041016 l -12.818359,0 z"
+     id="path4497"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;color:#000000;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
   <path
      style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8223);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.40899992;marker:none"
      id="rect9146"
-     d="m 2,13 10,0 0,2 L 2.2255647,15 2,13 Z" />
+     d="m 2,13 h 10 v 2 H 2.2255647 Z" />
   <path
      style="opacity:0.81142853;fill:url(#linearGradient8220);fill-opacity:1;fill-rule:evenodd;stroke:none"
      id="path9148"
      d="m 2.2255639,14.999999 c 0,0 -0.1503759,-1.442332 -0.1503759,-1.442332 1.0179428,1.143093 4.7514263,1.442332 7.3252263,1.442332 0,0 -7.1748504,0 -7.1748504,0 z" />
   <path
-     style="display:inline;opacity:0.7;fill:none;stroke:#ffffff;stroke-width:0.99999988;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path2215"
-     d="m 1.4762913,12.5 13.0474177,0" />
-  <path
      style="fill:url(#radialGradient8211);fill-opacity:1"
      id="path8117"
-     d="M 9.875,1.03125 C 9.5425325,1.03125 9.2896361,1.1933561 9.28125,1.4375 7.5462296,4.2547045 3.7159646,3.3310272 2.1875,6.6875 2.107281,7.5502069 2.3133647,8.6701052 3.09375,9.375 4.23596,10.40677 6.1379859,11.041207 8.15625,11 12.321615,10.914959 15.990924,8.1997572 12.8125,4.65625 12.794904,4.4114056 12.5625,1.4375 12.5625,1.4375 12.545264,1.1967161 12.267601,1.03125 11.9375,1.03125 l -2.0625,0 z m -0.03125,0.4375 2.0625,0 c 0.119904,0 0.214005,0.027064 0.21875,0.09375 L 11.6875,4.65625 C 15.160987,7.4613605 11.945518,9.7796633 8.25,9.90625 4.8918537,10.021279 2.9699492,8.847871 3.15625,6.84375 4.3344434,3.466723 8.863656,5.0817755 9.625,1.5625 9.6054609,1.4997867 9.7265155,1.46875 9.84375,1.46875 Z" />
+     d="M 9.875,1.03125 C 9.5425325,1.03125 9.2896361,1.1933561 9.28125,1.4375 7.5462296,4.2547045 3.7159646,3.3310272 2.1875,6.6875 2.107281,7.5502069 2.3133647,8.6701052 3.09375,9.375 4.23596,10.40677 6.1379859,11.041207 8.15625,11 12.321615,10.914959 15.990924,8.1997572 12.8125,4.65625 12.794904,4.4114056 12.5625,1.4375 12.5625,1.4375 12.545264,1.1967161 12.267601,1.03125 11.9375,1.03125 Z m -0.03125,0.4375 h 2.0625 c 0.119904,0 0.214005,0.027064 0.21875,0.09375 L 11.6875,4.65625 C 15.160987,7.4613605 11.945518,9.7796633 8.25,9.90625 4.8918537,10.021279 2.9699492,8.847871 3.15625,6.84375 4.3344434,3.466723 8.863656,5.0817755 9.625,1.5625 9.6054609,1.4997867 9.7265155,1.46875 9.84375,1.46875 Z" />
   <path
      style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient8208);fill-opacity:1;fill-rule:nonzero;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path9400"
@@ -273,7 +261,7 @@
     <path
        style="fill:#535353;fill-opacity:1"
        id="path9438"
-       d="m 37.925296,187.15033 c 0.31446,3.45855 5.02375,6.27902 10.51419,6.27902 5.48794,0 9.6432,-2.82047 9.27634,-6.27902 -0.36437,-3.44025 -5.07117,-6.21806 -10.5067,-6.21806 -5.43803,0.002 -9.59329,2.77781 -9.28383,6.21806 l 0,0 z" />
+       d="m 37.925296,187.15033 c 0.31446,3.45855 5.02375,6.27902 10.51419,6.27902 5.48794,0 9.6432,-2.82047 9.27634,-6.27902 -0.36437,-3.44025 -5.07117,-6.21806 -10.5067,-6.21806 -5.43803,0.002 -9.59329,2.77781 -9.28383,6.21806 z" />
   </g>
   <g
      id="g9496"
@@ -281,21 +269,14 @@
     <path
        style="fill:#535353;fill-opacity:1"
        id="path9498"
-       d="m 37.925296,187.15033 c 0.31446,3.45855 5.02375,6.27902 10.51419,6.27902 5.48794,0 9.6432,-2.82047 9.27634,-6.27902 -0.36437,-3.44025 -5.07117,-6.21806 -10.5067,-6.21806 -5.43803,0.002 -9.59329,2.77781 -9.28383,6.21806 l 0,0 z" />
+       d="m 37.925296,187.15033 c 0.31446,3.45855 5.02375,6.27902 10.51419,6.27902 5.48794,0 9.6432,-2.82047 9.27634,-6.27902 -0.36437,-3.44025 -5.07117,-6.21806 -10.5067,-6.21806 -5.43803,0.002 -9.59329,2.77781 -9.28383,6.21806 z" />
   </g>
-  <rect
-     style="opacity:0.2;fill:url(#radialGradient8201);fill-opacity:1;stroke:none"
-     id="rect6300-3"
-     y="13"
-     x="1"
-     height="2"
-     width="14" />
   <path
      style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient8198);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path8125"
-     d="M 3.5490052,1.2794204 C 3.5821222,1.4638603 3.5033392,1.668064 3.4765882,1.8577602 3.3642225,2.4379547 3.248083,3.0174209 3.1387788,3.5982061 3.0364568,3.976483 3.4034434,3.822574 3.4487925,3.8610185 3.9285086,3.6778743 4.4037673,3.4775049 4.8813544,3.2862237 5.3796101,3.0823738 5.8809457,2.8849464 6.3772748,2.677079 6.6902572,2.4909307 6.7820665,2.323762 6.8635898,2.0428768 6.9084532,1.7990145 6.9138614,1.5262921 6.7919595,1.3034032 6.7139126,1.1493881 6.5435087,1.0841579 6.379809,1.1073783 c -0.8675476,0 -1.7350953,0 -2.6026429,0 L 3.5490052,1.2794204 Z m 0.588988,0.4439693 c 0.5921265,0 1.184253,-1e-7 1.7763795,-1e-7 0.1871044,0.070513 0.054625,0.2194806 -0.083295,0.2325189 C 5.229708,2.1997992 4.6283387,2.4436898 4.0269694,2.6875804 3.8824333,2.7420385 3.8720481,2.5203138 3.9157358,2.4262942 c 0.037079,-0.2075185 0.074157,-0.415037 0.1112359,-0.6225555 0.041217,-0.021125 0.065659,-0.065363 0.1110215,-0.080349 z" />
+     d="M 3.5490052,1.2794204 C 3.5821222,1.4638603 3.5033392,1.668064 3.4765882,1.8577602 3.3642225,2.4379547 3.248083,3.0174209 3.1387788,3.5982061 3.0364568,3.976483 3.4034434,3.822574 3.4487925,3.8610185 3.9285086,3.6778743 4.4037673,3.4775049 4.8813544,3.2862237 5.3796101,3.0823738 5.8809457,2.8849464 6.3772748,2.677079 6.6902572,2.4909307 6.7820665,2.323762 6.8635898,2.0428768 6.9084532,1.7990145 6.9138614,1.5262921 6.7919595,1.3034032 6.7139126,1.1493881 6.5435087,1.0841579 6.379809,1.1073783 c -0.8675476,0 -1.7350953,0 -2.6026429,0 z m 0.588988,0.4439693 c 0.5921265,0 1.184253,-1e-7 1.7763795,-1e-7 0.1871044,0.070513 0.054625,0.2194806 -0.083295,0.2325189 C 5.229708,2.1997992 4.6283387,2.4436898 4.0269694,2.6875804 3.8824333,2.7420385 3.8720481,2.5203138 3.9157358,2.4262942 c 0.037079,-0.2075185 0.074157,-0.415037 0.1112359,-0.6225555 0.041217,-0.021125 0.065659,-0.065363 0.1110215,-0.080349 z" />
   <path
-     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4161);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;color:#000000;clip-rule:nonzero;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+     d="m 2.4980469,1.5019531 c -0.00136,0.00636 -0.00781,0.027344 -0.00781,0.027344 a 1.0015087,1.0015087 0 0 1 -0.00195,0.023437 l -0.8789062,9.9453126 12.78125,0 -0.892578,-9.9921876 C 12.708012,1.5058107 3.4947245,1.5020781 2.4980469,1.5019531 Z"
      id="path4266"
-     d="m 2.4980469,1.5019531 c -0.00136,0.00636 -0.00781,0.027344 -0.00781,0.027344 a 1.0015087,1.0015087 0 0 1 -0.00195,0.023437 l -0.8789062,9.9453126 12.78125,0 -0.892578,-9.9921876 C 12.708012,1.5058107 3.4947245,1.5020781 2.4980469,1.5019531 Z" />
+     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4161);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;color:#000000;clip-rule:nonzero;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
 </svg>

--- a/devices/24/drive-harddisk.svg
+++ b/devices/24/drive-harddisk.svg
@@ -18,11 +18,31 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs4">
+    <linearGradient
+       id="linearGradient4075">
+      <stop
+         id="stop4077"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4079"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03367912" />
+      <stop
+         id="stop4081"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4083"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
     <linearGradient
        id="linearGradient5048">
       <stop
@@ -49,15 +69,6 @@
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="9.5990496"
-       y1="13.498952"
-       x2="4.4590349"
-       y2="8.3495274"
-       id="linearGradient2869"
-       xlink:href="#linearGradient3484-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9892473,0,0,1.4696392,0.129032,-10.33859)" />
     <linearGradient
        x1="53.99139"
        y1="87.89592"
@@ -97,28 +108,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.03776775,0,0,0.01085997,-1.650341,17.380799)" />
     <linearGradient
-       id="linearGradient6310-8">
-      <stop
-         id="stop6312-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6314-6"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3484-2">
-      <stop
-         id="stop3486-2"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3488-0"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient7056-0">
       <stop
          id="stop7064-4"
@@ -140,29 +129,103 @@
          style="stop-color:#474747;stop-opacity:1"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       cx="7.2203388"
+       cy="4.2332726"
+       r="12"
+       fx="7.2203388"
+       fy="4.2332726"
+       id="radialGradient4072"
+       xlink:href="#linearGradient7056-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5193809,0.00371571,-0.00302474,1.2368318,-3.737301,0.06783288)" />
     <linearGradient
-       id="linearGradient4035">
+       x1="23.99999"
+       y1="51.346149"
+       x2="23.99999"
+       y2="53.354122"
+       id="linearGradient4525"
+       xlink:href="#linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42777307,0,0,0.51069006,6.7368356,-6.2528082)" />
+    <linearGradient
+       id="linearGradient4472">
       <stop
-         id="stop4037"
-         style="stop-color:#f5f5f5;stop-opacity:1"
+         id="stop4474"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4039"
-         style="stop-color:#e7e7e7;stop-opacity:1"
-         offset="0.47025558" />
+         id="stop4476"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02116842" />
       <stop
-         id="stop4041"
-         style="stop-color:#8c8c8c;stop-opacity:1"
-         offset="0.69348532" />
+         id="stop4478"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
       <stop
-         id="stop4043"
-         style="stop-color:#dddddd;stop-opacity:1"
-         offset="0.83542866" />
-      <stop
-         id="stop4045"
-         style="stop-color:#a8a8a8;stop-opacity:1"
+         id="stop4480"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.5391083"
+       x2="23.99999"
+       y2="42.102226"
+       id="linearGradient4161-4"
+       xlink:href="#linearGradient4075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26232885,0,0,0.42474288,8.0835877,-0.81629626)" />
+    <linearGradient
+       x1="7.0625"
+       y1="35.28125"
+       x2="24.6875"
+       y2="35.28125"
+       id="linearGradient8490"
+       xlink:href="#linearGradient6309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.2092209,1.4719088)" />
+    <linearGradient
+       id="linearGradient6309">
+      <stop
+         id="stop6311"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6313"
+         style="stop-color:#bbbbbb;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient8487"
+       xlink:href="#linearGradient4236-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.7959675,2.1869583)" />
+    <linearGradient
+       id="linearGradient4236-0">
+      <stop
+         id="stop4238-4"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240-3"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8447"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
     <radialGradient
        cx="113.0654"
        cy="97.587898"
@@ -189,47 +252,58 @@
          offset="1" />
     </radialGradient>
     <radialGradient
-       cx="24"
-       cy="42"
-       r="21"
-       fx="24"
-       fy="42"
-       id="radialGradient3248"
-       xlink:href="#linearGradient6310-8"
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8443"
+       xlink:href="#radialGradient4241"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5238095,0,1.4568516e-8,0.21428567,-0.57142763,11.500002)" />
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
     <radialGradient
-       cx="7.2203388"
-       cy="4.2332726"
-       r="12"
-       fx="7.2203388"
-       fy="4.2332726"
-       id="radialGradient4072"
-       xlink:href="#linearGradient7056-0"
+       cx="141.74666"
+       cy="206.42612"
+       r="78.728165"
+       fx="141.74666"
+       fy="206.42612"
+       id="radialGradient8471"
+       xlink:href="#linearGradient4035"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5193809,0.00371571,-0.00302474,1.2368318,-3.737301,0.06783288)" />
+       gradientTransform="matrix(0.18614571,-0.00314024,0.00137767,0.18068297,-15.012876,-20.635958)" />
     <linearGradient
-       id="linearGradient6309">
+       id="linearGradient4035">
       <stop
-         id="stop6311"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop4037"
+         style="stop-color:#f5f5f5;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop6313"
-         style="stop-color:#bbbbbb;stop-opacity:0"
+         id="stop4039"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop4041"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.69348532" />
+      <stop
+         id="stop4043"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop4045"
+         style="stop-color:#a8a8a8;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient4236-0">
-      <stop
-         id="stop4238-4"
-         style="stop-color:#eeeeee;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4240-3"
-         style="stop-color:#eeeeee;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+    <radialGradient
+       cx="142.62215"
+       cy="191.85428"
+       r="78.728165"
+       fx="142.62215"
+       fy="191.85428"
+       id="radialGradient8464"
+       xlink:href="#linearGradient7609-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09247618,0,0,-0.08716215,-1.5555849,24.365579)" />
     <linearGradient
        id="linearGradient7609-6">
       <stop
@@ -254,46 +328,6 @@
          offset="1" />
     </linearGradient>
     <radialGradient
-       cx="113.0654"
-       cy="97.587898"
-       r="2.5631001"
-       fx="113.667"
-       fy="98"
-       id="radialGradient8443"
-       xlink:href="#radialGradient4241"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient
-       cx="113.0654"
-       cy="97.587898"
-       r="2.5631001"
-       fx="113.667"
-       fy="98"
-       id="radialGradient8447"
-       xlink:href="#radialGradient4241"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient
-       cx="142.62215"
-       cy="191.85428"
-       r="78.728165"
-       fx="142.62215"
-       fy="191.85428"
-       id="radialGradient8464"
-       xlink:href="#linearGradient7609-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.09247618,0,0,-0.08716215,-1.5555849,24.365579)" />
-    <radialGradient
-       cx="141.74666"
-       cy="206.42612"
-       r="78.728165"
-       fx="141.74666"
-       fy="206.42612"
-       id="radialGradient8471"
-       xlink:href="#linearGradient4035"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.18614571,-0.00314024,0.00137767,0.18068297,-15.012876,-20.635958)" />
-    <radialGradient
        cx="127.31733"
        cy="143.82751"
        r="78.728165"
@@ -302,32 +336,14 @@
        id="radialGradient8475"
        xlink:href="#linearGradient4035"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.10005865,-0.02337636,0.00821684,0.05971738,-5.2741109,-0.91134684)" />
-    <linearGradient
-       x1="12.277412"
-       y1="37.205811"
-       x2="12.221823"
-       y2="33.758667"
-       id="linearGradient8487"
-       xlink:href="#linearGradient4236-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.7959675,2.1869584)" />
-    <linearGradient
-       x1="7.0625"
-       y1="35.28125"
-       x2="24.6875"
-       y2="35.28125"
-       id="linearGradient8490"
-       xlink:href="#linearGradient6309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.2092209,1.4719089)" />
+       gradientTransform="matrix(0.10005865,-0.02337636,0.00821684,0.05971738,-5.2741109,-0.9113469)" />
     <radialGradient
        cx="113.0654"
        cy="97.587898"
        r="2.5631001"
        fx="113.667"
        fy="98"
-       id="radialGradient8494"
+       id="radialGradient8498"
        xlink:href="#radialGradient4241"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
@@ -337,7 +353,7 @@
        r="2.5631001"
        fx="113.667"
        fy="98"
-       id="radialGradient8498"
+       id="radialGradient8494"
        xlink:href="#radialGradient4241"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
@@ -358,89 +374,94 @@
      id="path2727"
      style="opacity:0.40206185;fill:url(#radialGradient2877);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
   <path
+     d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 l 23,0 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.50000001 19.5,0.50000001 l -15,0 C 3.6666667,0.50000001 2.5992572,1.172599 2.5,2 z"
+     id="rect2990"
+     style="fill:url(#radialGradient4072);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 l 23,0 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.49999997 19.5,0.49999997 l -15,0 C 3.6666667,0.49999997 2.5992572,1.172599 2.5,2 z"
+     id="rect2990-5"
+     style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
      d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 0,-4.9e-5 z"
      id="rect2992"
-     style="fill:url(#linearGradient2872);fill-opacity:1;fill-rule:nonzero;stroke:#353537;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="fill:url(#linearGradient2872);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
-     d="M 2.7,19 16,19 16,22 3.0000009,22 2.7,19 z"
+     d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 0,-4.9e-5 z"
+     id="rect2992-0"
+     style="opacity:0.5;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 1.8811692,21.468685 20.1351998,0.01866 c 0.0552,-0.198713 0.332357,-1.987316 0.332357,-1.987316 l -20.7291868,0 c 0,0 0.1806404,1.463168 0.26163,1.968656 z"
+     id="path4497"
+     style="opacity:0.2;color:#000000;fill:none;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="M 4.5,1.46875 C 4.3477124,1.46875 4.0083027,1.5891821 3.78125,1.75 3.5541973,1.9108179 3.4725109,2.0936491 3.46875,2.125 L 1.625,17.53125 l 20.75,0 L 20.53125,2.125 C 20.527489,2.0936468 20.445803,1.910818 20.21875,1.75 19.991697,1.589182 19.652287,1.46875 19.5,1.46875 l -15,0 z"
+     id="path4034"
+     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="M 2.7,19 H 16 v 3 H 3.0000009 Z"
      id="rect9146"
-     style="fill:url(#linearGradient8490);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.40899992;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8490);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.40899992;marker:none" />
   <path
      d="m 2.9999999,21.999998 c 0,0 -0.1999999,-2.163497 -0.1999999,-2.163497 1.353864,1.714639 6.3193967,2.163497 9.742551,2.163497 0,0 -9.5425511,0 -9.5425511,0 z"
      id="path9148"
      style="opacity:0.81142853;fill:url(#linearGradient8487);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-  <path
-     d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 l 23,0 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.50000001 19.5,0.50000001 l -15,0 C 3.6666667,0.50000001 2.5992572,1.172599 2.5,2 z"
-     id="rect2990"
-     style="fill:url(#radialGradient4072);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2869);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     d="m 1.499053,18.5 21.001895,0"
-     id="path2215"
-     style="opacity:0.6;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
-  <rect
-     width="22"
-     height="3"
-     x="1"
-     y="19"
-     id="rect6300-3"
-     style="opacity:0.2;fill:url(#radialGradient3248);fill-opacity:1;stroke:none" />
   <g
-     transform="matrix(0.06610079,-0.01141585,0.00791914,0.04585394,-0.89214235,-6.4254018)"
+     transform="matrix(0.06610079,-0.01141585,0.00791914,0.04585394,-0.89214226,-6.4254019)"
      id="g9164">
     <path
        d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
        id="path9166"
        style="fill:#e6e6e6;fill-opacity:1" />
     <path
-       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 l -2e-5,0 z"
+       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
        id="path9168"
        style="fill:url(#radialGradient8447);fill-opacity:1" />
   </g>
   <g
-     transform="matrix(0.06707933,0,0,0.04653275,15.651438,-7.2130769)"
+     transform="matrix(0.06707933,0,0,0.04653275,15.651438,-7.213077)"
      id="g9170">
     <path
        d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
        id="path9172"
        style="fill:#e6e6e6;fill-opacity:1" />
     <path
-       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 l -2e-5,0 z"
+       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
        id="path9174"
        style="fill:url(#radialGradient8443);fill-opacity:1" />
   </g>
   <path
-     d="m 14.53125,1.8125 c -0.277487,0 -0.524679,0.080669 -0.71875,0.21875 -0.194071,0.1380809 -0.335443,0.3501636 -0.34375,0.59375 -0.02564,0.7496949 -0.408158,1.2892802 -1.125,1.78125 -0.71102,0.4879742 -1.754682,0.8998582 -3,1.28125 -0.010197,0.00312 -0.021024,-0.00312 -0.03125,0 -0.4709962,0.098904 -1.2449515,0.376082 -2,0.65625 C 6.5467846,6.627876 5.8477349,6.901852 5.53125,7.125 3.9333833,8.1304054 2.9482809,9.4666744 2.8125,10.9375 c -0.1236371,1.339128 0.479389,2.679448 1.65625,3.75 1.7216568,1.566191 4.535316,2.5 7.53125,2.5 2.995943,0 5.809394,-0.933827 7.53125,-2.5 1.074959,-0.977664 1.65625,-2.155057 1.65625,-3.375 0,-0.09948 0.0114,-0.242274 0,-0.375 C 21.06834,9.6463531 20.271626,8.4541408 19,7.5 18.96439,6.9956324 18.65625,2.625 18.65625,2.625 18.638973,2.3813174 18.480216,2.1678021 18.28125,2.03125 18.082284,1.8946979 17.839128,1.8125 17.5625,1.8125 l -3.03125,0 z m 0,0.53125 3.03125,0 c 0.06724,0 0.12597,0.018412 0.15625,0.03125 l 0.375,5.125 a 0.18751875,0.18751875 0 0 0 0,0.0625 0.18751875,0.18751875 0 0 0 0.03125,0.03125 0.18751875,0.18751875 0 0 0 0.0625,0.0625 c 1.232005,0.8428273 1.959003,2.1272478 2.0625,3.25 0.128872,1.395121 -0.699256,2.548585 -2.1875,3.40625 -1.488244,0.857665 -3.625741,1.375 -6.0625,1.375 -2.436754,0 -4.5742796,-0.517335 -6.0625,-1.375 C 4.4492796,13.454835 3.6212244,12.301377 3.75,10.90625 3.8608671,9.705693 4.7056237,8.3698014 6.09375,7.5 A 0.18751875,0.18751875 0 0 0 6.125,7.46875 C 6.1295861,7.4646691 6.1936848,7.4211298 6.28125,7.375 6.3688152,7.3288702 6.4894037,7.2799235 6.625,7.21875 6.8961926,7.096403 7.2259767,6.9543687 7.59375,6.8125 8.3292966,6.5287625 9.1621264,6.262651 9.5625,6.1875 a 0.18751875,0.18751875 0 0 0 0.03125,0 c 1.209316,-0.3682061 2.35807,-0.8065982 3.25,-1.40625 0.873851,-0.5874967 1.503327,-1.3689786 1.5625,-2.40625 0.02028,-0.00976 0.06108,-0.03125 0.125,-0.03125 z"
+     d="m 14.53125,1.8124999 c -0.277487,0 -0.524679,0.080669 -0.71875,0.21875 -0.194071,0.1380809 -0.335443,0.3501636 -0.34375,0.59375 -0.02564,0.7496949 -0.408158,1.2892802 -1.125,1.78125 -0.71102,0.4879742 -1.754682,0.8998582 -3,1.28125 -0.010197,0.00312 -0.021024,-0.00312 -0.03125,0 -0.4709962,0.098904 -1.2449515,0.376082 -2,0.65625 -0.7657154,0.284126 -1.4647651,0.558102 -1.78125,0.78125 C 3.9333833,8.1304053 2.9482809,9.4666743 2.8125,10.9375 c -0.1236371,1.339128 0.479389,2.679448 1.65625,3.75 1.7216568,1.566191 4.535316,2.5 7.53125,2.5 2.995943,0 5.809394,-0.933827 7.53125,-2.5 1.074959,-0.977664 1.65625,-2.155057 1.65625,-3.375 0,-0.09948 0.0114,-0.242274 0,-0.375 C 21.06834,9.646353 20.271626,8.4541407 19,7.4999999 c -0.03561,-0.5043676 -0.34375,-4.875 -0.34375,-4.875 -0.01728,-0.2436826 -0.176034,-0.4571979 -0.375,-0.59375 -0.198966,-0.1365521 -0.442122,-0.21875 -0.71875,-0.21875 z m 0,0.53125 h 3.03125 c 0.06724,0 0.12597,0.018412 0.15625,0.03125 l 0.375,5.125 a 0.18751875,0.18751875 0 0 0 0,0.0625 0.18751875,0.18751875 0 0 0 0.03125,0.03125 0.18751875,0.18751875 0 0 0 0.0625,0.0625 c 1.232005,0.8428273 1.959003,2.1272478 2.0625,3.2500001 0.128872,1.395121 -0.699256,2.548585 -2.1875,3.40625 -1.488244,0.857665 -3.625741,1.375 -6.0625,1.375 -2.436754,0 -4.5742796,-0.517335 -6.0625,-1.375 C 4.4492796,13.454835 3.6212244,12.301377 3.75,10.90625 3.8608671,9.7056929 4.7056237,8.3698013 6.09375,7.4999999 A 0.18751875,0.18751875 0 0 0 6.125,7.4687499 c 0.00459,-0.00408 0.068685,-0.04762 0.15625,-0.09375 0.087565,-0.04613 0.2081537,-0.095076 0.34375,-0.15625 0.2711926,-0.122347 0.6009767,-0.2643813 0.96875,-0.40625 0.7355466,-0.2837375 1.5683764,-0.549849 1.96875,-0.625 a 0.18751875,0.18751875 0 0 0 0.03125,0 c 1.209316,-0.3682061 2.35807,-0.8065982 3.25,-1.40625 0.873851,-0.5874967 1.503327,-1.3689786 1.5625,-2.40625 0.02028,-0.00976 0.06108,-0.03125 0.125,-0.03125 z"
      id="path8469"
      style="fill:url(#radialGradient8471);fill-opacity:1" />
   <path
-     d="m 11.999882,12.99994 c -1.682479,0 -2.9722688,-0.844745 -2.9994608,-1.965215 C 9.0002102,11.022185 9,11.010645 9,10.998855 9,10.5934 9.1690522,10.2078 9.4902852,9.8813062 10.033682,9.3294152 10.971891,9 12.000093,9 c 1.028,0 1.9662,0.3294152 2.509597,0.8813042 0.330721,0.3356738 0.500194,0.7346558 0.489864,1.1532668 C 14.971932,12.155054 13.682152,13 11.999882,13 l 0,-6.3e-5 z m 0.05026,-2.746049 c -1.580887,0 -2.4365112,0.210145 -2.4175362,0.974474 0.01833,0.752416 1.0781582,1.353592 2.3673172,1.353592 1.289159,0 2.348981,-0.60139 2.367315,-1.353592 0.01876,-0.76453 -0.736212,-0.974474 -2.317096,-0.974474 l 0,0 z"
+     d="m 11.999882,12.99994 c -1.682479,0 -2.9722688,-0.844745 -2.9994608,-1.965215 C 9.0002102,11.022185 9,11.010645 9,10.998855 9,10.5934 9.1690522,10.2078 9.4902852,9.8813061 10.033682,9.3294151 10.971891,8.9999999 12.000093,8.9999999 c 1.028,0 1.9662,0.3294152 2.509597,0.8813042 0.330721,0.3356739 0.500194,0.7346559 0.489864,1.1532669 C 14.971934,12.155054 13.682152,13 11.999882,13 v -6.3e-5 z m 0.05026,-2.746049 c -1.580887,0 -2.4365112,0.210145 -2.4175362,0.974474 0.01833,0.752416 1.0781582,1.353592 2.3673172,1.353592 1.289159,0 2.348981,-0.60139 2.367315,-1.353592 0.01876,-0.76453 -0.736212,-0.974474 -2.317096,-0.974474 z"
      id="path9156"
-     style="fill:url(#radialGradient8464);fill-opacity:1;fill-rule:nonzero;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient8464);fill-opacity:1;fill-rule:nonzero;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 4.96875,1.75 A 0.250025,0.250025 0 0 0 4.8125,1.875 0.250025,0.250025 0 0 0 4.78125,1.9375 L 4.71875,2.15625 3.875,5.40625 3.75,5.9375 a 0.250025,0.250025 0 0 0 0,0.09375 0.250025,0.250025 0 0 0 0.03125,0.09375 0.250025,0.250025 0 0 0 0.15625,0.125 0.250025,0.250025 0 0 0 0.125,0 l 0.40625,-0.125 6.875,-2.03125 0.03125,0 a 0.250025,0.250025 0 0 0 0.03125,0 0.250025,0.250025 0 0 0 0.03125,0 A 0.250025,0.250025 0 0 0 11.5,4.0625 C 11.960044,3.8087359 12.195214,3.3198993 12.25,2.875 12.278063,2.646761 12.258372,2.4184991 12.1875,2.21875 12.147248,2.1052472 12.061307,1.9975015 11.96875,1.90625 11.876193,1.8149985 11.757431,1.7451773 11.59375,1.75 l -0.03125,0 -6.375,0 -0.15625,0 a 0.250025,0.250025 0 0 0 -0.0625,0 z m 0.5,0.6875 5.90625,0 C 11.35969,2.51528 11.33974,2.5680551 11.3125,2.65625 11.26252,2.8180921 11.166855,2.9496143 11.1875,2.9375 L 4.9375,4.75 5.46875,2.4375 z"
+     d="m 4.96875,1.7499999 a 0.250025,0.250025 0 0 0 -0.15625,0.125 0.250025,0.250025 0 0 0 -0.03125,0.0625 l -0.0625,0.21875 -0.84375,3.25 -0.125,0.53125 a 0.250025,0.250025 0 0 0 0,0.09375 0.250025,0.250025 0 0 0 0.03125,0.09375 0.250025,0.250025 0 0 0 0.15625,0.125 0.250025,0.250025 0 0 0 0.125,0 l 0.40625,-0.125 6.875,-2.03125 H 11.375 a 0.250025,0.250025 0 0 0 0.03125,0 0.250025,0.250025 0 0 0 0.03125,0 0.250025,0.250025 0 0 0 0.0625,-0.03125 c 0.460044,-0.2537641 0.695214,-0.7426007 0.75,-1.1875 0.02806,-0.228239 0.0084,-0.4565009 -0.0625,-0.65625 -0.04025,-0.1135028 -0.126193,-0.2212485 -0.21875,-0.3125 -0.09256,-0.091252 -0.211319,-0.1610727 -0.375,-0.15625 H 11.5625 5.1875 5.03125 a 0.250025,0.250025 0 0 0 -0.0625,0 z m 0.5,0.6875 H 11.375 c -0.01531,0.07778 -0.03526,0.1305551 -0.0625,0.21875 -0.04998,0.1618421 -0.145645,0.2933643 -0.125,0.28125 l -6.25,1.8125 z"
      id="path8473"
-     style="fill:url(#radialGradient8475);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient8475);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
   <g
-     transform="matrix(-0.09781119,0,0,0.1076727,8.1622105,-3.8182514)"
+     transform="matrix(-0.09781119,0,0,0.1076727,8.1622105,-3.8182515)"
      id="g9158">
     <path
        d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
        id="path9160"
        style="fill:#e6e6e6;fill-opacity:1" />
     <path
-       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 l -2e-5,0 z"
+       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
        id="path9162"
        style="fill:url(#radialGradient8498);fill-opacity:1" />
   </g>
   <g
-     transform="matrix(0.09781119,0,0,0.1076727,15.777316,-3.8182514)"
+     transform="matrix(0.09781119,0,0,0.1076727,15.777316,-3.8182515)"
      id="g9190">
     <path
        d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
        id="path9192"
        style="fill:#e6e6e6;fill-opacity:1" />
     <path
-       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 l -2e-5,0 z"
+       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
        id="path9194"
        style="fill:url(#radialGradient8494);fill-opacity:1" />
   </g>

--- a/devices/32/drive-harddisk.svg
+++ b/devices/32/drive-harddisk.svg
@@ -18,34 +18,12 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs3788">
-    <linearGradient
-       id="linearGradient5026">
-      <stop
-         id="stop5028"
-         style="stop-color:#f5f5f5;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5030"
-         style="stop-color:#e7e7e7;stop-opacity:1"
-         offset="0.27751356" />
-      <stop
-         id="stop5032"
-         style="stop-color:#8c8c8c;stop-opacity:1"
-         offset="0.52359134" />
-      <stop
-         id="stop5034"
-         style="stop-color:#dddddd;stop-opacity:1"
-         offset="1" />
-      <stop
-         id="stop5036"
-         style="stop-color:#a8a8a8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
@@ -72,15 +50,6 @@
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="19.635744"
-       y1="23.297283"
-       x2="13.81718"
-       y2="9.7483387"
-       id="linearGradient2461"
-       xlink:href="#linearGradient3484-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6874548,0,0,0.6642584,-0.4986866,0.5245843)" />
     <linearGradient
        x1="29.9375"
        y1="41"
@@ -119,6 +88,104 @@
        xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-0.04484747,0,0,0.02184879,37.61113,30.138555)" />
+    <linearGradient
+       id="linearGradient2215-9">
+      <stop
+         id="stop2223-6"
+         style="stop-color:#7a7a7a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219-1"
+         style="stop-color:#474747;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7056-0">
+      <stop
+         id="stop7064-4"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060-2"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="10"
+       cy="7.2368369"
+       r="16"
+       fx="10"
+       fy="7.2368369"
+       id="radialGradient5024"
+       xlink:href="#linearGradient7056-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4045128,0,0,0.9375,-4.0451283,4.2154656)" />
+    <linearGradient
+       id="linearGradient4472">
+      <stop
+         id="stop4474"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4476"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02116842" />
+      <stop
+         id="stop4478"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4480"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="51.346149"
+       x2="23.99999"
+       y2="53.354122"
+       id="linearGradient3171"
+       xlink:href="#linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.58810697,0,0,0.51394954,8.8319415,0.58279532)" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.5391083"
+       x2="23.99999"
+       y2="42.102226"
+       id="linearGradient3168-6"
+       xlink:href="#linearGradient4075-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26232885,0,0,0.42474288,5.0669059,6.097143)" />
+    <linearGradient
+       id="linearGradient4075-8">
+      <stop
+         id="stop4077-4"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4079-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03367912" />
+      <stop
+         id="stop4081-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4083-4"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient3789"
+       xlink:href="#radialGradient3437"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
     <radialGradient
        cx="113.0654"
        cy="97.587898"
@@ -150,60 +217,10 @@
        r="2.5631001"
        fx="113.667"
        fy="98"
-       id="radialGradient3789"
-       xlink:href="#radialGradient3437"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient
-       cx="113.0654"
-       cy="97.587898"
-       r="2.5631001"
-       fx="113.667"
-       fy="98"
        id="radialGradient3793"
        xlink:href="#radialGradient3437"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient
-       cx="113.0654"
-       cy="97.587898"
-       r="2.5631001"
-       fx="113.667"
-       fy="98"
-       id="radialGradient3797"
-       xlink:href="#radialGradient3437"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient
-       cx="113.0654"
-       cy="97.587898"
-       r="2.5631001"
-       fx="113.667"
-       fy="98"
-       id="radialGradient3801"
-       xlink:href="#radialGradient3437"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient
-       cx="142.62215"
-       cy="191.85428"
-       r="78.728165"
-       fx="142.62215"
-       fy="191.85428"
-       id="radialGradient3820"
-       xlink:href="#linearGradient4035"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.12330157,0,0,-0.08625852,-2.074113,31.247748)" />
-    <radialGradient
-       cx="127.31733"
-       cy="143.82751"
-       r="78.728165"
-       fx="127.31733"
-       fy="143.82751"
-       id="radialGradient3827"
-       xlink:href="#linearGradient5026"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.12647903,-0.01718782,0.00571677,0.0512009,-5.1165779,6.5256499)" />
     <radialGradient
        cx="141.74666"
        cy="206.42612"
@@ -213,29 +230,7 @@
        id="radialGradient3831"
        xlink:href="#linearGradient4035"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.24819429,-0.00314007,0.00183689,0.18067324,-20.017169,-13.633933)" />
-    <linearGradient
-       id="linearGradient4236-0">
-      <stop
-         id="stop4238-4"
-         style="stop-color:#eeeeee;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4240-3"
-         style="stop-color:#eeeeee;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6309">
-      <stop
-         id="stop6311"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6313"
-         style="stop-color:#bbbbbb;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       gradientTransform="matrix(0.24573995,-0.00308859,0.00181873,0.17771138,-19.666102,-13.139935)" />
     <linearGradient
        id="linearGradient4035">
       <stop
@@ -259,69 +254,69 @@
          style="stop-color:#a8a8a8;stop-opacity:1"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       cx="142.62215"
+       cy="191.85428"
+       r="78.728165"
+       fx="142.62215"
+       fy="191.85428"
+       id="radialGradient3820"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12330157,0,0,-0.08625852,-2.074113,31.247748)" />
+    <radialGradient
+       cx="127.31733"
+       cy="143.82751"
+       r="78.728165"
+       fx="127.31733"
+       fy="143.82751"
+       id="radialGradient3827"
+       xlink:href="#linearGradient5026"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12092245,-0.01546848,0.00546562,0.04607914,-4.4169742,6.9719925)" />
     <linearGradient
-       id="linearGradient2215-9">
+       id="linearGradient5026">
       <stop
-         id="stop2223-6"
-         style="stop-color:#7a7a7a;stop-opacity:1"
+         id="stop5028"
+         style="stop-color:#f5f5f5;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2219-1"
-         style="stop-color:#474747;stop-opacity:1"
+         id="stop5030"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.27751356" />
+      <stop
+         id="stop5032"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.52359134" />
+      <stop
+         id="stop5034"
+         style="stop-color:#dddddd;stop-opacity:1"
          offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7056-0">
       <stop
-         id="stop7064-4"
-         style="stop-color:#e6e6e6;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7060-2"
-         style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3484-2">
-      <stop
-         id="stop3486-2"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3488-0"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6310-8">
-      <stop
-         id="stop6312-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6314-6"
-         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop5036"
+         style="stop-color:#a8a8a8;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <radialGradient
-       cx="24"
-       cy="42"
-       r="21"
-       fx="24"
-       fy="42"
-       id="radialGradient4226"
-       xlink:href="#linearGradient6310-8"
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient3797"
+       xlink:href="#radialGradient3437"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71428568,0,1.9866158e-8,0.21428567,-1.1428556,18.500001)" />
-    <linearGradient
-       x1="12.277412"
-       y1="37.205811"
-       x2="12.221823"
-       y2="33.758667"
-       id="linearGradient4235"
-       xlink:href="#linearGradient4236-0"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient3801"
+       xlink:href="#radialGradient3437"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.79304646,0,0,0.53932582,-1.209199,9.1869586)" />
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
     <linearGradient
        x1="7.0625"
        y1="35.28125"
@@ -330,18 +325,47 @@
        id="linearGradient4238"
        xlink:href="#linearGradient6309"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.79304646,0,0,0.53932582,-0.57833673,8.4719091)" />
-    <radialGradient
-       cx="10"
-       cy="7.2368369"
-       r="16"
-       fx="10"
-       fy="7.2368369"
-       id="radialGradient5024"
-       xlink:href="#linearGradient7056-0"
+       gradientTransform="matrix(0.79304646,0,0,0.53932582,-0.57833673,8.4719087)" />
+    <linearGradient
+       id="linearGradient6309">
+      <stop
+         id="stop6311"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6313"
+         style="stop-color:#bbbbbb;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient4235"
+       xlink:href="#linearGradient4236-0"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4045128,0,0,0.9375,-4.0451283,4.2154656)" />
+       gradientTransform="matrix(0.79304646,0,0,0.53932582,-1.209199,9.1869582)" />
+    <linearGradient
+       id="linearGradient4236-0">
+      <stop
+         id="stop4238-4"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240-3"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
   </defs>
+  <path
+     d="M 31.502339,25.502101 26.821023,8.3812814 C 26.688651,7.8937324 25.995252,7.4978971 25.412312,7.4978971 l -18.9855897,0 c -0.8955749,0 -1.4087718,0.1319037 -1.597617,0.8833843 L 0.49812296,25.485432"
+     id="path6345"
+     style="fill:url(#radialGradient5024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99578333;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="M 31.502339,25.502101 26.821023,8.381281 C 26.688651,7.893732 25.995252,7.4978967 25.412312,7.4978967 l -18.9855897,0 c -0.8955749,0 -1.4087718,0.1319037 -1.597617,0.8833843 L 0.49812296,25.485432 z"
+     id="path6345-9"
+     style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <g
      transform="matrix(0.6666596,0,0,0.6259973,-3.3331284,3.7969778)"
      id="g6029"
@@ -362,10 +386,6 @@
        id="path2727"
        style="opacity:0.40206185;fill:url(#radialGradient2475);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
   </g>
-  <path
-     d="m 0.50764664,25.485779 30.98450536,0 -0.619526,4.050331 -29.6765863,0 -0.68839306,-4.050331 z"
-     id="rect6431"
-     style="fill:url(#linearGradient2465);fill-opacity:1;fill-rule:evenodd;stroke:#353537;stroke-width:0.92799884;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;enable-background:new" />
   <rect
      width="31"
      height="1"
@@ -374,15 +394,23 @@
      id="rect6381"
      style="fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
   <path
-     d="M 31.502339,25.502101 26.821023,8.3812814 C 26.688651,7.8937324 25.995252,7.4978971 25.412312,7.4978971 l -18.9855897,0 c -0.8955749,0 -1.4087718,0.1319037 -1.597617,0.8833843 L 0.49812296,25.485432"
-     id="path6345"
-     style="fill:url(#radialGradient5024);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2461);stroke-width:0.99578333;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 0.50764664,25.485779 30.98450536,0 -0.619526,4.050331 -29.6765863,0 -0.68839306,-4.050331 z"
+     id="rect6431"
+     style="fill:url(#linearGradient2465);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
   <path
-     d="M 30.500001,25.507862 1.5000001,25.492138"
-     id="path7046"
-     style="opacity:0.35;fill:none;stroke:#ffffff;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 0.50764664,25.5 30.98450536,0 -0.619526,4 -29.6765863,0 -0.68839306,-4 z"
+     id="rect6431-1"
+     style="opacity:0.5;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 6.4375,8.5 c -0.4014515,0 -0.6181328,0.05924 -0.625,0.0625 -0.00687,0.00326 0.045405,-0.1181812 0,0.0625 L 1.78125,24.5 30.1875,24.5 25.84375,8.65625 a 1.0079748,1.0079748 0 0 1 0,-0.03125 c 0.03231,0.119003 0.01552,0.065777 -0.09375,0 C 25.640731,8.559223 25.474426,8.5 25.40625,8.5 L 6.4375,8.5 z"
+     id="path4094"
+     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient3168-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 2.0163276,28.5 27.9776234,2e-6 c 0.07589,-0.199983 0.332492,-2 0.332492,-2 l -28.6075888,0 c 0,0 0.1861288,1.491284 0.2974734,1.999998 z"
+     id="path4497"
+     style="opacity:0.2;color:#000000;fill:none;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <g
-     transform="matrix(0.06707933,0,0,0.04653275,2.4611632,-0.21307687)"
+     transform="matrix(0.06707933,0,0,0.04653275,2.4611632,-0.2130773)"
      id="g9164"
      style="display:inline;enable-background:new">
     <path
@@ -390,12 +418,12 @@
        id="path9166"
        style="fill:#f0f0f0;fill-opacity:1" />
     <path
-       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 l -2e-5,0 z"
+       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
        id="path9168"
        style="fill:url(#radialGradient3789);fill-opacity:1" />
   </g>
   <g
-     transform="matrix(0.06707933,0,0,0.04653275,21.361163,-0.21307687)"
+     transform="matrix(0.06707933,0,0,0.04653275,21.361163,-0.2130773)"
      id="g9170"
      style="display:inline;enable-background:new">
     <path
@@ -403,26 +431,24 @@
        id="path9172"
        style="fill:#e6e6e6;fill-opacity:1" />
     <path
-       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 l -2e-5,0 z"
+       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
        id="path9174"
        style="fill:url(#radialGradient3793);fill-opacity:1" />
   </g>
   <path
-     d="m 19.375,8.75 c -0.358936,0 -0.68286,0.081146 -0.9375,0.21875 -0.25464,0.1376039 -0.455501,0.3648875 -0.46875,0.65625 -0.03187,0.69869 -0.539442,1.2256 -1.5,1.71875 -0.954397,0.489987 -2.333704,0.898828 -4,1.28125 -0.01076,0.0025 -0.02047,-0.0025 -0.03125,0 -0.620375,0.09722 -1.655533,0.344339 -2.65625,0.625 -0.9999599,0.280449 -1.9191891,0.592616 -2.34375,0.8125 -0.00506,0.0026 -0.02633,-0.0026 -0.03125,0 -2.1117518,1.002416 -3.437887,2.354926 -3.625,3.875 C 3.6100457,19.328175 4.4284433,20.709111 6,21.78125 8.2980815,23.349089 12.017995,24.25 16,24.25 c 3.982015,0 7.732003,-0.900314 10.03125,-2.46875 1.435486,-0.979116 2.21875,-2.201934 2.21875,-3.46875 0,-0.138591 -0.01938,-0.271465 -0.03125,-0.375 -0.163565,-1.32915 -1.197023,-2.547861 -2.875,-3.5 C 25.291448,13.885956 24.875,9.59375 24.875,9.59375 24.847537,9.3032356 24.633529,9.1050939 24.375,8.96875 24.116471,8.8324061 23.795003,8.75 23.4375,8.75 l -4.0625,0 z m 0,0.65625 4.0625,0 c 0.08285,0 0.142892,0.01974 0.1875,0.03125 l 0.46875,5.09375 a 0.25210854,0.25210854 0 0 0 0,0.03125 0.25210854,0.25210854 0 0 0 0.03125,0.0625 0.25210854,0.25210854 0 0 0 0.09375,0.09375 c 1.645695,0.844333 2.618429,2.117087 2.75,3.1875 0.08201,0.665804 -0.138706,1.277578 -0.625,1.84375 -0.486294,0.566172 -1.259179,1.070089 -2.25,1.5 -1.981642,0.859822 -4.836312,1.375 -8.09375,1.375 -3.257433,0 -6.1121403,-0.515178 -8.09375,-1.375 -0.9908049,-0.429911 -1.7636904,-0.933825 -2.25,-1.5 -0.4863096,-0.566175 -0.7069466,-1.177942 -0.625,-1.84375 0.141263,-1.147218 1.2081576,-2.472347 3.0625,-3.34375 a 0.25210854,0.25210854 0 0 0 0.03125,0 C 8.12919,14.5597 8.225867,14.51522 8.34375,14.46875 8.461633,14.42228 8.6307512,14.342583 8.8125,14.28125 9.1759976,14.158583 9.6327098,14.017053 10.125,13.875 11.10958,13.590895 12.205895,13.326594 12.75,13.25 a 0.25210854,0.25210854 0 0 0 0.03125,0 c 1.610744,-0.367803 3.156787,-0.807728 4.34375,-1.40625 1.141118,-0.575405 1.953845,-1.349386 2.0625,-2.40625 0.02948,-0.011025 0.09513,-0.03125 0.1875,-0.03125 z"
-     transform="matrix(0.99011122,0,0,0.98360656,0.15312187,0.2704918)"
+     d="m 19.336526,8.8770488 c -0.355386,0 -0.676107,0.079816 -0.928229,0.2151639 -0.252122,0.1353481 -0.450996,0.3589057 -0.464114,0.6454918 -0.03156,0.6872365 -0.534108,1.2055085 -1.485167,1.6905735 -0.944959,0.481955 -2.310627,0.884093 -3.960445,1.260246 -0.01065,0.0025 -0.02027,-0.0025 -0.03094,0 -0.61424,0.09563 -1.639162,0.338694 -2.6299828,0.614754 -0.9900715,0.275852 -1.9002106,0.582901 -2.3205731,0.799181 -0.00501,0.0026 -0.02607,-0.0026 -0.030941,0 -2.0908692,0.985983 -3.4038905,2.31632 -3.5891532,3.811475 -0.1695113,1.367877 0.6407934,2.726175 2.1968093,3.780738 2.2753563,1.542136 5.9584838,2.428278 9.9011118,2.428278 3.942638,0 7.655543,-0.885554 9.932053,-2.428278 1.421291,-0.963065 2.19681,-2.165837 2.19681,-3.411886 0,-0.136319 -0.01919,-0.267014 -0.03094,-0.368852 -0.16195,-1.307361 -1.185188,-2.506093 -2.846572,-3.442623 C 25.194468,13.928809 24.782138,9.7069668 24.782138,9.7069668 24.754947,9.4212149 24.543055,9.2263215 24.287083,9.0922127 24.03111,8.9581039 23.712821,8.8770488 23.358853,8.8770488 Z m 0,0.6454918 h 4.022327 c 0.08203,0 0.141479,0.019416 0.185646,0.030738 l 0.464115,5.0102464 a 0.24961549,0.24797561 0 0 0 0,0.03074 0.24961549,0.24797561 0 0 0 0.03094,0.06147 0.24961549,0.24797561 0 0 0 0.09282,0.09221 c 1.629421,0.830491 2.592536,2.08238 2.722806,3.135245 0.0812,0.65489 -0.137335,1.256634 -0.61882,1.813525 -0.481485,0.55689 -1.246727,1.052546 -2.22775,1.47541 -1.962046,0.845726 -4.788487,1.352459 -8.013713,1.352459 -3.225221,0 -6.0516983,-0.506733 -8.0137123,-1.352459 C 7.0001817,20.749267 6.2349391,20.253614 5.7534385,19.696721 5.2719379,19.139827 5.0534827,18.538089 5.134619,17.883196 5.274485,16.754785 6.3308293,15.45138 8.1668346,14.594262 a 0.24961549,0.24797561 0 0 0 0.030941,0 c 0.00415,-0.0028 0.09987,-0.0465 0.2165869,-0.09221 0.1167171,-0.04571 0.284163,-0.124099 0.4641145,-0.184426 0.3599031,-0.120656 0.8120989,-0.259866 1.299521,-0.399591 0.974843,-0.279447 2.060317,-0.539415 2.599042,-0.614754 a 0.24961549,0.24797561 0 0 0 0.03094,0 c 1.594815,-0.361773 3.12557,-0.794486 4.300795,-1.383196 1.129834,-0.565973 1.934524,-1.327265 2.042105,-2.3668037 0.02919,-0.010844 0.09419,-0.030738 0.185645,-0.030738 z"
      id="path3829"
-     style="fill:url(#radialGradient3831);fill-opacity:1;display:inline;enable-background:new" />
+     style="display:inline;fill:url(#radialGradient3831);fill-opacity:1;stroke-width:0.98685354;enable-background:new" />
   <path
-     d="m 15.999844,19.999941 c -2.243306,0 -3.963027,-0.835988 -3.999283,-1.944843 C 12.00028,18.042688 12,18.031268 12,18.019598 c 0,-0.401251 0.225403,-0.782854 0.653714,-1.105962 0.724529,-0.546168 1.975473,-0.872168 3.34641,-0.872168 1.370667,0 2.6216,0.326 3.34613,0.872168 0.440961,0.332193 0.666925,0.72704 0.653152,1.14131 C 19.962576,19.163813 18.242868,20 15.999844,20 l 0,-6.2e-5 z m 0.06699,-2.717582 c -2.107848,0 -3.248681,0.207967 -3.22338,0.964372 0.02444,0.744615 1.437543,1.33956 3.156421,1.33956 1.718879,0 3.131975,-0.595156 3.156422,-1.33956 0.02502,-0.756604 -0.981616,-0.964372 -3.089463,-0.964372 l 0,0 z"
+     d="m 15.999844,19.999941 c -2.243306,0 -3.963027,-0.835988 -3.999283,-1.944843 C 12.00028,18.042688 12,18.031268 12,18.019598 c 0,-0.401251 0.225403,-0.782854 0.653714,-1.105962 0.724529,-0.546168 1.975473,-0.872168 3.34641,-0.872168 1.370667,0 2.6216,0.326 3.34613,0.872168 0.440961,0.332193 0.666925,0.72704 0.653152,1.14131 C 19.962576,19.163813 18.242868,20 15.999844,20 v -6.2e-5 z m 0.06699,-2.717582 c -2.107848,0 -3.248681,0.207967 -3.22338,0.964372 0.02444,0.744615 1.437543,1.33956 3.156421,1.33956 1.718879,0 3.131975,-0.595156 3.156422,-1.33956 0.02502,-0.756604 -0.981616,-0.964372 -3.089463,-0.964372 z"
      id="path9156"
-     style="fill:url(#radialGradient3820);fill-opacity:1;fill-rule:nonzero;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3820);fill-opacity:1;fill-rule:nonzero;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 7.25,8.90625 A 0.08979947,0.08979947 0 0 0 7.21875,8.9375 0.08979947,0.08979947 0 0 0 7.1875,8.96875 l -0.09375,0.21875 -1,3.25 -0.1875,0.53125 a 0.08979947,0.08979947 0 0 0 0,0.03125 0.08979947,0.08979947 0 0 0 0,0.03125 0.08979947,0.08979947 0 0 0 0.03125,0.03125 0.08979947,0.08979947 0 0 0 0.03125,0.03125 0.08979947,0.08979947 0 0 0 0.03125,0 0.08979947,0.08979947 0 0 0 0.03125,0 l 0.5,-0.125 8.65625,-2.03125 0.03125,0 a 0.08979947,0.08979947 0 0 0 0.03125,0 c 0.489245,-0.215897 0.781208,-0.687441 0.84375,-1.09375 0.03088,-0.2009175 0.02015,-0.3761222 -0.0625,-0.5625 -0.08817,-0.1989208 -0.319139,-0.3807363 -0.5625,-0.375 l -0.03125,0 -7.96875,0 -0.1875,0 a 0.08979947,0.08979947 0 0 0 -0.03125,0 z m 0.375,0.375 7.84375,0 C 15.4568,9.359007 15.43646,9.5138617 15.375,9.6875 c -0.06146,0.1736383 -0.158384,0.331993 -0.25,0.375 L 6.875,12 7.625,9.28125 z"
-     transform="matrix(0.95606719,0,0,0.89996733,0.47481804,1.0991212)"
+     d="m 7.4063052,9.1144548 a 0.08585433,0.08081659 0 0 0 -0.029877,0.028124 0.08585433,0.08081659 0 0 0 -0.029877,0.028124 L 7.2569197,9.3675706 6.3008525,12.292464 6.1215899,12.770572 a 0.08585433,0.08081659 0 0 0 0,0.02812 0.08585433,0.08081659 0 0 0 0,0.02812 0.08585433,0.08081659 0 0 0 0.029877,0.02812 0.08585433,0.08081659 0 0 0 0.029877,0.02812 0.08585433,0.08081659 0 0 0 0.029877,0 0.08585433,0.08081659 0 0 0 0.029877,0 l 0.478034,-0.112496 8.2759561,-1.828059 h 0.02988 a 0.08585433,0.08081659 0 0 0 0.02988,0 c 0.467745,-0.1943 0.746882,-0.618674 0.806676,-0.9843388 0.02952,-0.1808192 0.01927,-0.3384977 -0.05975,-0.5062317 -0.0843,-0.1790222 -0.305118,-0.3426502 -0.537788,-0.3374877 H 15.234105 7.6154449 7.4361823 a 0.08585433,0.08081659 0 0 0 -0.029877,0 z m 0.3585252,0.3374877 h 7.4991516 c -0.01142,0.069979 -0.03087,0.209343 -0.08963,0.3656118 -0.05876,0.1562688 -0.151426,0.2987827 -0.239017,0.3374877 L 7.04778,11.898729 Z"
      id="path3825"
-     style="fill:url(#radialGradient3827);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3827);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.92759323;marker:none;enable-background:accumulate" />
   <g
-     transform="matrix(-0.09781119,0,0,0.1076727,9.1622105,3.1817486)"
+     transform="matrix(-0.09781119,0,0,0.1076727,9.1622105,3.1817482)"
      id="g9158"
      style="display:inline;enable-background:new">
     <path
@@ -430,12 +456,12 @@
        id="path9160"
        style="fill:#e6e6e6;fill-opacity:1" />
     <path
-       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 l -2e-5,0 z"
+       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
        id="path9162"
        style="fill:url(#radialGradient3797);fill-opacity:1" />
   </g>
   <g
-     transform="matrix(0.09781119,0,0,0.1076727,22.777316,3.1817486)"
+     transform="matrix(0.09781119,0,0,0.1076727,22.777316,3.1817482)"
      id="g9190"
      style="display:inline;enable-background:new">
     <path
@@ -443,23 +469,16 @@
        id="path9192"
        style="fill:#e6e6e6;fill-opacity:1" />
     <path
-       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 l -2e-5,0 z"
+       d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
        id="path9194"
        style="fill:url(#radialGradient3801);fill-opacity:1" />
   </g>
   <path
-     d="M 4.699999,26 19,26 19,29 5.0225565,29 4.699999,26 z"
+     d="M 4.699999,26 H 19 v 3 H 5.0225565 Z"
      id="rect9146"
-     style="fill:url(#linearGradient4238);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.40899992;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4238);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.40899992;marker:none" />
   <path
      d="m 5.0225554,28.999998 c 0,0 -0.2150376,-2.163497 -0.2150376,-2.163497 1.4556584,1.714639 6.7945402,2.163497 10.4750742,2.163497 0,0 -10.2600366,0 -10.2600366,0 z"
      id="path9148"
      style="opacity:0.81142853;fill:url(#linearGradient4235);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-  <rect
-     width="30"
-     height="3"
-     x="1"
-     y="26"
-     id="rect6300-3"
-     style="opacity:0.2;fill:url(#radialGradient4226);fill-opacity:1;stroke:none" />
 </svg>

--- a/devices/48/drive-harddisk.svg
+++ b/devices/48/drive-harddisk.svg
@@ -18,57 +18,48 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs3788">
-    <radialGradient
-       cx="113.0654"
-       cy="97.587898"
-       r="2.5631001"
-       fx="113.667"
-       fy="98"
-       id="radialGradient4241"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop4243"
-         style="stop-color:#eeeeee;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4245"
-         style="stop-color:#cecece;stop-opacity:1"
-         offset="0.16" />
-      <stop
-         id="stop4247"
-         style="stop-color:#888888;stop-opacity:1"
-         offset="0.4675" />
-      <stop
-         id="stop4249"
-         style="stop-color:#555555;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
     <linearGradient
-       id="linearGradient4035">
+       id="linearGradient4231">
       <stop
-         id="stop4037"
-         style="stop-color:#f5f5f5;stop-opacity:1"
+         id="stop4233"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4039"
-         style="stop-color:#e7e7e7;stop-opacity:1"
-         offset="0.47025558" />
+         id="stop4235"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00818416" />
       <stop
-         id="stop4041"
-         style="stop-color:#8c8c8c;stop-opacity:1"
-         offset="0.69348532" />
+         id="stop4237"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
       <stop
-         id="stop4043"
-         style="stop-color:#dddddd;stop-opacity:1"
-         offset="0.83542866" />
+         id="stop4239"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4170">
       <stop
-         id="stop4045"
-         style="stop-color:#a8a8a8;stop-opacity:1"
+         id="stop4172"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4174"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02783963" />
+      <stop
+         id="stop4176"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99811679" />
+      <stop
+         id="stop4178"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -109,40 +100,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient7609">
-      <stop
-         id="stop7611"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7677"
-         style="stop-color:#e7e7e7;stop-opacity:1"
-         offset="0.47025558" />
-      <stop
-         id="stop7613"
-         style="stop-color:#8c8c8c;stop-opacity:1"
-         offset="0.67183787" />
-      <stop
-         id="stop7617"
-         style="stop-color:#dddddd;stop-opacity:1"
-         offset="0.83542866" />
-      <stop
-         id="stop7615"
-         style="stop-color:#a8a8a8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4236">
-      <stop
-         id="stop4238"
-         style="stop-color:#eeeeee;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4240"
-         style="stop-color:#eeeeee;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient7056">
       <stop
          id="stop7064"
@@ -153,86 +110,6 @@
          style="stop-color:#c8c8c8;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3484">
-      <stop
-         id="stop3486"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3488"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6310-8">
-      <stop
-         id="stop6312-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6314-6"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="24"
-       cy="42"
-       r="21"
-       fx="24"
-       fy="42"
-       id="radialGradient2896"
-       xlink:href="#linearGradient6310-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99999995,-1.0652117e-8,2.7812622e-8,0.35714279,1.0762331e-6,24.500003)" />
-    <radialGradient
-       cx="127.31733"
-       cy="143.82751"
-       r="78.728165"
-       fx="127.31733"
-       fy="143.82751"
-       id="radialGradient2902"
-       xlink:href="#linearGradient4035"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.19054222,-0.02505584,0.00619351,0.10073457,-7.4371744,4.4286866)" />
-    <linearGradient
-       x1="12.277412"
-       y1="37.205811"
-       x2="12.221823"
-       y2="33.758667"
-       id="linearGradient2905"
-       xlink:href="#linearGradient4236"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0212766,0,0,0.89887639,-0.02517836,8.978263)" />
-    <linearGradient
-       x1="7.0625"
-       y1="35.28125"
-       x2="24.6875"
-       y2="35.28125"
-       id="linearGradient2908"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0212766,0,0,0.89887639,0.78723995,7.7865138)" />
-    <radialGradient
-       cx="142.62215"
-       cy="191.85428"
-       r="78.728165"
-       fx="142.62215"
-       fy="191.85428"
-       id="radialGradient2920"
-       xlink:href="#linearGradient7609"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.18495239,0,0,-0.13074306,-3.1111723,45.048436)" />
-    <radialGradient
-       cx="141.74666"
-       cy="206.42612"
-       r="78.728165"
-       fx="141.74666"
-       fy="206.42612"
-       id="radialGradient2923"
-       xlink:href="#linearGradient4035"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35160878,-0.0050244,0.00260227,0.28909275,-27.02434,-25.217538)" />
     <radialGradient
        cx="11.734284"
        cy="8.4900017"
@@ -243,15 +120,6 @@
        xlink:href="#linearGradient7056"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.3767077,0.69719425,-0.46810846,0.92434578,-0.04915651,-2.9386274)" />
-    <linearGradient
-       x1="17.813944"
-       y1="29.796696"
-       x2="18.072828"
-       y2="10.000001"
-       id="linearGradient2929"
-       xlink:href="#linearGradient3484"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-1.0001465)" />
     <linearGradient
        x1="29.9375"
        y1="41"
@@ -290,36 +158,90 @@
        xlink:href="#linearGradient5048"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.07635654,0,0,0.02058824,-3.5974283,32.451372)" />
-    <radialGradient
-       cx="113.0654"
-       cy="97.587898"
-       r="2.5631001"
-       fx="113.667"
-       fy="98"
-       id="radialGradient2947"
-       xlink:href="#radialGradient4241"
+    <linearGradient
+       x1="34.947395"
+       y1="50.909214"
+       x2="34.947395"
+       y2="53.83601"
+       id="linearGradient3308"
+       xlink:href="#linearGradient4231"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.32948872,0,0,0.34974643,6.0549235,0.49382567)" />
-    <radialGradient
-       cx="113.0654"
-       cy="97.587898"
-       r="2.5631001"
-       fx="113.667"
-       fy="98"
-       id="radialGradient2953"
-       xlink:href="#radialGradient4241"
+       gradientTransform="matrix(0.84051728,0,0,1.0278991,14.415778,-14.334416)" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.2531767"
+       x2="23.99999"
+       y2="42.941334"
+       id="linearGradient3311-4"
+       xlink:href="#linearGradient4170"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.22333209,0.03439303,-0.02300572,0.14938839,14.791441,-7.6318403)" />
+       gradientTransform="matrix(0.26232885,0,0,0.65751536,6.9297476,6.8105801)" />
     <radialGradient
-       cx="113.0654"
-       cy="97.587898"
-       r="2.5631001"
-       fx="113.667"
-       fy="98"
-       id="radialGradient2959"
-       xlink:href="#radialGradient4241"
+       cx="141.74666"
+       cy="206.42612"
+       r="78.728165"
+       fx="141.74666"
+       fy="206.42612"
+       id="radialGradient2923"
+       xlink:href="#linearGradient4035"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.22282769,-0.03752228,0.02509892,0.149051,-18.145918,0.53228044)" />
+       gradientTransform="matrix(0.35160878,-0.0050244,0.00260227,0.28909275,-27.02434,-25.217538)" />
+    <linearGradient
+       id="linearGradient4035">
+      <stop
+         id="stop4037"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4039"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop4041"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.69348532" />
+      <stop
+         id="stop4043"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop4045"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="142.62215"
+       cy="191.85428"
+       r="78.728165"
+       fx="142.62215"
+       fy="191.85428"
+       id="radialGradient2920"
+       xlink:href="#linearGradient7609"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18495239,0,0,-0.13074306,-3.1111723,45.048436)" />
+    <linearGradient
+       id="linearGradient7609">
+      <stop
+         id="stop7611"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7677"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop7613"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.67183787" />
+      <stop
+         id="stop7617"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop7615"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <radialGradient
        cx="113.0654"
        cy="97.587898"
@@ -329,8 +251,106 @@
        id="radialGradient2965"
        xlink:href="#radialGradient4241"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.32948872,0,0,0.34974643,41.963041,0.49382567)" />
+       gradientTransform="matrix(-0.32948872,0,0,0.34974643,41.963041,0.4938254)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient4241"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop4243"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4245"
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="0.16" />
+      <stop
+         id="stop4247"
+         style="stop-color:#888888;stop-opacity:1"
+         offset="0.4675" />
+      <stop
+         id="stop4249"
+         style="stop-color:#555555;stop-opacity:1"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2959"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22282769,-0.03752228,0.02509892,0.149051,-18.145918,0.5322802)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2953"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22333209,0.03439303,-0.02300572,0.14938839,14.791441,-7.631841)" />
+    <linearGradient
+       x1="7.0625"
+       y1="35.28125"
+       x2="24.6875"
+       y2="35.28125"
+       id="linearGradient2908"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0212766,0,0,0.89887639,0.78723995,7.7865135)" />
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient2905"
+       xlink:href="#linearGradient4236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0212766,0,0,0.89887639,-0.02517836,8.9782627)" />
+    <linearGradient
+       id="linearGradient4236">
+      <stop
+         id="stop4238"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="127.31733"
+       cy="143.82751"
+       r="78.728165"
+       fx="127.31733"
+       fy="143.82751"
+       id="radialGradient2902"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.19054222,-0.02505584,0.00619351,0.10073457,-7.4371744,4.4286863)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2947"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32948872,0,0,0.34974643,6.0549235,0.4938254)" />
   </defs>
+  <path
+     d="M 46.55,36.601962 39.740367,10.827625 c -0.192553,-0.733973 -1.2012,-1.329879 -2.049166,-1.329879 l -27.617218,0 c -1.30274,0 -2.049257,0.198573 -2.323959,1.329879 L 1.45,36.576866 z"
+     id="path6345"
+     style="fill:url(#radialGradient2927);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99578345;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <rect
      width="36.869301"
      height="5"
@@ -347,38 +367,40 @@
      id="path2727"
      style="opacity:0.3;fill:url(#radialGradient2936);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
   <path
+     d="M 46.55,36.5 39.740367,10.824766 c -0.192553,-0.731151 -1.2012,-1.3247661 -2.049166,-1.3247661 l -27.617218,0 c -1.30274,0 -2.049257,0.1978095 -2.323959,1.3247661 L 1.45,36.475001 z"
+     id="path6345-1"
+     style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.0625,10.46875 c -0.6058109,0 -0.9673014,0.09427 -1.09375,0.15625 -0.1264486,0.06198 -0.1572339,0.02421 -0.25,0.40625 l -6.03125,24.5625 42.625,0.03125 -6.5,-24.5625 c -0.0041,-0.01553 -0.138916,-0.199012 -0.375,-0.34375 -0.236084,-0.144738 -0.549495,-0.25 -0.75,-0.25 l -27.625,0 z"
+     id="path4129"
+     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient3311-4);stroke-width:1.00312006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     transform="matrix(1,0,0,0.99378882,0,0.09627324)" />
+  <path
      d="m 1.4638537,36.464001 45.0720003,0 -0.901202,6.072 -43.1694186,0 -1.0013797,-6.072 z"
      id="rect6431"
-     style="fill:url(#linearGradient2933);fill-opacity:1;fill-rule:evenodd;stroke:#353537;stroke-width:0.9279989;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;enable-background:new" />
-  <rect
-     width="45"
-     height="1"
-     x="1.5"
-     y="35.999855"
-     id="rect6381"
-     style="fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
+     style="fill:url(#linearGradient2933);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
   <path
-     d="M 46.55,36.601962 39.740367,10.827625 c -0.192553,-0.733973 -1.2012,-1.329879 -2.049166,-1.329879 l -27.617218,0 c -1.30274,0 -2.049257,0.198573 -2.323959,1.329879 L 1.45,36.576866"
-     id="path6345"
-     style="fill:url(#radialGradient2927);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2929);stroke-width:0.99578345;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 1.4638537,36.5 45.0720003,0 -0.901202,6 -43.1694185,0 -1.0013798,-6 z"
+     id="rect6431-3"
+     style="opacity:0.5;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
-     d="M 45.500002,36.499854 2.5000001,36.475803"
-     id="path7046"
-     style="opacity:0.4;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 3.3117397,41.499995 41.4657843,3e-6 c 0.108461,-0.399966 0.576759,-4 0.576759,-4 H 2.654475 c 0,0 0.4981314,2.982569 0.6572647,3.999997 z"
+     id="path4497"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;stroke:url(#linearGradient3308);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 40.971397,25.373814 c -0.21768,-1.997975 -1.676509,-3.903122 -4.1004,-5.406472 C 36.822237,19.38948 36.200942,11.997153 36.200942,11.997153 36.153322,11.428888 35.429193,11 34.515926,11 l -5.731268,0 c -0.919834,0 -1.630882,0.434524 -1.654073,1.010704 -0.10517,2.603206 -3.312025,3.962376 -8.095624,5.198802 -1.67612,0.29034 -6.046005,1.655156 -7.048964,2.254183 -2.9524377,1.573605 -4.7132263,3.67147 -4.9572037,5.910125 -0.2219397,2.036069 0.8448261,4.073551 3.0038657,5.737168 C 13.192718,33.546027 18.414005,35 23.999896,35 29.585796,35 34.807072,33.546027 37.967531,31.110982 39.939434,29.591833 41,27.760327 41,25.903156 c 0,-0.17636 -0.01031,-0.352992 -0.02866,-0.529342 l 5.7e-5,0 z M 23.999896,33.99015 c -9.303498,0 -16.427483,-4.080325 -15.9120785,-8.810179 0.222328,-2.039173 1.8543618,-4.216036 4.5570215,-5.650539 0.506122,-0.381482 5.077073,-1.865367 6.716838,-2.126086 4.544655,-1.17209 8.700731,-2.693216 8.831026,-5.89884 0.0057,-0.153501 0.267557,-0.275107 0.591955,-0.275107 l 5.730502,0 c 0.33174,0 0.611698,0.127531 0.62484,0.284984 l 0.695941,8.281974 c 2.408816,1.395843 3.86841,3.479309 4.075655,5.383614 0.515781,4.729854 -6.608191,8.810179 -15.9117,8.810179 l 0,0 z"
+     d="m 40.971397,25.373814 c -0.21768,-1.997975 -1.676509,-3.903122 -4.1004,-5.406472 C 36.822237,19.38948 36.200942,11.997153 36.200942,11.997153 36.153322,11.428888 35.429193,11 34.515926,11 h -5.731268 c -0.919834,0 -1.630882,0.434524 -1.654073,1.010704 -0.10517,2.603206 -3.312025,3.962376 -8.095624,5.198802 -1.67612,0.29034 -6.046005,1.655156 -7.048964,2.254183 -2.9524377,1.573605 -4.7132263,3.67147 -4.9572037,5.910125 -0.2219397,2.036069 0.8448261,4.073551 3.0038657,5.737168 C 13.192718,33.546027 18.414005,35 23.999896,35 29.585796,35 34.807072,33.546027 37.967531,31.110982 39.939434,29.591833 41,27.760327 41,25.903156 41,25.726796 40.98969,25.550164 40.97134,25.373814 Z M 23.999896,33.99015 c -9.303498,0 -16.427483,-4.080325 -15.9120785,-8.810179 0.222328,-2.039173 1.8543618,-4.216036 4.5570215,-5.650539 0.506122,-0.381482 5.077073,-1.865367 6.716838,-2.126086 4.544655,-1.17209 8.700731,-2.693216 8.831026,-5.89884 0.0057,-0.153501 0.267557,-0.275107 0.591955,-0.275107 h 5.730502 c 0.33174,0 0.611698,0.127531 0.62484,0.284984 l 0.695941,8.281974 c 2.408816,1.395843 3.86841,3.479309 4.075655,5.383614 0.515781,4.729854 -6.608191,8.810179 -15.9117,8.810179 z"
      id="path9001"
      style="fill:url(#radialGradient2923);fill-opacity:1" />
   <path
-     d="M 23.999769,28 C 20.634805,28 18.055218,26.732885 18.000846,25.052175 18.000418,25.034 18,25.016137 18,24.998273 18,24.390098 18.338098,23.811689 18.980563,23.321951 20.067367,22.494127 21.943772,22 24.000185,22 c 2.055997,0 3.932391,0.494127 5.019195,1.321951 0.661441,0.503521 1.000395,1.101987 0.979728,1.729907 -0.05524,1.68071 -2.634804,2.948137 -5.999339,2.948137 l 0,3e-6 z m 0,-5.059679 c -3.161777,0 -4.77259,1.255831 -4.734647,2.402312 0.03667,1.128624 2.156333,2.030394 4.734647,2.030394 2.578314,0 4.697955,-0.902088 4.734637,-2.030394 0.03749,-1.146798 -1.572872,-2.402312 -4.734637,-2.402312 l 0,0 z"
+     d="M 23.999769,28 C 20.634805,28 18.055218,26.732885 18.000846,25.052175 18.000418,25.034005 18,25.016135 18,24.998275 c 0,-0.608175 0.338098,-1.186584 0.980563,-1.676322 1.086804,-0.827824 2.963209,-1.321951 5.019622,-1.321951 2.055997,0 3.932391,0.494127 5.019195,1.321951 0.661441,0.503521 1.000395,1.101987 0.979728,1.729907 -0.05524,1.68071 -2.634804,2.948137 -5.999339,2.948137 z m 0,-5.059679 c -3.161777,0 -4.77259,1.255831 -4.734647,2.402312 0.03667,1.128624 2.156333,2.030394 4.734647,2.030394 2.578314,0 4.697955,-0.902088 4.734637,-2.030394 0.03749,-1.146798 -1.572872,-2.402312 -4.734637,-2.402312 z"
      id="path9003"
-     style="fill:url(#radialGradient2920);fill-opacity:1;fill-rule:nonzero;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2920);fill-opacity:1;fill-rule:nonzero;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 6.0158229,34.619284 C 5.9743063,35.214553 5.3525618,35.7 4.6276859,35.7 c -0.7245458,0 -1.2731445,-0.485447 -1.2247097,-1.080716 0.048106,-0.592121 0.6695217,-1.070225 1.3871481,-1.070225 0.7179564,2.81e-4 1.2665551,0.478104 1.2256986,1.070225 z"
+     d="M 6.0158229,34.619284 C 5.9743059,35.214553 5.3525618,35.7 4.6276859,35.7 c -0.7245458,0 -1.2731445,-0.485447 -1.2247097,-1.080716 0.048106,-0.592121 0.6695217,-1.070225 1.3871481,-1.070225 0.7179564,2.81e-4 1.2665551,0.478104 1.2256986,1.070225 z"
      id="path9007"
      style="fill:#e1e1e1;fill-opacity:1" />
   <path
-     d="m 5.5469595,34.200637 c 0.066228,0.07554 0.1420102,0.196558 0.1420102,0.357441 0,0.01155 -6.602e-4,0.02308 -0.00132,0.03533 -0.028667,0.410252 -0.5140028,0.756851 -1.0596361,0.756851 -0.3107079,0 -0.5947269,-0.113668 -0.7594717,-0.304629 -0.070839,-0.08149 -0.1515649,-0.216493 -0.1370672,-0.396263 0.033278,-0.406755 0.5179556,-0.750556 1.0589773,-0.750556 0.3084014,2.8e-4 0.5914315,0.112968 0.7565052,0.301831 l 2.6e-6,0 z"
+     d="m 5.5469595,34.200637 c 0.066228,0.07554 0.1420102,0.196558 0.1420102,0.357441 0,0.01155 -6.602e-4,0.02308 -0.00132,0.03533 -0.028667,0.410252 -0.5140028,0.756851 -1.0596361,0.756851 -0.3107079,0 -0.5947269,-0.113668 -0.7594717,-0.304629 -0.070839,-0.08149 -0.1515649,-0.216493 -0.1370672,-0.396263 0.033278,-0.406755 0.5179556,-0.750556 1.0589773,-0.750556 0.3084014,2.8e-4 0.5914315,0.112968 0.7565052,0.301831 h 2.6e-6 z"
      id="path9009"
      style="fill:url(#radialGradient2965);fill-opacity:1" />
   <path
@@ -398,30 +420,27 @@
      id="path9027"
      style="fill:url(#radialGradient2953);fill-opacity:1" />
   <path
-     d="m 7.5000002,36.999999 18.5000088,0 0,5.000001 -17.9999999,0 -0.5000089,-5.000001 z"
+     d="M 7.5000002,36.999999 H 26.000009 V 42 H 8.0000091 Z"
      id="rect8993"
-     style="fill:url(#linearGradient2908);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.40899992;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2908);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.40899992;marker:none" />
   <path
      d="m 8.0000077,41.999996 c 0,0 -0.4000075,-3.605827 -0.4000075,-3.605827 1.8745811,2.857731 8.8730188,3.605827 13.6127708,3.605827 0,0 -13.2127633,0 -13.2127633,0 z"
      id="path8995"
      style="opacity:0.81142853;fill:url(#linearGradient2905);fill-opacity:1;fill-rule:evenodd;stroke:none" />
   <path
-     d="M 10.906579,11 10.803305,11.381009 9.2615551,17.051898 9,18 9.7639975,17.796205 22.758771,14.2519 l 0.04127,-0.01771 0.03442,-0.01771 c 0.688135,-0.354354 1.05583,-1.07045 1.142548,-1.727849 0.0434,-0.328702 0.03039,-0.650575 -0.08254,-0.948099 -0.106642,-0.280876 -0.384276,-0.530777 -0.674516,-0.522787 l 0,-0.01771 -0.04821,0 -11.955461,0 -0.30973,0 3.3e-5,10e-7 z m 0.439836,0.350376 11.976544,0 c 0.0056,0.04787 0.01906,0.07443 0.0067,0.165 -0.03757,0.285021 -0.199195,1.304699 -0.605242,1.527141 l -12.596058,3.437485 1.217592,-5.129624 3.91e-4,0 z"
+     d="M 10.906579,11 10.803305,11.381009 9.2615551,17.051898 9,18 9.7639975,17.796205 22.758771,14.2519 l 0.04127,-0.01771 0.03442,-0.01771 c 0.688135,-0.354354 1.05583,-1.07045 1.142548,-1.727849 0.0434,-0.328702 0.03039,-0.650575 -0.08254,-0.948099 -0.106642,-0.280876 -0.384276,-0.530777 -0.674516,-0.522787 v -0.01771 h -0.04821 -11.955461 -0.30973 l 3.3e-5,10e-7 z m 0.439836,0.350376 h 11.976544 c 0.0056,0.04787 0.01906,0.07443 0.0067,0.165 -0.03757,0.285021 -0.199195,1.304699 -0.605242,1.527141 l -12.596058,3.437485 1.217592,-5.129624 h 3.91e-4 z"
      id="path9039"
-     style="fill:url(#radialGradient2902);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2902);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 42.002142,34.619284 C 42.043659,35.214553 42.665403,35.7 43.390279,35.7 c 0.724546,0 1.273145,-0.485447 1.22471,-1.080716 -0.04811,-0.592121 -0.669522,-1.070225 -1.387148,-1.070225 -0.717957,2.81e-4 -1.266555,0.478104 -1.225699,1.070225 z"
+     d="M 42.002142,34.619284 C 42.043662,35.214553 42.665403,35.7 43.390279,35.7 c 0.724546,0 1.273145,-0.485447 1.22471,-1.080716 -0.04811,-0.592121 -0.669522,-1.070225 -1.387148,-1.070225 -0.717957,2.81e-4 -1.266555,0.478104 -1.225699,1.070225 z"
      id="path9091"
      style="fill:#e1e1e1;fill-opacity:1" />
   <path
-     d="m 42.471006,34.200637 c -0.06623,0.07554 -0.142011,0.196558 -0.142011,0.357441 0,0.01155 6.6e-4,0.02308 0.0013,0.03533 0.02867,0.410252 0.514002,0.756851 1.059636,0.756851 0.310708,0 0.594727,-0.113668 0.759471,-0.304629 0.07084,-0.08149 0.151565,-0.216493 0.137068,-0.396263 -0.03328,-0.406755 -0.517956,-0.750556 -1.058978,-0.750556 -0.308401,2.8e-4 -0.591431,0.112968 -0.756505,0.301831 l -2e-6,0 z"
+     d="m 42.471006,34.200637 c -0.06623,0.07554 -0.142011,0.196558 -0.142011,0.357441 0,0.01155 6.6e-4,0.02308 0.0013,0.03533 0.02867,0.410252 0.514002,0.756851 1.059636,0.756851 0.310708,0 0.594727,-0.113668 0.759471,-0.304629 0.07084,-0.08149 0.151565,-0.216493 0.137068,-0.396263 -0.03328,-0.406755 -0.517956,-0.750556 -1.058978,-0.750556 -0.308401,2.8e-4 -0.591431,0.112968 -0.756505,0.301831 h -2e-6 z"
      id="path9093"
      style="fill:url(#radialGradient2947);fill-opacity:1" />
-  <rect
-     width="42"
-     height="5"
-     x="3"
-     y="37"
-     id="rect6300-3"
-     style="opacity:0.3;fill:url(#radialGradient2896);fill-opacity:1;stroke:none" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.05"
+     d="m 7.1101004,38.038018 0.2591714,2.913255"
+     id="path1032" />
 </svg>


### PR DESCRIPTION
The harddisk icons were drawn many eons ago and don't obey our rules about highlights etc. This takes the detail stuff and plops it on top of `drive-removable-media` which does follow the rules