### PR TITLE
Add 16px variants of MS Office icons

### DIFF
--- a/mimes/16/application-msword.svg
+++ b/mimes/16/application-msword.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1">
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.076912"
+       x2="23.99999"
+       y1="6.9230647"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3"
+       id="radialGradient3441"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.1086766e-8,2.3603657,-2.5570421,-7.085182e-8,32.987014,-21.789244)"
+       cx="5.6491151"
+       cy="9.9571075"
+       fx="5.118885"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3">
+      <stop
+         id="stop3750-1-0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none" />
+  <path
+     d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 Z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
+     id="path4160-8"
+     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3441);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 8,4 4,5.066406 v 5.867187 L 8,12 Z m 1,1.066406 v 0.8190104 h 2.166667 V 6.1575519 H 9 v 0.5455728 h 2.166667 V 6.9752601 H 9 v 0.5455733 h 2.166667 V 7.7942707 H 9 v 0.5442705 h 2.166667 v 0.273438 H 9 v 0.545573 h 2.166667 v 0.272135 H 9 v 0.545573 h 2.166667 V 10.247395 H 9 v 0.819011 h 3 v -6 z M 6.8541667,6.6419267 h 0.2265627 c 0.2090786,0 0.2216873,0.015327 0.1979166,0.1328127 C 7.264493,6.8446864 7.146458,7.4658301 7.0156254,8.1575522 L 6.779948,9.4166662 H 6.5364584 c -0.1323202,0 -0.2396518,-0.0092 -0.2421876,-0.01693 C 6.2917042,9.3919662 6.2155887,8.9804902 6.125,8.4830732 6.0344125,7.9856527 5.9482764,7.6109194 5.9335938,7.6575521 5.9189091,7.7041854 5.8428205,8.1141874 5.765625,8.5585932 L 5.625,9.3671872 5.404948,9.3489582 5.1770833,9.3333332 4.9934896,8.2239582 C 4.8909196,7.6177307 4.7938118,7.0562174 4.7799479,6.9739581 c -0.022937,-0.1360954 -0.008,-0.1530934 0.1536458,-0.1744794 0.2252215,-0.029793 0.2343784,-0.00313 0.3671876,0.9752607 0.056735,0.4180028 0.1042825,0.7660178 0.1119791,0.7747398 0.00769,0.0087 0.086556,-0.387655 0.1744792,-0.8750005 0.087924,-0.4873453 0.1874598,-0.9000813 0.2213542,-0.9244786 0.09755,-0.070217 0.3716194,-0.05306 0.3971354,0.02474 0.012743,0.03886 0.091966,0.4594926 0.1692708,0.933594 0.1293352,0.7932021 0.2209624,1.0813191 0.2213542,0.6992191 1.51e-4,-0.152607 0.1032612,-0.8807385 0.2057292,-1.4661465 z"
+     id="path3439" />
+</svg>

