### PR TITLE
mimes: add symbolic links for sql files

### DIFF
--- a/mimes/128/application-sql.svg
+++ b/mimes/128/application-sql.svg
@@ -1,0 +1,1 @@
+office-database.svg

--- a/mimes/16/application-sql.svg
+++ b/mimes/16/application-sql.svg
@@ -1,0 +1,1 @@
+office-database.svg

--- a/mimes/24/application-sql.svg
+++ b/mimes/24/application-sql.svg
@@ -1,0 +1,1 @@
+office-database.svg

--- a/mimes/32/application-sql.svg
+++ b/mimes/32/application-sql.svg
@@ -1,0 +1,1 @@
+office-database.svg

--- a/mimes/32/office-database.svg
+++ b/mimes/32/office-database.svg
@@ -6,26 +6,10 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="32"
    height="32"
-   id="svg3234"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="text-x-sql.svg">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="640"
-     inkscape:window-height="480"
-     id="namedview1157" />
+   id="svg3234">
   <defs
      id="defs3236">
     <linearGradient

--- a/mimes/48/application-sql.svg
+++ b/mimes/48/application-sql.svg
@@ -1,0 +1,1 @@
+office-database.svg

--- a/mimes/48/office-database.svg
+++ b/mimes/48/office-database.svg
@@ -196,7 +196,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/mimes/64/application-sql.svg
+++ b/mimes/64/application-sql.svg
@@ -1,0 +1,1 @@
+office-database.svg


### PR DESCRIPTION
Fixes #375 

The mime-type name for .sql files is `application/sql`:
https://cgit.freedesktop.org/xdg/shared-mime-info/tree/freedesktop.org.xml.in#n6251