### PR TITLE
Convert go-* action icons to the new colorscheme

### DIFF
--- a/actions/48/go-bottom.svg
+++ b/actions/48/go-bottom.svg
@@ -6,100 +6,110 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="48"
-   height="48"
-   id="svg2510">
+   width="48px"
+   height="48px"
+   id="svg2510"
+   version="1.1">
   <defs
      id="defs2512">
     <linearGradient
-       x1="26"
-       y1="-9.193471"
-       x2="26"
        y2="0.079183199"
-       id="linearGradient3174"
-       xlink:href="#linearGradient5113"
+       x2="26"
+       y1="-9.193471"
+       x1="26"
+       gradientTransform="translate(-1.9601962,48.006354)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-1.960196,48.00635)" />
+       id="linearGradient3174"
+       xlink:href="#linearGradient5113" />
     <linearGradient
        id="linearGradient3168">
       <stop
          id="stop2551"
-         style="stop-color:#a7cc5c;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#a7cc5c;stop-opacity:1;" />
       <stop
          id="stop3173"
-         style="stop-color:#789e2d;stop-opacity:1"
-         offset="1" />
+         offset="1"
+         style="stop-color:#789e2d;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="42.506352"
+       x2="40.039804"
+       y1="42.506352"
        x1="8.0398045"
-       y1="42.506351"
-       x2="40.039803"
-       y2="42.506351"
        id="linearGradient3175"
        xlink:href="#linearGradient3168"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="translate(-2.5e-7,3.6875e-6)" />
     <linearGradient
        id="linearGradient5113">
       <stop
          id="stop5115"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:white;stop-opacity:1;" />
       <stop
          id="stop5117"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
+       xlink:href="#linearGradient5113"
+       id="linearGradient2606"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.004639,1,0,-1.9921112,51.044064)"
        x1="43.129921"
        y1="15.195395"
        x2="7.9313831"
-       y2="34.731434"
-       id="linearGradient2606"
-       xlink:href="#linearGradient5113"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.004639,1,0,-1.992111,51.04406)" />
+       y2="34.731434" />
     <linearGradient
        id="linearGradient2264">
       <stop
-         id="stop2266"
-         style="stop-color:#d7e866;stop-opacity:1"
+         id="stop3244-gr"
+         style="stop-color:#cdf87e;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2268"
-         style="stop-color:#8cab2a;stop-opacity:1"
+         id="stop3246-gr"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-gr"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-gr"
+         style="stop-color:#1d7e0d;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="24.004463"
-       y1="7.1938653"
-       x2="24.004463"
+       gradientUnits="userSpaceOnUse"
        y2="37.193859"
+       x2="24.004463"
+       y1="5.5667467"
+       x1="24.004463"
        id="linearGradient3172"
        xlink:href="#linearGradient2264"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="translate(-2.5e-7,3.6875e-6)" />
     <linearGradient
        id="linearGradient5105">
       <stop
          id="stop5107"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:black;stop-opacity:1;" />
       <stop
          id="stop5109"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         offset="1"
+         style="stop-color:black;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
+       xlink:href="#linearGradient5105"
+       id="radialGradient2604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.48062,0,0,0.68217177,-3.9069762,27.517428)"
        cx="11.25"
        cy="19.03125"
-       r="8.0625"
        fx="11.25"
        fy="19.03125"
-       id="radialGradient2604"
-       xlink:href="#linearGradient5105"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.282946,0,13.64644)" />
+       r="8.0625" />
   </defs>
   <metadata
      id="metadata2515">
@@ -112,39 +122,41 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <g
-       transform="translate(-2.5e-7,3.6875e-6)"
-       id="g2595"
-       style="display:inline">
-      <path
-         d="m 19.3125,19.03125 a 8.0625,2.28125 0 1 1 -16.125,0 8.0625,2.28125 0 1 1 16.125,0 z"
-         transform="matrix(2.48062,0,0,2.410961,-3.906976,-5.38361)"
-         id="path4346"
-         style="opacity:0.16292138;fill:url(#radialGradient2604);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="M 7.5398059,20.590592 24.04583,39.506349 40.469121,20.590592 l -7.869835,0 0,-15.0842271 -17.055132,0 0,15.0842271 -8.0043481,0 z"
-         id="path4348"
-         style="fill:url(#linearGradient3172);fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="m 9.6808629,21.573053 14.3862731,16.516639 14.199301,-16.516639 -6.738369,0 0,-15.0666835 -14.978334,0 0,15.0666835 -6.8688711,0 z"
-         id="path4360"
-         style="opacity:0.35400008;fill:none;stroke:url(#linearGradient2606);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <rect
-         width="33.000008"
-         height="4.0000119"
-         x="7.5398059"
-         y="40.506359"
-         id="rect2600"
-         style="fill:#97ae43;fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <rect
-         width="31"
-         height="2.0000019"
-         x="8.5398045"
-         y="41.506351"
-         id="rect2602"
-         style="opacity:0.35400008;fill:url(#linearGradient3175);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3174);stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    </g>
-  </g>
+  <path
+     d="m 43.999998,40.499995 a 19.999999,5.5000048 0 1 1 -39.9999979,0 19.999999,5.5000048 0 1 1 39.9999979,0 z"
+     id="path4346"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.16292138;fill:url(#radialGradient2604);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.44554257;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <path
+     id="path4348"
+     d="M 7.5398056,20.590596 24.04583,39.506353 40.469121,20.590596 H 32.599286 V 5.5063686 H 15.544154 V 20.590596 Z"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3172);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <path
+     id="path4360"
+     d="M 9.6808627,21.573057 24.067136,38.089696 38.266437,21.573057 H 31.528068 V 6.5063732 H 16.549734 V 21.573057 Z"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2606);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;fill:#1d7e0d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     id="rect2600"
+     width="33.000008"
+     height="4.0000119"
+     x="7.5398054"
+     y="40.506363" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:url(#linearGradient3175);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3174);stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     id="rect2602"
+     width="31"
+     height="2.0000019"
+     x="8.5398045"
+     y="41.506355" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="M 7.5398056,20.590596 24.04583,39.506353 40.469121,20.590596 H 32.599286 V 5.5063686 H 15.544154 V 20.590596 Z"
+     id="path849" />
+  <rect
+     y="40.506363"
+     x="7.5398054"
+     height="4.0000119"
+     width="33.000008"
+     id="rect851"
+     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;opacity:0.5" />
 </svg>

--- a/actions/48/go-down.svg
+++ b/actions/48/go-down.svg
@@ -6,73 +6,81 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="48"
-   height="48"
-   id="svg2495">
+   width="48px"
+   height="48px"
+   id="svg2495"
+   version="1.1">
   <defs
      id="defs2497">
     <linearGradient
        id="linearGradient5105-262-943-861">
       <stop
+         offset="0"
          id="stop2487"
-         style="stop-color:#0d0d0d;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#0d0d0d;stop-opacity:1;" />
       <stop
+         offset="1"
          id="stop2489"
-         style="stop-color:#0d0d0d;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#0d0d0d;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
-       cx="11.25"
-       cy="19.03125"
        r="8.0625"
-       fx="11.25"
        fy="19.03125"
-       id="radialGradient5315"
-       xlink:href="#linearGradient5105-262-943-861"
+       fx="11.25"
+       cy="19.03125"
+       cx="11.25"
+       gradientTransform="matrix(2.9695155,0,0,0.81661829,-9.4070494,25.374771)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.282946,0,13.64644)" />
+       id="radialGradient5315"
+       xlink:href="#linearGradient5105-262-943-861" />
     <linearGradient
        id="linearGradient2264">
       <stop
-         id="stop2266"
-         style="stop-color:#d7e866;stop-opacity:1"
+         id="stop3244-gr"
+         style="stop-color:#cdf87e;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2268"
-         style="stop-color:#8cab2a;stop-opacity:1"
+         id="stop3246-gr"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-gr"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-gr"
+         style="stop-color:#1d7e0d;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="28.670898"
+       xlink:href="#linearGradient2264"
+       id="linearGradient2615"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.98279,-0.9893763,0,47.637156,43.300051)"
+       x1="42.95055"
        y1="23.890965"
        x2="1.3099612"