--- a/mimes/16/application-vnd.ms-access.svg
+++ b/mimes/16/application-vnd.ms-access.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1">
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.076912"
+       x2="23.99999"
+       y1="6.9230647"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <radialGradient
+       cx="8.276144"
+       cy="9.9941158"
+       r="12.671875"
+       fx="8.276144"
+       fy="9.9941158"
+       id="radialGradient3988-4"
+       xlink:href="#linearGradient3242-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.6898989,-3.3023367,0,41.033106,-26.340537)" />
+    <linearGradient
+       id="linearGradient3242-4">
+      <stop
+         id="stop3244-7"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-1"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-5"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-7"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none" />
+  <path
+     d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 Z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
+     id="path4160-8"
+     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3988-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path4255"
+     d="M 8,4 4,5.0666666 V 10.933333 L 8,12 Z M 9.4083334,5.3333332 C 9.32303,5.3341666 9.236364,5.3383867 9.15,5.3416679 l -0.1729166,0.00833 V 6.024998 6.6999979 l -0.04375,0.016667 C 9.1991467,6.7500379 9.8244854,6.740032 10.241667,6.6999979 11.36395,6.5923441 12.071348,6.2839922 11.95,5.9583336 11.813858,5.5929753 10.687887,5.322407 9.4083334,5.3333332 Z M 12,6.6668786 11.9,6.7835453 c -0.131746,0.1583867 -0.495449,0.3269233 -0.941667,0.425 -0.275708,0.0606 -0.573572,0.083537 -1.258333,0.1 l -0.7229167,0.016667 v 0.3708333 0.341666 L 9.675,8.0127114 c 0.693159,-0.016413 0.963468,-0.040167 1.275,-0.1083321 0.449519,-0.098358 0.799729,-0.2396487 0.933333,-0.3833333 l 0.09167,-0.1 0.01667,-0.366666 z m -6.3421313,0.150278 h 0.2666666 c 0.2221174,0 0.274976,0.010373 0.2916667,0.066667 0.011093,0.037433 0.166432,0.6119448 0.35,1.2750001 0.183568,0.6630554 0.3407013,1.223264 0.35,1.25 0.01232,0.035413 -0.04634,0.05224 -0.2083333,0.05 -0.1223147,-0.00167 -0.241456,-0.01472 -0.2666667,-0.025 -0.0252,-0.01028 -0.070816,-0.1491913 -0.1083333,-0.3083333 l -0.075,-0.2833333 h -0.35 -0.3583334 l -0.058333,0.2583333 -0.05,0.2666667 -0.25,0.00833 -0.2416667,0.00833 0.016667,-0.066667 c 0.011707,-0.0385 0.148856,-0.5272227 0.3,-1.0833334 C 5.417346,7.677712 5.5675093,7.137782 5.5995353,7.02549 Z m 0.25,0.6 c -0.01096,0.00307 -0.062133,0.17176 -0.1166667,0.3916667 -0.05816,0.2345673 -0.1137547,0.454236 -0.125,0.4916668 -0.018,0.0599 0.012287,0.075 0.2333333,0.075 h 0.25 L 6.0328687,7.9171566 c -0.062687,-0.2513192 -0.118968,-0.479322 -0.125,-0.5 z M 12,7.9281074 l -0.116667,0.125 c -0.304228,0.3294534 -1.286062,0.5368974 -2.4916663,0.525 l -0.3895833,-0.00833 -0.016667,0.2416633 -0.00833,0.4333326 0.045833,0.025 c 0.1457067,0.04398 1.3797494,-0.012093 1.7270834,-0.075 0.484868,-0.087821 0.929162,-0.237874 1.091667,-0.375 L 11.975,8.7031081 11.991667,8.2197753 Z m 0,1.1385594 -0.116667,0.1416666 c -0.284058,0.327276 -1.157152,0.52029 -2.383333,0.525 H 8.9770833 v 0.125 0.5333336 l 0.03125,0.01667 C 9.430364,10.4382 9.5839707,10.406467 10.1,10.366667 c 0.873271,-0.06739 1.540067,-0.244766 1.758333,-0.4750002 l 0.116667,-0.125 0.01667,-0.5416667 z" />
+</svg>

--- a/mimes/16/application-vnd.ms-excel.svg
+++ b/mimes/16/application-vnd.ms-excel.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1">
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.076912"
+       x2="23.99999"
+       y1="6.9230647"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <radialGradient
+       xlink:href="#linearGradient3242-7-3-8-0-4-58"
+       id="radialGradient4777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0007967e-8,2.7357173,-3.3585864,-1.2027235e-8,41.437964,-23.895792)"
+       cx="5.6155143"
+       cy="9.9571075"
+       fx="5.0852842"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58">
+      <stop
+         offset="0"
+         style="stop-color:#bdff69;stop-opacity:1;"
+         id="stop3244-5-8-5-6-4-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#8ed451;stop-opacity:1;"
+         id="stop3246-9-5-1-5-3-0" />
+      <stop
+         offset="0.66093999"
+         style="stop-color:#58aa30;stop-opacity:1;"
+         id="stop3248-7-2-0-7-5-35" />
+      <stop
+         offset="1"
+         style="stop-color:#2a6c1f;stop-opacity:1;"
+         id="stop3250-8-2-8-5-6-40" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none" />
+  <path
+     d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 Z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
+     id="path4160-8"
+     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4777);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 8,4 4,5.0666667 V 10.933333 L 8,12 Z M 9,5.0711864 V 5.742578 h 1.002825 V 6.385105 H 9 v 0.3636364 h 1.002825 V 7.3912687 H 9 v 0.3466876 h 1.002825 v 0.664304 H 9 v 0.375757 h 1.002825 v 0.591679 H 9 v 0.363637 h 1.002825 V 10.409758 H 9 v 0.664099 h 3 V 5.0711864 Z m 1.467129,0.6713916 h 0.866204 v 0.642527 h -0.866204 z m 0,1.0061634 h 0.866204 V 7.3912687 H 10.467129 Z M 6.690904,6.52387 c 0.048433,-9.333e-4 0.075024,-0.00207 0.075,0 -3.73e-5,0.00407 -0.1363837,0.3140154 -0.308333,0.6833334 L 6.1409043,7.8738703 6.457571,8.5405363 c 0.1719493,0.364366 0.308333,0.676416 0.308333,0.691667 0,0.03203 -0.229765,0.02668 -0.4249997,-0.0083 -0.129232,-0.02317 -0.1356907,-0.03768 -0.3,-0.45 -0.093635,-0.234972 -0.184232,-0.441898 -0.2,-0.458334 -0.01576,-0.01643 -0.1072293,0.16162 -0.2,0.391667 -0.092771,0.230045 -0.1791147,0.42784 -0.1916667,0.441667 -0.01256,0.01384 -0.126624,0.01384 -0.2583333,0 L 4.9492376,9.1238703 5.2409043,8.5072033 5.532571,7.8905363 5.2742376,7.29887 C 5.1327949,6.9724354 5.0159043,6.6803567 5.0159043,6.6572027 c 0,-0.02584 0.097661,-0.041667 0.25,-0.041667 h 0.25 l 0.1416667,0.4 c 0.079621,0.2189507 0.1602826,0.4088627 0.175,0.425 0.01472,0.016133 0.1138266,-0.1785366 0.2166666,-0.433334 L 6.232571,6.5488694 6.4992376,6.5322027 c 0.073509,-0.00347 0.143232,-0.00737 0.1916664,-0.00833 z m 3.776225,1.2140863 h 0.866204 v 0.664304 h -0.866204 z m 0,1.040061 h 0.866204 v 0.591679 h -0.866204 z m 0,0.955316 h 0.866204 v 0.6764247 h -0.866204 z"
+     id="path4881" />
+</svg>

