### PR TITLE
New Wi-Fi icons for the network plug

### DIFF
--- a/devices/24/network-wireless.svg
+++ b/devices/24/network-wireless.svg
@@ -1,117 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="24"
-   height="24"
-   id="svg12094">
-  <defs
-     id="defs12096">
-    <linearGradient
-       x1="24.448801"
-       y1="37.155445"
-       x2="24.448801"
-       y2="42.677994"
-       id="linearGradient6637"
-       xlink:href="#linearGradient4181-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6577143,0,0,0.64918698,-3.7726899,-15.99019)" />
-    <linearGradient
-       id="linearGradient4181-6">
-      <stop
-         id="stop4183-2"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4185-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" id="svg12094">
+  <defs id="defs12096">
+    <linearGradient id="linearGradient3966">
+      <stop id="stop3968" style="stop-color:#000000;stop-opacity:1" offset="0" />
+      <stop id="stop3970" style="stop-color:#000000;stop-opacity:0" offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-2-6">
-      <stop
-         id="stop3750-5-2-9"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-7-4-8"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-4-7-4"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-7-8"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
+    <linearGradient id="linearGradient4011-7">
+      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop4013-4" />
+      <stop offset="0.507761" style="stop-color:#ffffff;stop-opacity:0.23529412" id="stop4015-61" />
+      <stop offset="0.83456558" style="stop-color:#ffffff;stop-opacity:0.15686275" id="stop4017-2" />
+      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0.39215687" id="stop4019-2" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-5-4-4">
-      <stop
-         id="stop3760-9-8-2"
-         style="stop-color:#185f9a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3762-7-1-0"
-         style="stop-color:#599ec9;stop-opacity:1"
-         offset="1" />
+    <linearGradient id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-8">
+      <stop id="stop3750-8-9-0" style="stop-color:#64baff;stop-opacity:1" offset="0" />
+      <stop id="stop3752-3-2-2" style="stop-color:#64baff;stop-opacity:1" offset="0.26238" />
+      <stop id="stop3754-7-2-2" style="stop-color:#3689e6;stop-opacity:1" offset="0.704952" />
+      <stop id="stop3756-9-3-05" style="stop-color:#0d52bf;stop-opacity:1" offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="12.145765"
-       cy="8.4497671"
-       r="19.99999"
-       fx="12.145765"
-       fy="8.4497671"
-       id="radialGradient12090"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-2-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.97196175,-1.0490213,-2.5079458e-8,20.86404,-16.6808)" />
-    <linearGradient
-       x1="24"
-       y1="39.474808"
-       x2="24"
-       y2="13.954866"
-       id="linearGradient12092"
-       xlink:href="#linearGradient3707-319-631-407-324-5-4-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6577143,0,0,0.70182188,-3.7851599,-15.2532)" />
+    <linearGradient y2="44.340794" x2="71.204407" y1="6.2375584" x1="71.204407" gradientTransform="matrix(0.5913016,0,0,0.57624522,-30.408105,-2.912613)" gradientUnits="userSpaceOnUse" id="linearGradient3540" xlink:href="#linearGradient4011-7" />
+    <radialGradient r="19.99999" fy="8.4497671" fx="1.1978998" cy="8.4497671" cx="1.1978998" gradientTransform="matrix(0,2.7334724,-2.9672427,-7.440091e-8,37.080617,-11.256041)" gradientUnits="userSpaceOnUse" id="radialGradient3543" xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-8" />
+    <radialGradient r="62.769119" fy="185.29727" fx="99.189415" cy="185.29727" cx="99.189415" gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)" gradientUnits="userSpaceOnUse" id="radialGradient3300-8" xlink:href="#linearGradient3966" />
+    <radialGradient r="62.769119" fy="185.29727" fx="99.189415" cy="185.29727" cx="99.189415" gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)" gradientUnits="userSpaceOnUse" id="radialGradient4192-6" xlink:href="#linearGradient3966" />
   </defs>