-       y2="23.890965"
-       id="linearGradient2615"
-       xlink:href="#linearGradient2264"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.98279,-0.9893763,0,47.637156,43.300051)" />
+       y2="23.890965" />
     <linearGradient
        id="linearGradient4222">
       <stop
-         id="stop4224"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4224" />
       <stop
-         id="stop4226"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4226" />
     </linearGradient>
     <linearGradient
+       xlink:href="#linearGradient4222"
+       id="linearGradient2612"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.1398464,-1.1421864,0,54.071685,-7.2102842)"
        x1="8.5273199"
        y1="33.332287"
        x2="57.411129"
-       y2="33.332287"
-       id="linearGradient2612"
-       xlink:href="#linearGradient4222"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1398464,-1.1421864,0,54.071685,-7.2102842)" />
+       y2="33.332287" />
   </defs>
   <metadata
      id="metadata2500">
@@ -85,20 +93,20 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <path
-       d="m 19.3125,19.03125 a 8.0625,2.28125 0 1 1 -16.125,0 8.0625,2.28125 0 1 1 16.125,0 z"
-       transform="matrix(2.9695155,0,0,2.8861277,-9.4070494,-14.010597)"
-       id="path4346"
-       style="opacity:0.16292138;fill:url(#radialGradient5315);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="M 43.500221,19.500222 23.951009,41.500221 4.4997782,19.500222 l 9.0002218,0 0,-18.0002212 21,0 0,18.0002212 9.000221,0 z"
-       id="path4348"
-       style="fill:url(#linearGradient2615);fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.9995572;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="M 41.338037,20.500222 24,40.000221 6.4999996,20.500222 l 8.0000004,0 0,-18.0000002 19,0 0,18.0000002 7.838037,0 z"
-       id="path4360"
-       style="opacity:0.35400008;fill:none;stroke:url(#linearGradient2612);stroke-width:0.9995572;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-  </g>
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.16292138;fill:url(#radialGradient5315);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.92752481;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="m 47.941719,40.916021 a 23.941719,6.5839788 0 1 1 -47.88343774,0 23.941719,6.5839788 0 1 1 47.88343774,0 z"
+     id="path4346" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2615);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.9995572;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="M 43.500221,19.500222 23.951009,41.500221 4.4997782,19.500222 H 13.5 V 1.5000008 h 21 V 19.500222 Z"
+     id="path4348" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2612);stroke-width:0.9995572;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="M 41.338037,20.500222 24,40.000221 6.4999996,20.500222 H 14.5 V 2.5002218 h 19 V 20.500222 Z"
+     id="path4360" />
+  <path
+     id="path833"
+     d="M 43.500221,19.500222 23.951009,41.500221 4.4997782,19.500222 H 13.5 V 1.5000008 h 21 V 19.500222 Z"
+     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.9995572;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;opacity:0.5" />
 </svg>

--- a/actions/48/go-first.svg
+++ b/actions/48/go-first.svg
@@ -6,147 +6,165 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg2482"
-   height="48"
-   width="48"
+   width="48px"
+   height="48px"
+   id="svg2491"
    version="1.1">
   <defs
-     id="defs2484">
+     id="defs2493">
     <linearGradient
-       gradientTransform="translate(0,47.00001)"
+       gradientTransform="translate(-2.9999963,48.000004)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5113"
-       id="linearGradient6723"
        y2="-7.0000062"
        x2="41.116112"
        y1="-4.4393449"
-       x1="11.767765" />
+       x1="11.767765"
+       id="linearGradient6723"
+       xlink:href="#linearGradient5113" />
     <linearGradient
        id="linearGradient3166">
       <stop
+         id="stop3168"
          offset="0"
-         style="stop-color:#a7cc5c;stop-opacity:1"
-         id="stop3168" />
+         style="stop-color:#a7cc5c;stop-opacity:1;" />
       <stop
+         id="stop3170"
          offset="1"
-         style="stop-color:#789e2d;stop-opacity:1"
-         id="stop3170" />
+         style="stop-color:#789e2d;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3166"
-       id="linearGradient3173"
        y2="41.5"
        x2="41.999996"
        y1="41.5"
-       x1="9.9999981" />
+       x1="9.9999981"
+       id="linearGradient3173"
+       xlink:href="#linearGradient3166"
+       gradientTransform="translate(-2.9999963,0.9999938)" />
     <linearGradient
        id="linearGradient5113">
       <stop
+         id="stop5115"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop5115" />
+         style="stop-color:white;stop-opacity:1;" />
       <stop
+         id="stop5117"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop5117" />
+         style="stop-color:white;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.004639,0,0,1,-4.037671,-0.05462481)"
+       gradientTransform="matrix(1.004639,0,0,1,-3.0376772,-3.0546211)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5113"
-       id="linearGradient5315"
        y2="42.793934"
        x2="37.73064"
        y1="11.133182"
-       x1="16.067961" />
+       x1="16.067961"
+       id="linearGradient5315"
+       xlink:href="#linearGradient5113" />
     <linearGradient
        id="linearGradient2264">
       <stop
-         offset="0"
-         style="stop-color:#d7e866;stop-opacity:1"
-         id="stop2266" />
+         id="stop3244-gr"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
       <stop
-         offset="1"
-         style="stop-color:#8cab2a;stop-opacity:1"
-         id="stop2268" />
+         id="stop3246-gr"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-gr"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-gr"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
     </linearGradient>
     <linearGradient
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2264"
-       id="linearGradient3172"
-       y2="38.714657"
+       y2="39.731606"
        x2="21.131361"
-       y1="13.152157"
-       x1="21.131361" />
+       y1="10.10131"
+       x1="21.131361"
+       id="linearGradient3172"
+       xlink:href="#linearGradient2264"
+       gradientTransform="translate(0.9999938,-2.9999963)" />
     <linearGradient
        id="linearGradient5105">
       <stop
+         id="stop5107"
          offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5107" />
+         style="stop-color:black;stop-opacity:1;" />
       <stop
+         id="stop5109"
          offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5109" />
+         style="stop-color:black;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(1,0,0,0.282946,0,13.64644)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5105"
-       id="radialGradient4354"
+       r="8.0625"
        fy="19.03125"
        fx="11.25"
-       r="8.0625"
        cy="19.03125"
-       cx="11.25" />
+       cx="11.25"
+       gradientTransform="matrix(-2.48062,0,0,0.68217177,51.906974,24.517428)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4354"
+       xlink:href="#linearGradient5105" />
   </defs>
   <metadata
