### PR TITLE
Symlink system-reboot-symbolic

### DIFF
--- a/actions/symbolic/system-reboot-symbolic.svg
+++ b/actions/symbolic/system-reboot-symbolic.svg
@@ -1,0 +1,1 @@
+status/symbolic/rotation-allowed-symbolic.svg

--- a/actions/symbolic/system-reboot-symbolic.svg
+++ b/actions/symbolic/system-reboot-symbolic.svg
@@ -1,1 +1,1 @@
-status/symbolic/rotation-allowed-symbolic.svg
+../../status/symbolic/rotation-allowed-symbolic.svg


### PR DESCRIPTION
Just symlink the icon we're using in the installer for now. Minimally fixes #616 