-  <metadata
-     id="metadata12099">
+  <metadata id="metadata12099">
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     transform="translate(0,8)"
-     id="layer1">
-    <path
-       d="m 11.99998,7.6796199 c -1.35513,0 -2.6960299,0.7054901 -3.2483299,1.3112801 L 11.99998,12.5 15.27983,9.02222 C 14.72753,8.38511 13.3551,7.6796199 11.99998,7.6796199 z m 0,-6.0930899 c -2.8334299,0 -5.3729899,1.12186 -7.4595699,2.83505 l 2.03095,2.1534799 C 7.9611201,5.5861899 10.12381,4.63307 11.91798,4.63307 c 1.83757,0 4.10323,0.9746599 5.51272,2.0077799 L 19.52314,4.38999 C 17.43657,2.6768 14.8334,1.58653 11.99998,1.58653 z m 0,-6.0930898 c -4.3752399,0 -8.3847499,1.6700198 -11.49997994,4.4521898 l 1.98707004,2.223 c 2.77795,-2.41964 5.7004,-3.62864 9.5129099,-3.62864 3.8125,0 6.64604,1.13864 9.55703,3.67762 l 1.94295,-2.27198 C 20.38472,-2.83654 16.37521,-4.5065598 11.99998,-4.5065598 z"
-       id="path4112-19-69-3-4"
-       style="color:#000000;fill:url(#radialGradient12090);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient12092);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 10.38947,9.19905 c 0.25236,-0.32736 0.81621,-0.41966 1.60666,-0.39632 0.79045,0.0233 1.50817,0.13755 1.69419,0.42274 l -1.64256,1.68404 z"
-       id="path4112-19-69-3-3-1"
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient6637);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.06;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="M 5.5808801,4.90188 C 7.4297601,3.37841 10.56269,2.48875 12.00564,2.5 c 1.44295,0.0107 4.6401,0.74221 6.47682,2.31735"
-       id="path4112-19-69-3-3-8-8"
-       style="opacity:0.4;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.06;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 1.6168601,0.34062 c 2.87106,-2.39368 6.37694,-3.8604098 10.0445399,-3.9062198 3.62694,-0.0411 7.76235,1.3079398 10.81087,3.9437998"
-       id="path4112-19-69-3-3-9-8"
-       style="opacity:0.4;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.06;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <g id="g4198-4" transform="matrix(0.39735974,0,0,0.39049423,-0.70747302,-0.99234621)" style="stroke-width:2.53863811">
+    <path d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" id="path3818-0-6" style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:2.53863811" />
+    <path style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:2.53863811" id="path4190-2" d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
+  </g>
+  <path d="m 12.008042,0.49214339 c -6.3453352,0 -11.50005978,5.02346721 -11.50005978,11.20723161 0,6.183764 5.15472458,11.207234 11.50005978,11.207232 6.345333,0 11.500064,-5.023468 11.500058,-11.207232 0,-6.1837644 -5.154725,-11.20723161 -11.500058,-11.20723161 z" id="path2555" style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3543);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;marker:none;enable-background:accumulate" />
+  <path d="m 22.947121,11.698997 c 0,5.887843 -4.897954,10.660915 -10.938941,10.660915 -6.0415418,0 -10.9392193,-4.773127 -10.9392193,-10.660915 0,-5.8875691 4.8976775,-10.6601583 10.9392193,-10.6601583 6.040987,0 10.938941,4.7725892 10.938941,10.6601583 z" id="path8655-4" style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3540);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path d="m 12.008042,0.49214324 c -6.3453352,0 -11.50005978,5.02346736 -11.50005978,11.20723176 0,6.183764 5.15472458,11.207234 11.50005978,11.207232 6.345333,0 11.500064,-5.023468 11.500058,-11.207232 0,-6.1837644 -5.154725,-11.20723176 -11.500058,-11.20723176 z" id="path2555-6-0" style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#00537d;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <g id="g2526-7" transform="matrix(0.93333333,0,0,0.98601649,-250.26666,351.13374)" style="fill:#002e99;fill-opacity:0.53333285;stroke-width:1.04241216">
+    <path id="path2524-5" style="color:#000000;overflow:visible;fill:#002e99;fill-opacity:0.53333285;stroke-width:1.04241216;marker:none" overflow="visible" d="m 281,-348 c -2.853,0 -5.468,1.111 -7.5,2.938 l 1.282,1.437 c 1.811,-1.588 3.732,-2.375 6.218,-2.375 2.487,0 4.32,0.74 6.22,2.406 l 1.28,-1.469 C 286.469,-346.889 283.854,-348 281,-348 Z m 0,4 c -1.847,0 -3.514,0.75 -4.875,1.875 l 1.344,1.406 c 0.907,-0.649 2.299,-1.281 3.469,-1.281 1.198,0 2.674,0.634 3.594,1.313 l 1.375,-1.47 C 284.546,-343.28 282.848,-344 281,-344 Z m 0,4 c -0.883,0 -1.764,0.477 -2.125,0.875 l 2.125,2.281 2.125,-2.281 C 282.765,-339.543 281.885,-340 281,-340 Z" />
+  </g>
+  <g id="g2526" transform="matrix(0.93333333,0,0,0.98601649,-250.26667,350.13374)" style="fill:#f5fcff;fill-opacity:1;stroke-width:1.04241216">
+    <path id="path2524" style="color:#000000;overflow:visible;fill:#f5fcff;fill-opacity:1;stroke-width:1.04241216;marker:none" overflow="visible" d="m 281,-348 c -2.853,0 -5.468,1.111 -7.5,2.938 l 1.282,1.437 c 1.811,-1.588 3.732,-2.375 6.218,-2.375 2.487,0 4.32,0.74 6.22,2.406 l 1.28,-1.469 C 286.469,-346.889 283.854,-348 281,-348 Z m 0,4 c -1.847,0 -3.514,0.75 -4.875,1.875 l 1.344,1.406 c 0.907,-0.649 2.299,-1.281 3.469,-1.281 1.198,0 2.674,0.634 3.594,1.313 l 1.375,-1.47 C 284.546,-343.28 282.848,-344 281,-344 Z m 0,4 c -0.883,0 -1.764,0.477 -2.125,0.875 l 2.125,2.281 2.125,-2.281 C 282.765,-339.543 281.885,-340 281,-340 Z" />
   </g>
 </svg>