-     id="metadata2487">
+     id="metadata2496">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <path
+     d="m 4.0000002,37.499995 a 19.999999,5.5000048 0 1 0 39.9999978,0 19.999999,5.5000048 0 1 0 -39.9999978,0 z"
+     id="path4346"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.16292138;fill:url(#radialGradient4354);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.44554257;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
   <g
-     id="layer1">
-    <g
-       style="display:inline"
-       id="g2571"
-       transform="matrix(-1,0,0,1,47.000019,-2.9999963)">
-      <path
-         style="opacity:0.16292138;fill:url(#radialGradient4354);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="path4346"
-         transform="matrix(-2.48062,0,0,2.410961,50.90698,-5.38361)"
-         d="m 19.3125,19.03125 a 8.0625,2.28125 0 1 1 -16.125,0 8.0625,2.28125 0 1 1 16.125,0 z" />
-      <path
-         style="fill:url(#linearGradient3172);fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="path4348"
-         d="m 19.502209,9.4374998 19.004144,16.5060242 -19.004144,16.423291 0,-7.869835 -14.9958391,0 0,-17.055132 14.9958391,0 0,-8.0043482 z" />
-      <path
-         style="opacity:0.35400008;fill:none;stroke:url(#linearGradient5315);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="path4360"
-         d="m 20.573058,11.578557 16.516638,14.386273 -16.516638,14.199301 0,-6.738369 -15.0666831,0 0,-14.978334 15.0666831,0 0,-6.868871 z" />
-      <rect
-         style="fill:#b3c360;fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="rect4242"
-         transform="matrix(0,1,1,0,0,0)"
-         y="39.500008"
-         x="9.5"
-         height="4.0000119"
-         width="33.000008" />
-      <rect
-         style="opacity:0.35400008;fill:url(#linearGradient3173);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6723);stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="rect6697"
-         transform="matrix(0,1,1,0,0,0)"
-         y="40.5"
-         x="10.499998"
-         height="2.0000019"
-         width="31" />
-    </g>
+     id="g859"
+     transform="matrix(-1,0,0,1,48.000012,0)">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3172);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       d="M 20.502203,6.4375035 39.506347,22.943528 20.502203,39.366819 V 31.496984 H 5.5063637 V 14.441852 H 20.502203 Z"
+       id="path4348" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5315);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       d="M 21.573052,8.5785607 38.08969,22.964834 21.573052,37.164135 V 30.425766 H 6.5063687 V 15.447432 H 21.573052 Z"
+       id="path4360" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:#a2e34f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       id="rect4242"
+       width="33.000008"
+       height="4.0000119"
+       x="6.5000038"
+       y="40.5"
+       transform="matrix(0,1,1,0,0,0)" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:url(#linearGradient3173);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6723);stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       id="rect6697"
+       width="31"
+       height="2.0000019"
+       x="7.5000019"
+       y="41.499992"
+       transform="matrix(0,1,1,0,0,0)" />
+    <path
+       id="path849"
+       d="M 20.502203,6.4375035 39.506347,22.943528 20.502203,39.366819 V 31.496984 H 5.5063637 V 14.441852 H 20.502203 Z"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <rect
+       transform="matrix(0,1,1,0,0,0)"
+       y="40.5"
+       x="6.5000038"
+       height="4.0000119"
+       width="33.000008"
+       id="rect851"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
   </g>
 </svg>

--- a/actions/48/go-last.svg
+++ b/actions/48/go-last.svg
@@ -6,100 +6,110 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="48px"
+   height="48px"
    id="svg2491"
-   height="48"
-   width="48"
    version="1.1">
   <defs
      id="defs2493">
     <linearGradient
-       gradientTransform="translate(0,47.00001)"
+       gradientTransform="translate(-2.9999963,48.000004)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5113"
-       id="linearGradient6723"
        y2="-7.0000062"
        x2="41.116112"
        y1="-4.4393449"
-       x1="11.767765" />
+       x1="11.767765"
+       id="linearGradient6723"
+       xlink:href="#linearGradient5113" />
     <linearGradient
        id="linearGradient3166">
       <stop
+         id="stop3168"
          offset="0"
-         style="stop-color:#a7cc5c;stop-opacity:1"
-         id="stop3168" />
+         style="stop-color:#a7cc5c;stop-opacity:1;" />
       <stop
+         id="stop3170"
          offset="1"
-         style="stop-color:#789e2d;stop-opacity:1"
-         id="stop3170" />
+         style="stop-color:#789e2d;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3166"
-       id="linearGradient3173"
        y2="41.5"
        x2="41.999996"
        y1="41.5"
-       x1="9.9999981" />
+       x1="9.9999981"
+       id="linearGradient3173"
+       xlink:href="#linearGradient3166"
+       gradientTransform="translate(-2.9999963,0.9999938)" />
     <linearGradient
        id="linearGradient5113">
       <stop
+         id="stop5115"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop5115" />
+         style="stop-color:white;stop-opacity:1;" />
       <stop
+         id="stop5117"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop5117" />
+         style="stop-color:white;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.004639,0,0,1,-4.037671,-0.05462481)"
+       gradientTransform="matrix(1.004639,0,0,1,-3.0376772,-3.0546211)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5113"
-       id="linearGradient5315"
        y2="42.793934"
        x2="37.73064"
        y1="11.133182"
-       x1="16.067961" />
+       x1="16.067961"
+       id="linearGradient5315"
+       xlink:href="#linearGradient5113" />
     <linearGradient
        id="linearGradient2264">
       <stop
-         offset="0"
-         style="stop-color:#d7e866;stop-opacity:1"
-         id="stop2266" />
+         id="stop3244-gr"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
       <stop
-         offset="1"
-         style="stop-color:#8cab2a;stop-opacity:1"
-         id="stop2268" />
+         id="stop3246-gr"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-gr"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-gr"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
     </linearGradient>
     <linearGradient
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2264"
-       id="linearGradient3172"
-       y2="38.714657"
+       y2="39.731606"
        x2="21.131361"
-       y1="13.152157"
-       x1="21.131361" />
+       y1="10.10131"
+       x1="21.131361"
+       id="linearGradient3172"
+       xlink:href="#linearGradient2264"
+       gradientTransform="translate(0.9999938,-2.9999963)" />
     <linearGradient
        id="linearGradient5105">
       <stop
+         id="stop5107"
          offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5107" />
+         style="stop-color:black;stop-opacity:1;" />
       <stop
+         id="stop5109"
          offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5109" />
+         style="stop-color:black;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(1,0,0,0.282946,0,13.64644)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5105"
-       id="radialGradient4354"
+       r="8.0625"
        fy="19.03125"
        fx="11.25"
-       r="8.0625"
        cy="19.03125"
-       cx="11.25" />
+       cx="11.25"
+       gradientTransform="matrix(-2.48062,0,0,0.68217177,51.906974,24.517428)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4354"
+       xlink:href="#linearGradient5105" />
   </defs>
   <metadata
      id="metadata2496">
@@ -112,41 +122,44 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <g
-       style="display:inline"
-       id="g2571"
-       transform="translate(0.9999938,-2.9999963)">
-      <path
-         style="opacity:0.16292138;fill:url(#radialGradient4354);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="path4346"
-         transform="matrix(-2.48062,0,0,2.410961,50.90698,-5.38361)"
-         d="m 19.3125,19.03125 a 8.0625,2.28125 0 1 1 -16.125,0 8.0625,2.28125 0 1 1 16.125,0 z" />
-      <path
-         style="fill:url(#linearGradient3172);fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="path4348"
-         d="m 19.502209,9.4374998 19.004144,16.5060242 -19.004144,16.423291 0,-7.869835 -14.9958391,0 0,-17.055132 14.9958391,0 0,-8.0043482 z" />
-      <path
-         style="opacity:0.35400008;fill:none;stroke:url(#linearGradient5315);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="path4360"
-         d="m 20.573058,11.578557 16.516638,14.386273 -16.516638,14.199301 0,-6.738369 -15.0666831,0 0,-14.978334 15.0666831,0 0,-6.868871 z" />
-      <rect
-         style="fill:#b3c360;fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="rect4242"
-         transform="matrix(0,1,1,0,0,0)"
-         y="39.500008"
-         x="9.5"
-         height="4.0000119"
-         width="33.000008" />
-      <rect
-         style="opacity:0.35400008;fill:url(#linearGradient3173);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6723);stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="rect6697"
-         transform="matrix(0,1,1,0,0,0)"
-         y="40.5"
-         x="10.499998"
-         height="2.0000019"
-         width="31" />
-    </g>
-  </g>
+  <path
+     d="m 4.0000002,37.499995 a 19.999999,5.5000048 0 1 0 39.9999978,0 19.999999,5.5000048 0 1 0 -39.9999978,0 z"
+     id="path4346"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.16292138;fill:url(#radialGradient4354);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.44554257;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <path
+     id="path4348"
+     d="M 20.502203,6.4375035 39.506347,22.943528 20.502203,39.366819 V 31.496984 H 5.5063637 V 14.441852 H 20.502203 Z"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3172);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <path
+     id="path4360"
+     d="M 21.573052,8.5785607 38.08969,22.964834 21.573052,37.164135 V 30.425766 H 6.5063687 V 15.447432 H 21.573052 Z"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5315);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <rect
+     transform="matrix(0,1,1,0,0,0)"
+     y="40.5"
+     x="6.5000038"
+     height="4.0000119"
+     width="33.000008"
+     id="rect4242"
+     style="display:inline;overflow:visible;visibility:visible;fill:#a2e34f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <rect
+     transform="matrix(0,1,1,0,0,0)"
+     y="41.499992"
+     x="7.5000019"
+     height="2.0000019"
+     width="31"
+     id="rect6697"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:url(#linearGradient3173);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6723);stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="M 20.502203,6.4375035 39.506347,22.943528 20.502203,39.366819 V 31.496984 H 5.5063637 V 14.441852 H 20.502203 Z"
+     id="path849" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;opacity:0.5"
+     id="rect851"
+     width="33.000008"
+     height="4.0000119"
+     x="6.5000038"
+     y="40.5"
+     transform="matrix(0,1,1,0,0,0)" />
 </svg>

--- a/actions/48/go-next.svg
+++ b/actions/48/go-next.svg
@@ -6,73 +6,81 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="48px"
+   height="48px"
    id="svg2497"
-   height="48"
-   width="48"
    version="1.1">
   <defs
      id="defs2499">
     <linearGradient
        id="linearGradient4222">
       <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
          id="stop4224" />
       <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
          id="stop4226" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-1.3106532,0,0,1.2884463,57.824782,-9.9439155)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4222"
