### PR TITLE
updated pre-commit to check for flatpak inkscape

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -3,12 +3,18 @@
 # Runs Inkscape vacuum to clean up svgs
 
 CDIR=$(git rev-parse --show-toplevel)
-
 echo "Running Inkscape vacuum. This may take some time..."
+
+# Check if Inkscape is a flatpak or not
+if [ $(which inkscape &>/dev/null; echo $?) == 0 ]; then
+  INKSCAPE='inkscape'
+else
+  INKSCAPE='flatpak run org.inkscape.Inkscape'
+fi
 
 git diff --cached --name-status --diff-filter=ACMR | while read STATUS FILE; do
   if [[ "$FILE" =~ ^.+(svg)$ ]]; then
-    inkscape --vacuum-defs -z $CDIR/$FILE --export-plain-svg=$CDIR/$FILE
+    $INKSCAPE --vacuum-defs -z $CDIR/$FILE --export-plain-svg=$CDIR/$FILE
   fi
 done
 


### PR DESCRIPTION
The pre-commit will not vacuum if you're using flatpak-ed inkscape (like me) so I added lines to check which is installed and use the appropriate command.