--- a/devices/24/nm-device-wireless.svg
+++ b/devices/24/nm-device-wireless.svg
@@ -1,1 +1,1 @@
-../../devices/32/network-wireless.svg
+network-wireless.svg

--- a/devices/32/network-wireless.svg
+++ b/devices/32/network-wireless.svg
@@ -1,221 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg4286"
-   height="32"
-   width="32"
-   version="1.1"
-   sodipodi:docname="network-wireless.svg"
-   inkscape:version="0.92+devel (unknown)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     inkscape:document-rotation="0"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1600"
-     inkscape:window-height="837"
-     id="namedview42"
-     showgrid="false"
-     inkscape:zoom="14.6875"
-     inkscape:cx="16"
-     inkscape:cy="16"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4286" />
-  <defs
-     id="defs4288">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient853">
-      <stop
-         style="stop-color:#64baff;stop-opacity:1"
-         offset="0"
-         id="stop849" />
-      <stop
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="1"
-         id="stop851" />
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="32" height="32" id="svg4286">
+  <defs id="defs4288">
+    <linearGradient id="linearGradient3966">
+      <stop id="stop3968" style="stop-color:#000000;stop-opacity:1" offset="0" />
+      <stop id="stop3970" style="stop-color:#000000;stop-opacity:0" offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient5005">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop5007" />
-      <stop
-         offset="0.6069864"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop5009" />
-      <stop
-         offset="0.83456558"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop5011" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop5013" />
+    <linearGradient id="linearGradient4011-7">
+      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop4013-4" />
+      <stop offset="0.507761" style="stop-color:#ffffff;stop-opacity:0.23529412" id="stop4015-61" />
+      <stop offset="0.83456558" style="stop-color:#ffffff;stop-opacity:0.15686275" id="stop4017-2" />
+      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0.39215687" id="stop4019-2" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient4951">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4953" />
-      <stop
-         offset="0.27070504"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4955" />
-      <stop
-         offset="0.45041913"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4957" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4959" />
+    <linearGradient id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-8">
+      <stop id="stop3750-8-9-0" style="stop-color:#64baff;stop-opacity:1" offset="0" />
+      <stop id="stop3752-3-2-2" style="stop-color:#64baff;stop-opacity:1" offset="0.26238" />
+      <stop id="stop3754-7-2-2" style="stop-color:#3689e6;stop-opacity:1" offset="0.704952" />
+      <stop id="stop3756-9-3-05" style="stop-color:#0d52bf;stop-opacity:1" offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient4891">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4893" />
-      <stop
-         offset="0.66162539"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4895" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4899" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3966">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop3968" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop3970" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0.99937388,0,0,0.24590164,-7.6533136,17.648594)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3966"
-       id="radialGradient4284"
-       fy="44.129044"
-       fx="23.668133"
-       r="6.0999999"
-       cy="44.129044"
-       cx="23.668133" />
-    <linearGradient
-       x1="120.19312"
-       y1="24.809452"
-       x2="120.19312"
-       y2="28.251366"
-       id="linearGradient3012"
-       xlink:href="#linearGradient5005"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-71.777208,-1.712916)" />
-    <linearGradient
-       y2="19.708174"
-       x2="120.00706"
-       y1="16.029192"
-       x1="120.00706"
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-71.624914,-1.4590926)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4889"
-       xlink:href="#linearGradient4891" />
-    <linearGradient
-       y2="71.138969"
-       x2="137.01239"
-       y1="64.287117"
-       x1="137.01239"
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-83.982011,-23.912218)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4949"
-       xlink:href="#linearGradient4951" />
-    <radialGradient
-       gradientTransform="matrix(2.4412981,0,0,0.52195982,-41.780969,4.3994066)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3966"
-       id="radialGradient4284-8"
-       fy="44.129044"
-       fx="23.668133"
-       r="6.0999999"
-       cy="44.129044"
-       cx="23.668133" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient853"
-       id="linearGradient855"
-       x1="26.729849"
-       y1="5.5710273"
-       x2="26.729849"
-       y2="28.441809"
-       gradientUnits="userSpaceOnUse" />
+    <linearGradient y2="44.340794" x2="71.204407" y1="6.2375584" x1="71.204407" gradientTransform="matrix(0.74555346,0,0,0.74768093,-37.481175,-2.9192442)" gradientUnits="userSpaceOnUse" id="linearGradient3540" xlink:href="#linearGradient4011-7" />
+    <radialGradient r="19.99999" fy="8.4497671" fx="1.1978998" cy="8.4497671" cx="1.1978998" gradientTransform="matrix(0,3.5466935,-3.7413024,-9.6535537e-8,47.613217,-13.744882)" gradientUnits="userSpaceOnUse" id="radialGradient3543" xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-8" />
+    <radialGradient r="62.769119" fy="185.29727" fx="99.189415" cy="185.29727" cx="99.189415" gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)" gradientUnits="userSpaceOnUse" id="radialGradient3300-8" xlink:href="#linearGradient3966" />
+    <radialGradient r="62.769119" fy="185.29727" fx="99.189415" cy="185.29727" cx="99.189415" gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)" gradientUnits="userSpaceOnUse" id="radialGradient4192-6" xlink:href="#linearGradient3966" />
   </defs>