-       id="linearGradient3194"
        y2="49.56282"
        x2="28.62199"
        y1="18.218788"
-       x1="28.62199" />
+       x1="28.62199"
+       gradientTransform="matrix(-1.3106532,0,0,1.2884463,56.853922,-9.8894841)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3194"
+       xlink:href="#linearGradient4222" />
     <linearGradient
        id="linearGradient2264">
       <stop
-         offset="0"
-         style="stop-color:#d7e866;stop-opacity:1"
-         id="stop2266" />
+         id="stop3244-gr"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
       <stop
-         offset="1"
-         style="stop-color:#8cab2a;stop-opacity:1"
-         id="stop2268" />
+         id="stop3246-gr"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-gr"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-gr"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.1300621,0,0,1.1160684,-0.5665555,-3.1639481)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2264"
-       id="linearGradient3192"
-       y2="44.051018"
+       y2="42.593117"
        x2="22.181572"
-       y1="14.499924"
-       x1="22.181572" />
+       y1="4.841321"
+       x1="22.181572"
+       gradientTransform="matrix(1.1300621,0,0,1.1160684,-1.5374152,-3.1095167)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3192"
+       xlink:href="#linearGradient2264" />
     <linearGradient
        id="linearGradient5105-262-943-861">
       <stop
          offset="0"
-         style="stop-color:#0d0d0d;stop-opacity:1"
-         id="stop2487" />
+         id="stop2487"
+         style="stop-color:#0d0d0d;stop-opacity:1;" />
       <stop
          offset="1"
-         style="stop-color:#0d0d0d;stop-opacity:0"
-         id="stop2489" />
+         id="stop2489"
+         style="stop-color:#0d0d0d;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(1,0,0,0.282946,0,13.64644)"
-       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5105-262-943-861"
        id="radialGradient2628"
-       fy="19.03125"
-       fx="11.25"
-       r="8.0625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.9695155,0,0,0.81661829,57.43619,25.374771)"
+       cx="11.25"
        cy="19.03125"
-       cx="11.25" />
+       fx="11.25"
+       fy="19.03125"
+       r="8.0625" />
   </defs>
   <metadata
      id="metadata2502">