--- a/mimes/16/application-vnd.ms-powerpoint.presentation.macroEnabled.12.svg
+++ b/mimes/16/application-vnd.ms-powerpoint.presentation.macroEnabled.12.svg
@@ -1,0 +1,1 @@
+application-vnd.ms-powerpoint.svg

--- a/mimes/16/application-vnd.ms-powerpoint.svg
+++ b/mimes/16/application-vnd.ms-powerpoint.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1">
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.076912"
+       x2="23.99999"
+       y1="6.9230647"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <radialGradient
+       cx="6.5633106"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
+       id="radialGradient3029"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.6321568,-3.2314473,0,40.106516,-23.337487)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
+      <stop
+         id="stop3750-1-0-7"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7-4"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8-5"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6-2"
+         style="stop-color:#ac441f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none" />
+  <path
+     d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 Z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
+     id="path4160-8"
+     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 8,4 4,5.114754 v 5.770492 L 8,12 Z m 0.9998116,1 v 0.6393443 h 2.5411724 v 3.409836 H 12 V 5.6393444 5 h -0.393443 z m 3.769e-4,0.9999999 -3.769e-4,0.4672132 c 0.083978,-0.021659 -0.024979,-0.040984 0.065762,-0.040984 v 1.0491803 h 0.9672132 c 0,0.5794467 -0.3877667,1.0491809 -0.9672133,1.0491809 -0.090741,0 0.018215,-0.01932 -0.065762,-0.04098 v 0.565574 h 1.5575655 v 0.327869 H 8.9998116 v 0.6557377 h 1.5575654 v 0.333756 H 8.9998116 v 0.657213 h 2.0000004 l 3.76e-4,-5.0237599 z m 0.3276804,0.1639344 c 0.5794464,0 0.9672131,0.4697338 0.9672131,1.0491804 H 9.3278689 Z m -3.2387938,0.590164 c 0.2628304,0.00446 0.3962833,0.056715 0.5081969,0.1639344 0.1459831,0.1398598 0.2066571,0.323739 0.2049181,0.6475411 C 6.7993049,8.0970493 6.4824813,8.4262293 5.982518,8.4262293 H 5.7939932 l -0.016392,0.42623 -0.0082,0.434426 -0.1967213,-0.01639 -0.2503847,-0.0082 V 8.0245903 6.7868854 l 0.4553028,-0.02459 c 0.1211199,-0.00687 0.2238635,-0.00969 0.3114753,-0.0082 z m -0.3032784,0.442623 v 0.3770492 c 0,0.2069764 0.018753,0.3876072 0.032788,0.4016393 0.041002,0.041003 0.1549585,0.033961 0.295082,-0.02459 C 6.2837021,7.8797744 6.3609062,7.6577555 6.2939945,7.4344261 6.2446581,7.2697574 6.1352944,7.1967214 5.925141,7.1967214 Z"
+     id="path3065"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+</svg>

--- a/mimes/16/application-vnd.openxmlformats-officedocument.spreadsheetml.sheet.svg
+++ b/mimes/16/application-vnd.openxmlformats-officedocument.spreadsheetml.sheet.svg
@@ -1,0 +1,1 @@
+application-vnd.ms-excel.svg


### PR DESCRIPTION
Currently there are no 16px versions of those icons. I know the 24px svgs can be scaled down, but this proposal contains slightly optimized icons for 16px (mostly aligning along the grid).

I've added these to elementary-xfce anyway, so I thought I'd propose them here too.