-  <metadata
-     id="metadata4291">
+  <metadata id="metadata4291">
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     d="m 30.891918,27.432994 a 14.891919,3.183955 0 0 1 -29.7838367,0 14.891919,3.183955 0 1 1 29.7838367,0 z"
-     id="path3964-9"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient4284-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-  <path
-     d="m 22.096181,28.499998 a 6.096181,1.5000001 0 0 1 -12.192362,0 6.096181,1.5000001 0 1 1 12.192362,0 z"
-     id="path3964"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4284);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-  <path
-     id="path4391"
-     d="M 16 5.5 C 10.117319 5.5 4.7256708 7.7912068 0.53710938 11.556641 L 3.9003906 15.242188 A 17.868883 17.868883 0 0 1 16 10.494141 A 17.868883 17.868883 0 0 1 28.101562 15.240234 L 31.462891 11.556641 C 27.274329 7.7912068 21.882681 5.5 16 5.5 z M 16 13.439453 A 14.924096 14.924096 0 0 0 5.8828125 17.414062 L 9.2734375 21.128906 A 9.8918657 9.8918657 0 0 1 16 18.472656 A 9.8918657 9.8918657 0 0 1 22.730469 21.126953 L 26.115234 17.416016 A 14.924096 14.924096 0 0 0 16 13.439453 z M 16 21.492188 A 6.8725262 6.8725262 0 0 0 11.302734 23.353516 L 16 28.5 L 20.693359 23.355469 A 6.8725262 6.8725262 0 0 0 16 21.492188 z "
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient855);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0" />
-  <path
-     id="path4710"
-     d="m 28.703568,13.12535 1.333495,-1.473375 C 26.122889,8.4046791 21.362877,6.5107817 16.060727,6.5107817 c -5.298746,0 -10.1501992,1.8739796 -14.0631022,5.1175093 l 1.3093901,1.479041"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4889);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path4706"
-     d="m 23.306392,18.984684 1.356262,-1.454222 c -2.395665,-2.005128 -5.452785,-3.089325 -8.651029,-3.089325 -3.184268,0 -6.011625,1.077371 -8.6632701,3.05327 l 1.3856203,1.521726"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3012);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path4171"
-     d="m 9.4021761,19.729934 c 1.5359089,-1.18085 4.1271819,-2.25479 6.5960599,-2.25479 2.518453,0 5.043041,0.8041 6.642701,2.230642"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.39215686;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path4706-6"
-     d="m 3.9893106,13.82291 c 3.67105,-2.977722 7.6837804,-4.3229456 12.0181504,-4.3229456 4.334369,0 8.216973,1.2344486 12.012291,4.3338526"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.39215686;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path5276"
-     d="m 15.998047,22.505859 c -1.074473,-0.0065 -2.270146,0.357557 -3.216744,0.972709 L 16,26.996094 19.223818,23.489547 C 18.264699,22.811206 17.07252,22.512403 15.998047,22.505859 Z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.35;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4949);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path4391-5"
-     d="M 16,5.5 C 10.117319,5.5 4.7256708,7.7912068 0.53710938,11.556641 L 3.9003906,15.242188 A 17.868883,17.868883 0 0 1 16,10.494141 17.868883,17.868883 0 0 1 28.101562,15.240234 l 3.361329,-3.683593 C 27.274329,7.7912068 21.882681,5.5 16,5.5 Z m 0,7.939453 A 14.924096,14.924096 0 0 0 5.8828125,17.414062 l 3.390625,3.714844 A 9.8918657,9.8918657 0 0 1 16,18.472656 a 9.8918657,9.8918657 0 0 1 6.730469,2.654297 l 3.384765,-3.710937 A 14.924096,14.924096 0 0 0 16,13.439453 Z m 0,8.052735 a 6.8725262,6.8725262 0 0 0 -4.697266,1.861328 L 16,28.5 20.693359,23.355469 A 6.8725262,6.8725262 0 0 0 16,21.492188 Z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;opacity:0.5;filter-blend-mode:normal;filter-gaussianBlur-deviation:0" />
+  <g style="stroke-width:1.98477566" transform="matrix(0.50101832,0,0,0.50666813,-0.03258883,-0.42768886)" id="g4198-4">
+    <path style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.98477566" id="path3818-0-6" d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+    <path d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" id="path4190-2" style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.98477566" />
+  </g>
+  <path style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3543);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" id="path2555" d="m 16.000002,1.4984435 c -8.0006328,0 -14.5000618,6.5179727 -14.5000618,14.5414365 0,8.023464 6.499429,14.54144 14.5000618,14.541437 8.000629,0 14.500066,-6.517973 14.500058,-14.541437 0,-8.0234638 -6.499429,-14.5414365 -14.500058,-14.5414365 z" />
+  <path style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3540);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path8655-4" d="m 29.79274,16.03939 c 0,7.639504 -6.175675,13.832588 -13.792565,13.832588 -7.6175883,0 -13.7929148,-6.193155 -13.7929148,-13.832588 0,-7.6391494 6.1753265,-13.8316067 13.7929148,-13.8316067 7.61689,0 13.792565,6.1924573 13.792565,13.8316067 z" />
+  <path style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#00537d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path2555-6-0" d="m 16.000002,1.4984433 c -8.0006328,0 -14.5000618,6.5179729 -14.5000618,14.5414367 0,8.023464 6.499429,14.54144 14.5000618,14.541437 8.000629,0 14.500066,-6.517973 14.500058,-14.541437 0,-8.0234638 -6.499429,-14.5414367 -14.500058,-14.5414367 z" />
+  <g style="fill:#002e99;fill-opacity:0.53333285;stroke-width:0.78725958" transform="matrix(1.2,0,0,1.3445679,-321.2,477.90963)" id="g2526-7">
+    <path d="m 281,-348 c -2.853,0 -5.468,1.111 -7.5,2.938 l 1.282,1.437 c 1.811,-1.588 3.732,-2.375 6.218,-2.375 2.487,0 4.32,0.74 6.22,2.406 l 1.28,-1.469 C 286.469,-346.889 283.854,-348 281,-348 Z m 0,4 c -1.847,0 -3.514,0.75 -4.875,1.875 l 1.344,1.406 c 0.907,-0.649 2.299,-1.281 3.469,-1.281 1.198,0 2.674,0.634 3.594,1.313 l 1.375,-1.47 C 284.546,-343.28 282.848,-344 281,-344 Z m 0,4 c -0.883,0 -1.764,0.477 -2.125,0.875 l 2.125,2.281 2.125,-2.281 C 282.765,-339.543 281.885,-340 281,-340 Z" overflow="visible" style="color:#000000;overflow:visible;fill:#002e99;fill-opacity:0.53333285;stroke-width:0.78725958;marker:none" id="path2524-5" />
+  </g>
+  <g style="fill:#f5fcff;fill-opacity:1;stroke-width:0.78725958" transform="matrix(1.2,0,0,1.3445679,-321.2,476.90963)" id="g2526">
+    <path d="m 281,-348 c -2.853,0 -5.468,1.111 -7.5,2.938 l 1.282,1.437 c 1.811,-1.588 3.732,-2.375 6.218,-2.375 2.487,0 4.32,0.74 6.22,2.406 l 1.28,-1.469 C 286.469,-346.889 283.854,-348 281,-348 Z m 0,4 c -1.847,0 -3.514,0.75 -4.875,1.875 l 1.344,1.406 c 0.907,-0.649 2.299,-1.281 3.469,-1.281 1.198,0 2.674,0.634 3.594,1.313 l 1.375,-1.47 C 284.546,-343.28 282.848,-344 281,-344 Z m 0,4 c -0.883,0 -1.764,0.477 -2.125,0.875 l 2.125,2.281 2.125,-2.281 C 282.765,-339.543 281.885,-340 281,-340 Z" overflow="visible" style="color:#000000;overflow:visible;fill:#f5fcff;fill-opacity:1;stroke-width:0.78725958;marker:none" id="path2524" />
+  </g>
 </svg>

