### PR TITLE
pre-commit: --export-plain-svg is bloating diffs

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -8,7 +8,9 @@ echo "Running Inkscape vacuum. This may take some time..."
 
 git diff --cached --name-status --diff-filter=ACMR | while read STATUS FILE; do
   if [[ "$FILE" =~ ^.+(svg)$ ]]; then
+    # --export-plain-svg is reordering elements, executing it twice restores the original order
     inkscape --vacuum-defs -z $CDIR/$FILE --export-plain-svg=$CDIR/$FILE
+    inkscape -z $CDIR/$FILE --export-plain-svg=$CDIR/$FILE
   fi
 done
 


### PR DESCRIPTION
Closes https://github.com/elementary/icons/issues/470

As it is explained in the mentioned issue the option `--export-plain-svg` is reordering elements in the svg file. Doing this twice seems to cancel the effect out.

Reasons to merge this commit:
1. Keeping the git history clean
2. If you added just symbolic links, pre-commit also changed the targeted svg files. With this commit you'll see the symbolic links only, which makes such PRs easier to review.