@@ -82,102 +90,98 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="display:inline"
-       id="g2577"
-       transform="matrix(-1,0,0,1,47.97086,0.05443139)">
-      <g
-         id="g2579"
-         transform="translate(-78.10831,-36.954333)" />
-      <g
-         style="display:inline"
-         id="g2581"
-         transform="translate(-78.10831,-36.954333)" />
-      <g
-         id="g2583"
-         transform="translate(-206.6385,-8.427334)" />
-      <g
-         id="g2585"
-         transform="translate(-206.6385,-8.427334)" />
-      <g
-         id="g2587"
-         transform="translate(-206.6385,-8.427334)" />
-      <g
-         style="display:inline"
-         id="g2589"
-         transform="translate(-285.63611,-16.782179)" />
-      <g
-         id="g2591"
-         transform="translate(-285.63611,-16.782179)" />
-      <g
-         style="display:inline"
-         id="g2593"
-         transform="translate(-285.63611,-16.782179)" />
-      <g
-         id="g2595"
-         transform="translate(-129.11181,-7.874573)" />
-      <g
-         id="g2597"
-         transform="translate(39.2169,-2.614304)" />
-      <g
-         id="g2599"
-         transform="translate(-314.9727,-42.827302)" />
-      <g
-         style="display:inline"
-         id="g2601"
-         transform="translate(-314.9727,-42.827302)" />
-      <g
-         id="g2603"
-         transform="translate(-314.9727,-42.827302)" />
-      <g
-         style="display:inline"
-         id="g2605"
-         transform="translate(-283.53559,-28.586205)" />
-      <g
-         id="g2607"
-         transform="translate(-283.53559,-28.586205)" />
-      <g
-         style="display:inline"
-         id="g2609"
-         transform="translate(-283.53559,-28.586205)" />
-      <g
-         id="g2611"
-         transform="translate(-127.01129,-19.678599)" />
-      <g
-         id="g2613"
-         transform="translate(41.31742,-14.41833)" />
-      <g
-         id="g2615"
-         transform="translate(-312.87218,-54.631328)" />
-      <g
-         style="display:inline"
-         id="g2617"
-         transform="translate(-312.87218,-54.631328)" />
-      <g
-         id="g2619"
-         transform="translate(-312.87218,-54.631328)" />
-      <path
-         style="opacity:0.16292138;fill:url(#radialGradient2628);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="path2621"
-         transform="matrix(-2.9695155,0,0,2.8861277,57.40705,-14.065028)"
-         d="m 19.3125,19.03125 a 8.0625,2.28125 0 1 1 -16.125,0 8.0625,2.28125 0 1 1 16.125,0 z" />
-      <g
-         id="g3188"
-         transform="translate(-1,0)">
-        <path
-           style="fill:url(#linearGradient3192);fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:1.00545704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-           id="path2624"
-           d="M 27.5,1.5027285 1.5027285,23.555266 27.5,45.497271 27.5,34.5 l 19.997271,0 0,-22 -19.997271,0 0,-10.9972715 z" />
-        <path
-           style="opacity:0.35400008;fill:none;stroke:url(#linearGradient3194);stroke-width:1.00545704;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-           id="path2626"
-           d="M 26.5,3.5 2.9999995,23.580749 26.5,43.5 l 0,-10 20,0 0,-20 -20,0 0,-10 z" />
-      </g>
-    </g>
+     transform="translate(-78.07917,-36.899902)"
+     id="g2579" />
+  <g
+     transform="translate(-78.07917,-36.899902)"
+     id="g2581"
+     style="display:inline" />
+  <g
+     transform="translate(-206.60936,-8.3729026)"
+     id="g2583" />
+  <g
+     transform="translate(-206.60936,-8.3729026)"
+     id="g2585" />
+  <g
+     transform="translate(-206.60936,-8.3729026)"
+     id="g2587" />
+  <g
+     id="g2589"
+     style="display:inline"
+     transform="translate(-285.60697,-16.727748)" />
+  <g
+     id="g2591"
+     transform="translate(-285.60697,-16.727748)" />
+  <g
+     id="g2593"
+     style="display:inline"
+     transform="translate(-285.60697,-16.727748)" />
+  <g
+     transform="translate(-129.08267,-7.8201416)"
+     id="g2595" />
+  <g
+     transform="translate(39.24604,-2.5598726)"
+     id="g2597" />
+  <g
+     id="g2599"
+     transform="translate(-314.94356,-42.772871)" />
+  <g
+     style="display:inline"
+     id="g2601"
+     transform="translate(-314.94356,-42.772871)" />
+  <g
+     id="g2603"
+     transform="translate(-314.94356,-42.772871)" />
+  <g
+     id="g2605"
+     style="display:inline"
+     transform="translate(-283.50645,-28.531774)" />
+  <g
+     id="g2607"
+     transform="translate(-283.50645,-28.531774)" />
+  <g
+     id="g2609"
+     style="display:inline"
+     transform="translate(-283.50645,-28.531774)" />
+  <g
+     transform="translate(-126.98215,-19.624168)"
+     id="g2611" />
+  <g
+     transform="translate(41.34656,-14.363899)"
+     id="g2613" />
+  <g
+     id="g2615"
+     transform="translate(-312.84304,-54.576897)" />
+  <g
+     style="display:inline"
+     id="g2617"
+     transform="translate(-312.84304,-54.576897)" />
+  <g
+     id="g2619"
+     transform="translate(-312.84304,-54.576897)" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.16292138;fill:url(#radialGradient2628);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.92752481;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="m 0.08742191,40.916021 a 23.941719,6.5839788 0 1 0 47.88343709,0 23.941719,6.5839788 0 1 0 -47.88343709,0 z"
+     id="path2621" />
+  <g
+     id="g911"
+     transform="matrix(-1,0,0,1,48.00014,0)">
+    <path
+       id="path2624"
+       d="M 26.52914,1.5571599 0.53186884,23.609697 26.52914,45.551702 V 34.554431 h 19.997271 v -22 H 26.52914 Z"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3192);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00545704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <path
+       id="path2626"
+       d="M 25.52914,3.5544314 2.0291398,23.63518 25.52914,43.554431 v -10 h 20 v -20 h -20 z"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3194);stroke-width:1.00545704;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1.00545704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       d="M 26.52914,1.5571599 0.53186884,23.609697 26.52914,45.551702 V 34.554431 h 19.997271 v -22 H 26.52914 Z"
+       id="path906" />
   </g>
 </svg>

--- a/actions/48/go-previous.svg
+++ b/actions/48/go-previous.svg
@@ -6,73 +6,81 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="48px"
+   height="48px"
    id="svg2497"
-   height="48"
-   width="48"
    version="1.1">
   <defs
      id="defs2499">
     <linearGradient
        id="linearGradient4222">
       <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
          id="stop4224" />
       <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
          id="stop4226" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-1.3106532,0,0,1.2884463,57.824782,-9.9439155)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4222"
-       id="linearGradient3194"
        y2="49.56282"
        x2="28.62199"
        y1="18.218788"
-       x1="28.62199" />
+       x1="28.62199"
+       gradientTransform="matrix(-1.3106532,0,0,1.2884463,56.853922,-9.8894841)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3194"
+       xlink:href="#linearGradient4222" />
     <linearGradient
        id="linearGradient2264">
       <stop
-         offset="0"
-         style="stop-color:#d7e866;stop-opacity:1"
-         id="stop2266" />
+         id="stop3244-gr"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
       <stop
-         offset="1"
-         style="stop-color:#8cab2a;stop-opacity:1"
-         id="stop2268" />
+         id="stop3246-gr"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-gr"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-gr"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.1300621,0,0,1.1160684,-0.5665555,-3.1639481)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2264"
-       id="linearGradient3192"
-       y2="44.051018"
+       y2="42.593117"
        x2="22.181572"
-       y1="14.499924"
-       x1="22.181572" />
+       y1="4.841321"
+       x1="22.181572"
+       gradientTransform="matrix(1.1300621,0,0,1.1160684,-1.5374152,-3.1095167)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3192"
+       xlink:href="#linearGradient2264" />
     <linearGradient
        id="linearGradient5105-262-943-861">
       <stop
          offset="0"
-         style="stop-color:#0d0d0d;stop-opacity:1"
-         id="stop2487" />
+         id="stop2487"
+         style="stop-color:#0d0d0d;stop-opacity:1;" />
       <stop
          offset="1"
-         style="stop-color:#0d0d0d;stop-opacity:0"
-         id="stop2489" />
+         id="stop2489"
+         style="stop-color:#0d0d0d;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(1,0,0,0.282946,0,13.64644)"
-       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5105-262-943-861"
        id="radialGradient2628"
-       fy="19.03125"
-       fx="11.25"
-       r="8.0625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.9695155,0,0,0.81661829,57.43619,25.374771)"
+       cx="11.25"
        cy="19.03125"
-       cx="11.25" />
+       fx="11.25"
+       fy="19.03125"
+       r="8.0625" />
   </defs>
   <metadata
      id="metadata2502">