--- a/devices/48/network-wireless.svg
+++ b/devices/48/network-wireless.svg
@@ -1,221 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg4286"
-   height="48"
-   width="48"
-   version="1.1"
-   sodipodi:docname="network-wireless.svg"
-   inkscape:version="0.92+devel (unknown)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     inkscape:document-rotation="0"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1600"
-     inkscape:window-height="837"
-     id="namedview42"
-     showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="24"
-     inkscape:cy="24"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4286" />
-  <defs
-     id="defs4288">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient853">
-      <stop
-         style="stop-color:#64baff;stop-opacity:1"
-         offset="0"
-         id="stop849" />
-      <stop
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="1"
-         id="stop851" />
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="48" height="48" id="svg4286">
+  <defs id="defs4288">
+    <linearGradient id="linearGradient3966">
+      <stop id="stop3968" style="stop-color:#000000;stop-opacity:1" offset="0" />
+      <stop id="stop3970" style="stop-color:#000000;stop-opacity:0" offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient5005">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop5007" />
-      <stop
-         offset="0.6069864"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop5009" />
-      <stop
-         offset="0.83456558"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop5011" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop5013" />
+    <linearGradient id="linearGradient4011-7">
+      <stop id="stop4013-4" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop4015-61" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.507761" />
+      <stop id="stop4017-2" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.83456558" />
+      <stop id="stop4019-2" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient4951">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4953" />
-      <stop
-         offset="0.27070504"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4955" />
-      <stop
-         offset="0.45041913"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4957" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4959" />
+    <linearGradient id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-8">
+      <stop offset="0" style="stop-color:#64baff;stop-opacity:1" id="stop3750-8-9-0" />
+      <stop offset="0.26238" style="stop-color:#64baff;stop-opacity:1" id="stop3752-3-2-2" />
+      <stop offset="0.704952" style="stop-color:#3689e6;stop-opacity:1" id="stop3754-7-2-2" />
+      <stop offset="1" style="stop-color:#0d52bf;stop-opacity:1" id="stop3756-9-3-05" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient4891">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4893" />
-      <stop
-         offset="0.66162539"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4895" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4899" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3966">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop3968" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop3970" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(1.3962496,0,0,0.46382834,-9.0466213,19.310077)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3966"
-       id="radialGradient4284"
-       fy="44.129044"
-       fx="23.668133"
-       r="6.0999999"
-       cy="44.129044"
-       cx="23.668133" />
-    <linearGradient
-       x1="120.19312"
-       y1="24.809452"
-       x2="120.19312"
-       y2="28.251366"
-       id="linearGradient3012"
-       xlink:href="#linearGradient5005"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0452457,0,0,1.0470044,-101.72983,-2.2518007)" />
-    <linearGradient
-       y2="19.708174"
-       x2="120.00706"
-       y1="16.029192"
-       x1="120.00706"
-       gradientTransform="matrix(1.0452457,0,0,1.0470044,-101.53858,-1.9206998)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4889"
-       xlink:href="#linearGradient4891" />
-    <linearGradient
-       y2="71.138969"
-       x2="137.01239"
-       y1="64.287117"
-       x1="137.01239"
-       gradientTransform="matrix(1.2047511,0,0,1.2161045,-141.05523,-44.754251)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4949"
-       xlink:href="#linearGradient4951" />
-    <radialGradient
-       gradientTransform="matrix(3.7102089,0,0,0.95427648,-63.813721,-3.4344993)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3966"
-       id="radialGradient4284-8"
-       fy="44.129044"
-       fx="23.668133"
-       r="6.0999999"
-       cy="44.129044"
-       cx="23.668133" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient853"
-       id="linearGradient855"
-       x1="23.999998"
-       y1="8.5001221"
-       x2="23.999998"
-       y2="41.341358"
-       gradientUnits="userSpaceOnUse" />
+    <linearGradient xlink:href="#linearGradient4011-7" id="linearGradient3540" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.054054,0,0,1.054054,-51.611004,-3.2279094)" x1="71.204407" y1="6.2375584" x2="71.204407" y2="44.340794" />
+    <radialGradient xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-8" id="radialGradient3543" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,5.0000024,-5.2894057,-1.3609237e-7,68.694364,-18.489509)" cx="1.1978998" cy="8.4497671" fx="1.1978998" fy="8.4497671" r="19.99999" />
+    <radialGradient xlink:href="#linearGradient3966" id="radialGradient3300-8" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)" cx="99.189415" cy="185.29727" fx="99.189415" fy="185.29727" r="62.769119" />
+    <radialGradient xlink:href="#linearGradient3966" id="radialGradient4192-6" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)" cx="99.189415" cy="185.29727" fx="99.189415" fy="185.29727" r="62.769119" />
   </defs>
