### PR TITLE
Remove error symlink

### DIFF
--- a/status/24/error.svg
+++ b/status/24/error.svg
@@ -1,1 +1,0 @@
-dialog-error.svg


### PR DESCRIPTION
Seems vestigial. it's not in the spec. `dialog-error` is the spec named version