### PR TITLE
README: add links to the color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you feel the desire to compensate the artists who maintain these icons for yo
 ## Contributing Icons
 It is recommended to use the free and open source [Inkscape](http://inkscape.org) vector editor to create elementary icons. Any and all icons must follow the elementary [Icon Design Guidelines](http://elementary.io/docs/human-interface-guidelines#iconography).
 
-An elementary color palette is provided, it is recommended to copy it into your Inkscape settings before you get started.
+An [elementary color palette](elementary.gpl) ([rendered version](https://elementary.io/docs/human-interface-guidelines#color)) is provided; it is recommended to copy it into your Inkscape settings before you get started.
 
 ```bash
 cp elementary.gpl ~/.config/inkscape/palettes/


### PR DESCRIPTION
For convenience :)

If this change is welcome, I'll also add the same links in CONTRIBUTING.md (although perhaps it would be better to remove that file since it pretty much duplicates the README?)