@@ -82,102 +90,97 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="display:inline"
-       id="g2577"
-       transform="translate(0.02914034,0.05443139)">
-      <g
-         id="g2579"
-         transform="translate(-78.10831,-36.954333)" />
-      <g
-         style="display:inline"
-         id="g2581"
-         transform="translate(-78.10831,-36.954333)" />
-      <g
-         id="g2583"
-         transform="translate(-206.6385,-8.427334)" />
-      <g
-         id="g2585"
-         transform="translate(-206.6385,-8.427334)" />
-      <g
-         id="g2587"
-         transform="translate(-206.6385,-8.427334)" />
-      <g
-         style="display:inline"
-         id="g2589"
-         transform="translate(-285.63611,-16.782179)" />
-      <g
-         id="g2591"
-         transform="translate(-285.63611,-16.782179)" />
-      <g
-         style="display:inline"
-         id="g2593"
-         transform="translate(-285.63611,-16.782179)" />
-      <g
-         id="g2595"
-         transform="translate(-129.11181,-7.874573)" />
-      <g
-         id="g2597"
-         transform="translate(39.2169,-2.614304)" />
-      <g
-         id="g2599"
-         transform="translate(-314.9727,-42.827302)" />
-      <g
-         style="display:inline"
-         id="g2601"
-         transform="translate(-314.9727,-42.827302)" />
-      <g
-         id="g2603"
-         transform="translate(-314.9727,-42.827302)" />
-      <g
-         style="display:inline"
-         id="g2605"
-         transform="translate(-283.53559,-28.586205)" />
-      <g
-         id="g2607"
-         transform="translate(-283.53559,-28.586205)" />
-      <g
-         style="display:inline"
-         id="g2609"
-         transform="translate(-283.53559,-28.586205)" />
-      <g
-         id="g2611"
-         transform="translate(-127.01129,-19.678599)" />
-      <g
-         id="g2613"
-         transform="translate(41.31742,-14.41833)" />
-      <g
-         id="g2615"
-         transform="translate(-312.87218,-54.631328)" />
-      <g
-         style="display:inline"
-         id="g2617"
-         transform="translate(-312.87218,-54.631328)" />
-      <g
-         id="g2619"
-         transform="translate(-312.87218,-54.631328)" />
-      <path
-         style="opacity:0.16292138;fill:url(#radialGradient2628);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-         id="path2621"
-         transform="matrix(-2.9695155,0,0,2.8861277,57.40705,-14.065028)"
-         d="m 19.3125,19.03125 a 8.0625,2.28125 0 1 1 -16.125,0 8.0625,2.28125 0 1 1 16.125,0 z" />
-      <g
-         id="g3188"
-         transform="translate(-1,0)">
-        <path
-           style="fill:url(#linearGradient3192);fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:1.00545704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-           id="path2624"
-           d="M 27.5,1.5027285 1.5027285,23.555266 27.5,45.497271 27.5,34.5 l 19.997271,0 0,-22 -19.997271,0 0,-10.9972715 z" />
-        <path
-           style="opacity:0.35400008;fill:none;stroke:url(#linearGradient3194);stroke-width:1.00545704;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-           id="path2626"
-           d="M 26.5,3.5 2.9999995,23.580749 26.5,43.5 l 0,-10 20,0 0,-20 -20,0 0,-10 z" />
-      </g>
-    </g>
+     transform="translate(-78.07917,-36.899902)"
+     id="g2579" />
+  <g
+     transform="translate(-78.07917,-36.899902)"
+     id="g2581"
+     style="display:inline" />
+  <g
+     transform="translate(-206.60936,-8.3729026)"
+     id="g2583" />
+  <g
+     transform="translate(-206.60936,-8.3729026)"
+     id="g2585" />
+  <g
+     transform="translate(-206.60936,-8.3729026)"
+     id="g2587" />
+  <g
+     id="g2589"
+     style="display:inline"
+     transform="translate(-285.60697,-16.727748)" />
+  <g
+     id="g2591"
+     transform="translate(-285.60697,-16.727748)" />
+  <g
+     id="g2593"
+     style="display:inline"
+     transform="translate(-285.60697,-16.727748)" />
+  <g
+     transform="translate(-129.08267,-7.8201416)"
+     id="g2595" />
+  <g
+     transform="translate(39.24604,-2.5598726)"
+     id="g2597" />
+  <g
+     id="g2599"
+     transform="translate(-314.94356,-42.772871)" />
+  <g
+     style="display:inline"
+     id="g2601"
+     transform="translate(-314.94356,-42.772871)" />
+  <g
+     id="g2603"
+     transform="translate(-314.94356,-42.772871)" />
+  <g
+     id="g2605"
+     style="display:inline"
+     transform="translate(-283.50645,-28.531774)" />
+  <g
+     id="g2607"
+     transform="translate(-283.50645,-28.531774)" />
+  <g
+     id="g2609"
+     style="display:inline"
+     transform="translate(-283.50645,-28.531774)" />
+  <g
+     transform="translate(-126.98215,-19.624168)"
+     id="g2611" />
+  <g
+     transform="translate(41.34656,-14.363899)"
+     id="g2613" />
+  <g
+     id="g2615"
+     transform="translate(-312.84304,-54.576897)" />
+  <g
+     style="display:inline"
+     id="g2617"
+     transform="translate(-312.84304,-54.576897)" />
+  <g
+     id="g2619"
+     transform="translate(-312.84304,-54.576897)" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.16292138;fill:url(#radialGradient2628);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.92752481;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="m 0.08742191,40.916021 a 23.941719,6.5839788 0 1 0 47.88343709,0 23.941719,6.5839788 0 1 0 -47.88343709,0 z"
+     id="path2621" />
+  <g
+     id="g911">
+    <path
+       id="path2624"
+       d="M 26.52914,1.5571599 0.53186884,23.609697 26.52914,45.551702 V 34.554431 h 19.997271 v -22 H 26.52914 Z"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3192);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00545704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <path
+       id="path2626"
+       d="M 25.52914,3.5544314 2.0291398,23.63518 25.52914,43.554431 v -10 h 20 v -20 h -20 z"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3194);stroke-width:1.00545704;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1.00545704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;opacity:0.5"
+       d="M 26.52914,1.5571599 0.53186884,23.609697 26.52914,45.551702 V 34.554431 h 19.997271 v -22 H 26.52914 Z"
+       id="path906" />
   </g>
 </svg>

--- a/actions/48/go-top.svg
+++ b/actions/48/go-top.svg
@@ -6,92 +6,101 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="48"
-   height="48"
-   id="svg2511">
+   width="48px"
+   height="48px"
+   id="svg2511"
+   version="1.1">
   <defs
      id="defs2513">
     <linearGradient
        id="linearGradient3167">
       <stop
          id="stop3169"
-         style="stop-color:#a7cc5c;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#a7cc5c;stop-opacity:1;" />
       <stop
          id="stop3171"
-         style="stop-color:#789e2d;stop-opacity:1"
-         offset="1" />
+         offset="1"
+         style="stop-color:#789e2d;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       x1="-5.0347199"
-       y1="-23.848377"
-       x2="26.965281"
+       gradientTransform="translate(13.034706,29.348369)"
        y2="-23.848377"
-       id="linearGradient2485"
-       xlink:href="#linearGradient3167"
+       x2="26.965281"
+       y1="-23.848377"
+       x1="-5.0347199"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(13.03472,29.34838)" />
+       id="linearGradient2485"
+       xlink:href="#linearGradient3167" />
     <linearGradient
        id="linearGradient5113">
       <stop
          id="stop5115"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:white;stop-opacity:1;" />
       <stop
          id="stop5117"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       x1="43.129921"
-       y1="15.195395"
-       x2="7.9313831"
-       y2="34.731434"
-       id="linearGradient5315"
-       xlink:href="#linearGradient5113"
+       gradientTransform="matrix(0,-1.004639,1,0,-1.9921252,51.044049)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.004639,1,0,-1.992111,51.04406)" />
+       y2="34.731434"
+       x2="7.9313831"
+       y1="15.195395"
+       x1="43.129921"
+       id="linearGradient5315"
+       xlink:href="#linearGradient5113" />
     <linearGradient
        id="linearGradient2264">
       <stop