-  <metadata
-     id="metadata4291">
+  <metadata id="metadata4291">
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     d="m 46.632275,38.676809 a 22.632276,5.8210869 0 0 1 -45.2645496,0 22.632276,5.8210869 0 1 1 45.2645496,0 z"
-     id="path3964-9"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient4284-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-  <path
-     d="m 32.517122,39.778376 a 8.517123,2.8293529 0 0 1 -17.034244,0 8.517123,2.8293529 0 1 1 17.034244,0 z"
-     id="path3964"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4284);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-  <path
-     id="path4391"
-     d="m 23.999999,8.500122 c -8.426197,0 -16.1490517,3.287385 -22.1486366,8.689968 l 4.8174753,5.287963 a 25.594918,25.637981 0 0 1 17.3311613,-6.81242 25.594918,25.637981 0 0 1 17.333959,6.809617 l 4.81468,-5.28516 C 40.149051,11.787507 32.426198,8.500122 23.999999,8.500122 Z m 0,11.391397 A 21.376883,21.412849 0 0 0 9.5084066,25.594223 l 4.8566424,5.329999 a 14.168848,14.192689 0 0 1 9.63495,-3.811146 14.168848,14.192689 0 0 1 9.640547,3.808342 l 4.848249,-5.32439 A 21.376883,21.412849 0 0 0 23.999999,19.891519 Z m 0,11.553933 a 9.8440257,9.860589 0 0 0 -6.728239,2.670602 l 6.728239,7.384092 6.722644,-7.381289 a 9.8440257,9.860589 0 0 0 -6.722644,-2.673405 z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient855);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path4710"
-     d="m 41.958314,20.32697 2.782119,-3.070423 c -5.606561,-4.659167 -12.666224,-7.7422 -20.680409,-7.7422 -8.014185,0 -15.0311687,2.970062 -20.7906268,7.76448 l 2.8038526,3.036356"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4889);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path4706"
-     d="m 34.240359,28.766927 2.828794,-3.099203 c -3.54401,-2.989449 -8.432367,-4.812735 -13.052581,-4.77179 -4.620214,0.04095 -9.22977,1.561567 -13.056048,4.790386 l 2.786454,3.104631"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3012);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path4171"
-     d="m 14.435965,29.519726 c 2.122636,-1.820854 5.960896,-3.403921 9.497252,-3.403921 4.26844,0 7.84943,1.871047 9.634386,3.390372"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.39215686;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path4706-6"
-     d="M 6.7755302,21.046509 C 12.033846,16.774123 17.79564,14.6471 24.004077,14.6471 c 6.208437,0 11.811974,1.954019 17.248286,6.400993"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.39215686;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path5276"
-     d="m 24.00736,32.391042 c -2.247082,-0.01377 -4.045093,0.783489 -5.365445,1.808648 l 5.368668,5.885456 5.345841,-5.867161 c -1.380127,-1.060108 -3.101981,-1.81317 -5.349064,-1.826943 z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.35;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4949);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="path4391-5"
-     d="m 23.999999,8.500122 c -8.426197,0 -16.1490513,3.287385 -22.1486364,8.689968 l 4.8174754,5.287963 a 25.594918,25.637982 0 0 1 17.331161,-6.81242 25.594918,25.637982 0 0 1 17.33396,6.809617 l 4.814678,-5.28516 C 40.149052,11.787507 32.426198,8.500122 23.999999,8.500122 Z m 0,11.391397 A 21.376882,21.412849 0 0 0 9.508407,25.594223 l 4.856642,5.329998 a 14.168849,14.192689 0 0 1 9.63495,-3.811145 14.168849,14.192689 0 0 1 9.640546,3.808342 l 4.84825,-5.324391 A 21.376882,21.412849 0 0 0 23.999999,19.891519 Z m 0,11.553933 a 9.8440257,9.860589 0 0 0 -6.72824,2.670601 l 6.72824,7.384093 6.722646,-7.381289 a 9.8440257,9.860589 0 0 0 -6.722646,-2.673405 z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g style="stroke-width:1.40587306" transform="matrix(0.70833333,0,0,0.71428273,1.33333,0.28459677)" id="g4198-4">
+    <path style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587306" id="path3818-0-6" d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+    <path d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" id="path4190-2" style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587306" />
+  </g>
+  <path style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3543);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" id="path2555" d="M 24.000003,2.9999897 C 12.68881,2.9999897 3.5,12.188796 3.5,23.49999 3.5,34.811184 12.68881,43.999995 24.000003,43.999992 35.311191,43.999992 44.500011,34.811184 44.5,23.49999 44.5,12.188796 35.311191,2.9999897 24.000003,2.9999897 Z" />
+  <path style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3540);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path8655-4" d="M 43.5,23.4993 C 43.5,34.2692 34.76891,42.99999 24.000247,42.99999 13.230598,42.99999 4.5,34.269101 4.5,23.4993 4.5,12.729898 13.230598,3.9999917 24.000247,3.9999917 34.76891,3.9999917 43.5,12.729898 43.5,23.4993 Z" />
+  <path style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#00537d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path2555-6-0" d="M 24.000003,2.9999895 C 12.68881,2.9999895 3.5,12.188796 3.5,23.49999 3.5,34.811184 12.68881,43.999995 24.000003,43.999992 35.311191,43.999992 44.500011,34.811184 44.5,23.49999 44.5,12.188796 35.311191,2.9999895 24.000003,2.9999895 Z" />
+  <g style="fill:#002e99;fill-opacity:0.53333285;stroke-width:0.55360955" transform="matrix(1.7333333,0,0,1.8823951,-463.06667,669.5735)" id="g2526-7">
+    <path d="m 281,-348 c -2.853,0 -5.468,1.111 -7.5,2.938 l 1.282,1.437 c 1.811,-1.588 3.732,-2.375 6.218,-2.375 2.487,0 4.32,0.74 6.22,2.406 l 1.28,-1.469 C 286.469,-346.889 283.854,-348 281,-348 Z m 0,4 c -1.847,0 -3.514,0.75 -4.875,1.875 l 1.344,1.406 c 0.907,-0.649 2.299,-1.281 3.469,-1.281 1.198,0 2.674,0.634 3.594,1.313 l 1.375,-1.47 C 284.546,-343.28 282.848,-344 281,-344 Z m 0,4 c -0.883,0 -1.764,0.477 -2.125,0.875 l 2.125,2.281 2.125,-2.281 C 282.765,-339.543 281.885,-340 281,-340 Z" overflow="visible" style="color:#000000;overflow:visible;fill:#002e99;fill-opacity:0.53333285;stroke-width:0.55360955;marker:none" id="path2524-5" />
+  </g>
+  <g style="fill:#f5fcff;fill-opacity:1;stroke-width:0.55360955" transform="matrix(1.7333333,0,0,1.8823951,-463.06668,669.0735)" id="g2526">
+    <path d="m 281,-348 c -2.853,0 -5.468,1.111 -7.5,2.938 l 1.282,1.437 c 1.811,-1.588 3.732,-2.375 6.218,-2.375 2.487,0 4.32,0.74 6.22,2.406 l 1.28,-1.469 C 286.469,-346.889 283.854,-348 281,-348 Z m 0,4 c -1.847,0 -3.514,0.75 -4.875,1.875 l 1.344,1.406 c 0.907,-0.649 2.299,-1.281 3.469,-1.281 1.198,0 2.674,0.634 3.594,1.313 l 1.375,-1.47 C 284.546,-343.28 282.848,-344 281,-344 Z m 0,4 c -0.883,0 -1.764,0.477 -2.125,0.875 l 2.125,2.281 2.125,-2.281 C 282.765,-339.543 281.885,-340 281,-340 Z" overflow="visible" style="color:#000000;overflow:visible;fill:#f5fcff;fill-opacity:1;stroke-width:0.55360955;marker:none" id="path2524" />
+  </g>
 </svg>


### PR DESCRIPTION
Remade the network Wi-Fi icons to make them cohesive with other network icons in the plug, as well as updating it to look more in-line with the newly made icons & palette.

In action:
![screenshot from 2018-09-25 09 44 19](https://user-images.githubusercontent.com/4886639/46015385-8b5d8200-c0a8-11e8-9318-fea160a78fff.png)
