### PR TITLE
Enable icons cache

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -3,8 +3,8 @@ set -e
 
 write_cache()
 {
-if [ -x /usr/bin/gtk-update-icon-cache-3.0 ]; then
-    if ! gtk-update-icon-cache-3.0 --force --quiet /usr/share/icons/elementary; then
+if [ -x /usr/bin/gtk-update-icon-cache ]; then
+    if ! gtk-update-icon-cache --force --quiet /usr/share/icons/elementary; then
         echo "WARNING: icon cache generation failed"
     fi
 fi

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,1 +1,22 @@
+#!/bin/sh
+set -e
+
+write_cache()
+{
+if [ -x /usr/bin/gtk-update-icon-cache-3.0 ]; then
+    if ! gtk-update-icon-cache-3.0 --force --quiet /usr/share/icons/gnome; then
+        echo "WARNING: icon cache generation failed"
+    fi
+fi
+}
+
+if [ "$1" = "triggered" ]; then
+    write_cache
+    exit 0
+fi
+
+write_cache
+
 update-alternatives --install /usr/share/icons/default/index.theme x-cursor-theme /usr/share/icons/elementary/cursor.theme 12
+
+#DEBHELPER#

--- a/debian/postinst
+++ b/debian/postinst
@@ -4,7 +4,7 @@ set -e
 write_cache()
 {
 if [ -x /usr/bin/gtk-update-icon-cache-3.0 ]; then
-    if ! gtk-update-icon-cache-3.0 --force --quiet /usr/share/icons/gnome; then
+    if ! gtk-update-icon-cache-3.0 --force --quiet /usr/share/icons/elementary; then
         echo "WARNING: icon cache generation failed"
     fi
 fi

--- a/debian/preinst
+++ b/debian/preinst
@@ -14,3 +14,5 @@ if dpkg --compare-versions "$2" lt 4.3.0; then
    rm -rf /usr/share/icons/elementary/places@2x
    rm -rf /usr/share/icons/elementary/status@2x
 fi
+
+#DEBHELPER#

--- a/debian/prerm
+++ b/debian/prerm
@@ -4,4 +4,6 @@ if [ "$1" = "remove" ] || [ "$1" = "deconfigure" ] ; then
     update-alternatives --remove x-cursor-theme /usr/share/icons/elementary/cursor.theme
 fi
 
+rm -f /usr/share/icons/elementary/icon-theme.cache
+
 #DEBHELPER#

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,3 +1,5 @@
 #!/bin/sh
 
 update-alternatives --remove x-cursor-theme /usr/share/icons/elementary/cursor.theme
+
+#DEBHELPER#

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,5 +1,7 @@
 #!/bin/sh
 
-update-alternatives --remove x-cursor-theme /usr/share/icons/elementary/cursor.theme
+if [ "$1" = "remove" ] || [ "$1" = "deconfigure" ] ; then
+    update-alternatives --remove x-cursor-theme /usr/share/icons/elementary/cursor.theme
+fi
 
 #DEBHELPER#

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+update-alternatives --remove x-cursor-theme /usr/share/icons/elementary/cursor.theme

--- a/debian/triggers
+++ b/debian/triggers
@@ -1,0 +1,1 @@
+interest-noawait /usr/share/icons/elementary


### PR DESCRIPTION
Fixes #433

The code is largely copy-pasted from `gnome-icon-theme` packaging

Includes PR #434 because otherwise they would conflict. And apparently github cannot handle dependent PRs, so the displayed diff includes changes from both

Supersedes #435 where I've accidentally messed up git history