-         id="stop2266"
-         style="stop-color:#d7e866;stop-opacity:1"
+         id="stop3244-gr"
+         style="stop-color:#cdf87e;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2268"
-         style="stop-color:#8cab2a;stop-opacity:1"
+         id="stop3246-gr"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-gr"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-gr"
+         style="stop-color:#1d7e0d;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="23.964672"
-       y1="11.357888"
-       x2="23.964672"
+       gradientUnits="userSpaceOnUse"
        y2="40.70282"
+       x2="23.964672"
+       y1="9.7307692"
+       x1="23.964672"
        id="linearGradient3173"
        xlink:href="#linearGradient2264"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="translate(-1.425e-5,-1.13125e-5)" />
     <linearGradient
        id="linearGradient5105">
       <stop
          id="stop5107"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:black;stop-opacity:1;" />
       <stop
          id="stop5109"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         offset="1"
+         style="stop-color:black;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
-       cx="11.25"
-       cy="19.03125"
        r="8.0625"
-       fx="11.25"
        fy="19.03125"
-       id="radialGradient4354"
-       xlink:href="#linearGradient5105"
+       fx="11.25"
+       cy="19.03125"
+       cx="11.25"
+       gradientTransform="matrix(2.48062,0,0,0.68217177,-3.9069763,27.517428)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.282946,0,13.64644)" />
+       id="radialGradient4354"
+       xlink:href="#linearGradient5105" />
   </defs>
   <metadata
      id="metadata2516">
@@ -104,39 +113,41 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <g
-       transform="translate(-1.425e-5,-1.13125e-5)"
-       id="g2577"
-       style="display:inline">
-      <path
-         d="m 19.3125,19.03125 a 8.0625,2.28125 0 1 1 -16.125,0 8.0625,2.28125 0 1 1 16.125,0 z"
-         transform="matrix(2.48062,0,0,2.410961,-3.906962,-5.383595)"
-         id="path2579"
-         style="opacity:0.16292138;fill:url(#radialGradient4354);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="M 7.5000144,27.504176 24.006038,8.500031 l 16.423291,19.004145 -7.869835,0 0,14.995839 -17.055132,0 0,-14.995839 -8.0043476,0 z"
-         id="path2581"
-         style="fill:url(#linearGradient3173);fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="M 9.6410714,26.433327 24.027344,9.916688 l 14.199301,16.516639 -6.738369,0 0,15.066683 -14.978334,0 0,-15.066683 -6.8688706,0 z"
-         id="path2583"
-         style="opacity:0.35400008;fill:none;stroke:url(#linearGradient5315);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <rect
-         width="33.000008"
-         height="4.0000119"
-         x="7.5000019"
-         y="3.5000086"
-         id="rect4242"
-         style="fill:#c2ce70;fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <rect
-         width="31"
-         height="2.0000019"
-         x="8.5"
-         y="4.500001"
-         id="rect6697"
-         style="opacity:0.35400008;fill:url(#linearGradient2485);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    </g>
-  </g>
+  <path
+     d="m 43.999997,40.499995 a 19.999999,5.5000048 0 1 1 -39.999997,0 19.999999,5.5000048 0 1 1 39.999997,0 z"
+     id="path2579"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.16292138;fill:url(#radialGradient4354);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.44554257;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <path
+     id="path2581"
+     d="M 7.5000001,27.504165 24.006024,8.5000197 40.429315,27.504165 H 32.55948 V 42.500004 H 15.504348 V 27.504165 Z"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3173);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <path
+     id="path2583"
+     d="M 9.6410572,26.433316 24.02733,9.9166767 38.226631,26.433316 H 31.488262 V 41.499999 H 16.509928 V 26.433316 Z"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5315);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <rect
+     y="3.4999974"
+     x="7.4999876"
+     height="4.0000119"
+     width="33.000008"
+     id="rect4242"
+     style="display:inline;overflow:visible;visibility:visible;fill:#cdf87e;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <rect
+     y="4.4999895"
+     x="8.4999857"
+     height="2.0000019"
+     width="31"
+     id="rect6697"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:url(#linearGradient2485);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="M 7.5000001,27.504165 24.006024,8.5000197 40.429315,27.504165 H 32.55948 V 42.500004 H 15.504348 V 27.504165 Z"
+     id="path851" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;opacity:0.5"
+     id="rect853"
+     width="33.000008"
+     height="4.0000119"
+     x="7.4999876"
+     y="3.4999974" />
 </svg>

--- a/actions/48/go-up.svg
+++ b/actions/48/go-up.svg
@@ -6,73 +6,81 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="48"
-   height="48"
-   id="svg2500">
+   width="48px"
+   height="48px"
+   id="svg2500"
+   version="1.1">
   <defs
      id="defs2502">
     <linearGradient
        id="linearGradient5105-262-943-861">
       <stop
+         offset="0"
          id="stop2487"
-         style="stop-color:#0d0d0d;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#0d0d0d;stop-opacity:1;" />
       <stop
+         offset="1"
          id="stop2489"
-         style="stop-color:#0d0d0d;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#0d0d0d;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
-       cx="11.25"
-       cy="19.03125"
        r="8.0625"
-       fx="11.25"
        fy="19.03125"
-       id="radialGradient5315"
-       xlink:href="#linearGradient5105-262-943-861"
+       fx="11.25"
+       cy="19.03125"
+       cx="11.25"
+       gradientTransform="matrix(2.9695155,0,0,0.81661829,-9.4070494,25.374771)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.282946,0,13.64644)" />
+       id="radialGradient5315"
+       xlink:href="#linearGradient5105-262-943-861" />
     <linearGradient
        id="linearGradient2264">
       <stop
-         id="stop2266"
-         style="stop-color:#d7e866;stop-opacity:1"
+         id="stop3244-gr"
+         style="stop-color:#cdf87e;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2268"
-         style="stop-color:#8cab2a;stop-opacity:1"
+         id="stop3246-gr"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-gr"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-gr"
+         style="stop-color:#1d7e0d;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="15.658319"
+       xlink:href="#linearGradient2264"
+       id="linearGradient2615"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.98279,-0.9893763,0,47.637156,-0.2998291)"
+       x1="1.9995228"
        y1="23.890965"
        x2="43.091583"
-       y2="23.890965"
-       id="linearGradient2615"
-       xlink:href="#linearGradient2264"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.98279,-0.9893763,0,47.637156,-0.2998291)" />
+       y2="23.890965" />
     <linearGradient
        id="linearGradient4222">
       <stop
-         id="stop4224"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4224" />
       <stop
-         id="stop4226"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4226" />
     </linearGradient>
     <linearGradient
+       xlink:href="#linearGradient4222"
+       id="linearGradient2612"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.1398464,-1.1421864,0,54.071685,50.210506)"
        x1="37.390652"
        y1="26.022907"
        x2="-7.150826"
-       y2="26.022907"
-       id="linearGradient2612"
-       xlink:href="#linearGradient4222"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.1398464,-1.1421864,0,54.071685,50.210506)" />
+       y2="26.022907" />
   </defs>
   <metadata
      id="metadata2505">
@@ -85,20 +93,20 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <path
-       d="m 19.3125,19.03125 a 8.0625,2.28125 0 1 1 -16.125,0 8.0625,2.28125 0 1 1 16.125,0 z"
-       transform="matrix(2.9695155,0,0,2.8861277,-9.4070494,-14.010597)"
-       id="path4346"
-       style="opacity:0.16292138;fill:url(#radialGradient5315);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="M 43.500221,23.5 23.951009,1.5000008 4.4997782,23.5 13.5,23.5 l 0,18.000221 21,0 0,-18.000221 9.000221,0 z"
-       id="path4348"
-       style="fill:url(#linearGradient2615);fill-opacity:1;fill-rule:nonzero;stroke:#548820;stroke-width:0.9995572;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="M 41.338037,22.5 24,3.0000008 6.4999996,22.5 14.5,22.5 l 0,18 19,0 0,-18 7.838037,0 z"
-       id="path4360"
-       style="opacity:0.35400008;fill:none;stroke:url(#linearGradient2612);stroke-width:0.9995572;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-  </g>
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.16292138;fill:url(#radialGradient5315);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.92752481;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="m 47.941719,40.916021 a 23.941719,6.5839788 0 1 1 -47.88343774,0 23.941719,6.5839788 0 1 1 47.88343774,0 z"
+     id="path4346" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2615);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.9995572;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="M 43.500221,23.5 23.951009,1.5000008 4.4997782,23.5 H 13.5 v 18.000221 h 21 V 23.5 Z"
+     id="path4348" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.35400008;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2612);stroke-width:0.9995572;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     d="M 41.338037,22.5 24,3.0000008 6.4999996,22.5 H 14.5 v 18 h 19 v -18 z"
+     id="path4360" />
+  <path
+     id="path833"
+     d="M 43.500221,23.5 23.951009,1.5000008 4.4997782,23.5 H 13.5 v 18.000221 h 21 V 23.5 Z"
+     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:0.9995572;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;opacity:0.5" />
 </svg>

--- a/actions/64/go-down.svg
+++ b/actions/64/go-down.svg
@@ -6,114 +6,94 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
    width="64"
    height="64"
-   id="svg4027">
+   id="svg4027"
+   version="1.1">
   <defs
      id="defs4029">
     <linearGradient
+       xlink:href="#linearGradient3264"
+       id="linearGradient3179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.5047456,-1.4219701,0,69.347287,-4.606065)"
        x1="8.2639351"
        y1="25.410501"
        x2="41.2967"
-       y2="25.410501"
-       id="linearGradient3179"
-       xlink:href="#linearGradient3264"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.5047456,-1.4219701,0,69.347287,-20.606065)" />
+       y2="25.410501" />
     <linearGradient
        id="linearGradient3264">
       <stop
-         id="stop3266"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3266" />
       <stop
          id="stop3268"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
          offset="0.00917203" />
       <stop
          id="stop3270"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
          offset="0.4854593" />
       <stop
          id="stop3272"
-         style="stop-color:#ffffff;stop-opacity:1"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0.48746586" />
       <stop
-         id="stop3274"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3274" />
     </linearGradient>
     <radialGradient
-       cx="66.364601"
-       cy="48.605404"
        r="31.000002"
-       fx="66.364601"
        fy="48.605404"
+       fx="66.364601"
+       cy="48.605404"
+       cx="66.364601"
+       gradientTransform="matrix(0,2.7191422,-2.3531013,0,146.34697,-174.08021)"
+       gradientUnits="userSpaceOnUse"
        id="radialGradient3087-5"
-       xlink:href="#linearGradient3242-7-8-3-6-1-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,2.7191422,-2.3531013,0,146.34697,-190.08021)" />
-    <linearGradient
-       id="linearGradient3242-7-8-3-6-1-9">
-      <stop
-         id="stop3244-5-5-7-5-7-9"
-         style="stop-color:#eef87e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-9-0-2-5-5-0"
-         style="stop-color:#cde34f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-7-5-3-3-3-7"
-         style="stop-color:#93b723;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-8-9-5-8-8-6"
-         style="stop-color:#5a7e0d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="72.421684"
-       y1="130.55844"
-       x2="72.421684"
-       y2="56.651321"
-       id="linearGradient3089-3"
-       xlink:href="#linearGradient4121-6-7-7-7-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.583717,0,0,0.73979403,-19.366886,-51.977643)" />
-    <linearGradient
-       id="linearGradient4121-6-7-7-7-7">
-      <stop
-         id="stop4123-85-8-3-7-6"
-         style="stop-color:#3f7010;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4125-2-9-6-3-1"
-         style="stop-color:#84a718;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
+       xlink:href="#linearGradient3242-7-3-8-0-4-58-06" />
     <linearGradient
        id="linearGradient5105-262-943-861">
       <stop
+         offset="0"
          id="stop2487"
-         style="stop-color:#0d0d0d;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#0d0d0d;stop-opacity:1;" />
       <stop
+         offset="1"
          id="stop2489"
-         style="stop-color:#0d0d0d;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#0d0d0d;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
-       cx="11.25"
-       cy="19.03125"
        r="8.0625"
-       fx="11.25"
        fy="19.03125"
-       id="radialGradient4025"
-       xlink:href="#linearGradient5105-262-943-861"
+       fx="11.25"
+       cy="19.03125"
+       cx="11.25"
+       gradientTransform="matrix(3.9690171,0,0,1.0914818,-12.65124,34.427693)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.282946,0,13.64644)" />
+       id="radialGradient4025"
+       xlink:href="#linearGradient5105-262-943-861" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58-06">
+      <stop
+         id="stop3244-5-8-5-6-4-3-8"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0-7"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35-9"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40-4"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata4032">
@@ -127,21 +107,20 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     transform="translate(0,16)"
-     id="layer1">
-    <path
-       d="m 19.3125,19.03125 a 8.0625,2.28125 0 1 1 -16.125,0 8.0625,2.28125 0 1 1 16.125,0 z"
-       transform="matrix(3.9690171,0,0,3.8575622,-12.65124,-34.214298)"
-       id="path4346"
-       style="opacity:0.16292138;fill:url(#radialGradient4025);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="M 57.353125,15.5 31.936511,43.507286 6.6472799,15.5 18.5,15.5 l 0,-25 27,0 0,25 z"
-       id="path3288"
-       style="color:#000000;fill:url(#radialGradient3087-5);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3089-3);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="M 55.151615,16.5 31.909409,41.997306 8.8217055,16.5 19.5,16.5 l 0,-25 25,0 0,25 z"
-       id="path3290"
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3179);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-  </g>
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.16292138;fill:url(#radialGradient4025);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.91289282;marker:none"
+     d="m 64.000403,55.199933 c 0,4.860142 -14.326977,8.800063 -32.000201,8.800063 C 14.32698,63.999996 2.00625e-6,60.060075 2.00625e-6,55.199933 2.00625e-6,50.33979 14.32698,46.399869 32.000202,46.399869 c 17.673224,0 32.000201,3.939921 32.000201,8.800064 z"
+     id="path4346" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3087-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 57.353125,31.5 31.936511,59.507286 6.6472799,31.5 H 18.5 v -25 h 27 v 25 z"
+     id="path3288" />
+  <path
+     d="M 55.151615,32.5 31.909409,57.997306 8.8217055,32.5 H 19.5 v -25 h 25 v 25 z"
+     id="path3290"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3179);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     id="path897"
+     d="M 57.353125,31.5 31.936511,59.507286 6.6472799,31.5 H 18.5 v -25 h 27 v 25 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;opacity:0.5" />
 </svg>


### PR DESCRIPTION
There are still some arrows using the "old greens". This patch converts them.