### PR TITLE
Make new colored icons for print preview

### DIFF
--- a/actions/24/document-print-preview.svg
+++ b/actions/24/document-print-preview.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.1" width="24" height="24" id="svg3828" sodipodi:docname="document-print-preview.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview92" showgrid="false" inkscape:zoom="16" inkscape:cx="7.2998556" inkscape:cy="6.6194628" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3828">
+    <inkscape:grid type="xygrid" id="grid899" />
+  </sodipodi:namedview>
+  <defs id="defs3830">
+    <linearGradient id="linearGradient3958">
+      <stop style="stop-color:#e8efff;stop-opacity:1;" offset="0" id="stop3960" />
+      <stop style="stop-color:#1166c9;stop-opacity:1;" offset="1" id="stop3963" />
+    </linearGradient>
+    <linearGradient id="linearGradient3916">
+      <stop style="stop-color:#232323;stop-opacity:1;" offset="0" id="stop3918" />
+      <stop id="stop3926" offset="0.80000001" style="stop-color:#535353;stop-opacity:1;" />
+      <stop id="stop3924" offset="0.80000001" style="stop-color:#676767;stop-opacity:1;" />
+      <stop style="stop-color:#676767;stop-opacity:1;" offset="1" id="stop3920" />
+    </linearGradient>
+    <linearGradient id="linearGradient3801">
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop3803" />
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop3805" />
+    </linearGradient>
+    <linearGradient id="linearGradient3977">
+      <stop id="stop3979" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop3981" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.03626217" />
+      <stop id="stop3983" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.95056331" />
+      <stop id="stop3985" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    </linearGradient>
+    <linearGradient id="linearGradient3600-4">
+      <stop id="stop3602-7" style="stop-color:#f4f4f4;stop-opacity:1" offset="0" />
+      <stop id="stop3604-6" style="stop-color:#dbdbdb;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="23.99999" y1="5.5641499" x2="23.99999" y2="43" id="linearGradient3000" xlink:href="#linearGradient3977" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.40540511,0,0,0.51351253,1.2696879,-1.32431)" />
+    <linearGradient x1="25.132275" y1="0.98520643" x2="25.132275" y2="47.013336" id="linearGradient3003" xlink:href="#linearGradient3988-5" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.48571543,0,0,-0.45629579,-0.6571703,22.651132)" />
+    <linearGradient xlink:href="#linearGradient3988-5" id="linearGradient3158" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)" x1="144.00006" y1="280.00018" x2="144.00006" y2="40.000172" />
+    <linearGradient id="linearGradient3988-5">
+      <stop style="stop-color:#ededed;stop-opacity:1;" offset="0" id="stop3990-5" />
+      <stop style="stop-color:#fafafa;stop-opacity:1;" offset="1" id="stop3992-0" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3801" id="linearGradient3807" x1="10" y1="0" x2="10" y2="22" gradientUnits="userSpaceOnUse" />
+    <radialGradient xlink:href="#linearGradient6557" id="radialGradient3981" gradientUnits="userSpaceOnUse" cx="311.46875" cy="828.53125" fx="311.46875" fy="828.53125" r="3.28125" />
+    <linearGradient id="linearGradient6557">
+      <stop style="stop-color:#fce94f;stop-opacity:1;" offset="0" id="stop6559" />
+      <stop id="stop6565" offset="0.67301035" style="stop-color:#fce94f;stop-opacity:1" />
+      <stop style="stop-color:#fce94f;stop-opacity:0;" offset="1" id="stop6561" />
+    </linearGradient>
+    <linearGradient id="linearGradient6620">
+      <stop id="stop6622" offset="0" style="stop-color:#ffffff;stop-opacity:1" />
+      <stop style="stop-color:#ffffff;stop-opacity:1" offset="0.32992947" id="stop6624" />
+      <stop id="stop6626" offset="1" style="stop-color:#fce94f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="linearGradient3952">
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop3954" />
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop3956" />
+    </linearGradient>
+    <linearGradient id="linearGradient3944">
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop3946" />
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop3948" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3960" id="linearGradient3051" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.1428571,0,0,1,-11.857143,2)" x1="25" y1="45" x2="25" y2="42" />
+    <linearGradient id="linearGradient3960">
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="0" id="stop3962" />
+      <stop id="stop3970" offset="0.5" style="stop-color:#000000;stop-opacity:1;" />
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop3964" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3960" id="linearGradient3320" gradientUnits="userSpaceOnUse" gradientTransform="translate(-9,-23)" x1="25" y1="45" x2="25" y2="42" />
+    <radialGradient xlink:href="#linearGradient3944" id="radialGradient3323" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-5,-12.125)" cx="9" cy="43.5" fx="9" fy="43.5" r="2" />
+    <radialGradient xlink:href="#linearGradient3952" id="radialGradient3326" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-22,-12.125)" cx="40" cy="43.5" fx="40" fy="43.5" r="2" />
+    <linearGradient xlink:href="#linearGradient3960" id="linearGradient4262" gradientUnits="userSpaceOnUse" gradientTransform="translate(-9,-23)" x1="25" y1="45" x2="25" y2="42" />
+    <radialGradient xlink:href="#linearGradient3944" id="radialGradient4265" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-3,-12.125)" cx="9" cy="43.5" fx="9" fy="43.5" r="2" />
+    <radialGradient xlink:href="#linearGradient3952" id="radialGradient4268" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-22,-12.125)" cx="40" cy="43.5" fx="40" fy="43.5" r="2" />
+    <radialGradient xlink:href="#linearGradient3952" id="radialGradient4295" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-22,-12.125)" cx="40" cy="43.5" fx="40" fy="43.5" r="2" />
+    <radialGradient xlink:href="#linearGradient3944" id="radialGradient4297" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-3,-12.125)" cx="9" cy="43.5" fx="9" fy="43.5" r="2" />
+    <linearGradient xlink:href="#linearGradient3960" id="linearGradient4299" gradientUnits="userSpaceOnUse" gradientTransform="translate(-9,-23)" x1="25" y1="45" x2="25" y2="42" />
+    <linearGradient xlink:href="#linearGradient3988-5" id="linearGradient4301" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.48571543,0,0,-0.45629579,-0.6571703,22.651132)" x1="25.132275" y1="0.98520643" x2="25.132275" y2="47.013336" />
+    <linearGradient xlink:href="#linearGradient3801" id="linearGradient4303" gradientUnits="userSpaceOnUse" x1="10" y1="0" x2="10" y2="22" />
+    <radialGradient xlink:href="#linearGradient3952" id="radialGradient4305" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-22,-12.125)" cx="40" cy="43.5" fx="40" fy="43.5" r="2" />
+    <radialGradient xlink:href="#linearGradient3944" id="radialGradient4307" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-3,-12.125)" cx="9" cy="43.5" fx="9" fy="43.5" r="2" />
+    <linearGradient xlink:href="#linearGradient3960" id="linearGradient4309" gradientUnits="userSpaceOnUse" gradientTransform="translate(-9,-23)" x1="25" y1="45" x2="25" y2="42" />
+    <linearGradient xlink:href="#linearGradient3988-5" id="linearGradient4311" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.48571543,0,0,-0.45629579,-0.6571703,22.651132)" x1="25.132275" y1="0.98520643" x2="25.132275" y2="47.013336" />
+    <linearGradient xlink:href="#linearGradient3801" id="linearGradient4313" gradientUnits="userSpaceOnUse" x1="10" y1="0" x2="10" y2="22" />
+    <linearGradient xlink:href="#linearGradient3801" id="linearGradient4333" gradientUnits="userSpaceOnUse" x1="10" y1="0" x2="10" y2="22" gradientTransform="translate(-3,-2)" />
+    <linearGradient xlink:href="#linearGradient3988-5" id="linearGradient4338" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.48571543,0,0,-0.45629579,-3.6571703,20.651132)" x1="25.132275" y1="0.98520643" x2="25.132275" y2="47.013336" />
+    <linearGradient xlink:href="#linearGradient3960" id="linearGradient4341" gradientUnits="userSpaceOnUse" gradientTransform="translate(-12,-25)" x1="25" y1="45" x2="25" y2="42" />
+    <radialGradient xlink:href="#linearGradient3944" id="radialGradient4344" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-6,-14.125)" cx="9" cy="43.5" fx="9" fy="43.5" r="2" />
+    <radialGradient xlink:href="#linearGradient3952" id="radialGradient4347" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.75,-25,-14.125)" cx="40" cy="43.5" fx="40" fy="43.5" r="2" />
+    <linearGradient xlink:href="#linearGradient3801" id="linearGradient3129" gradientUnits="userSpaceOnUse" gradientTransform="translate(0,-5)" x1="10" y1="0" x2="10" y2="22" />
+    <linearGradient xlink:href="#linearGradient3988-5" id="linearGradient3134" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.48571543,0,0,-0.25856743,-0.6571703,10.218952)" x1="25.132275" y1="0.98520643" x2="25.132275" y2="47.013336" />
+    <linearGradient xlink:href="#linearGradient3916" id="linearGradient3922" x1="11" y1="19" x2="11" y2="9" gradientUnits="userSpaceOnUse" gradientTransform="translate(1,-1)" />
+    <linearGradient xlink:href="#linearGradient3988-5" id="linearGradient4032" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.48571543,0,0,-0.25856743,-0.6571312,24.718969)" x1="25.132275" y1="0.98520643" x2="25.132275" y2="47.013336" />
+  </defs>
+  <metadata id="metadata3833">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g id="layer1" style="display:inline" transform="translate(0,2)">
+    <path id="path4291" d="m 6,1 0,1 c 4.157995,7.52e-5 11.292656,-7.52e-5 12,0 l 0,-1 c -0.707344,-7.52e-5 -7.842005,7.52e-5 -12,0 z" style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;display:inline" />
+    <path id="path4293" d="M 6,1 6,15 18,15 18,1 z M 7,2 17,2 17,14 7,14 z" style="opacity:0.4;fill:url(#linearGradient3129);fill-opacity:1" />
+    <path style="fill:url(#linearGradient3922);fill-opacity:1;stroke:none" d="m 4.78125,7.5 -0.125,0.15625 -2,2 L 2.5,9.78125 2.5,10 l 0,7 0,0.5 0.5,0 18,0 0.5,0 0,-0.5 0,-7 0,-0.21875 -0.15625,-0.125 -2,-2 L 19.21875,7.5 19,7.5 5,7.5 z" id="rect3145" />
+    <path id="path3935" d="m 4.78125,7.5 -0.125,0.15625 -2,2 L 2.5,9.78125 2.5,10 l 0,7 0,0.5 0.5,0 18,0 0.5,0 0,-0.5 0,-7 0,-0.21875 -0.15625,-0.125 -2,-2 L 19.21875,7.5 19,7.5 5,7.5 z" style="opacity:0.70999995;fill:none;stroke:#000000;stroke-opacity:1" />
+    <path style="fill:url(#linearGradient3134);fill-opacity:1;stroke:none;display:inline" id="path4287" d="M 5.4999609,9 C 9.3955418,9 18.50002,8.9992064 18.50002,8.9992064 l 2.1e-5,-8.4992434 c 0,0 -7.333386,0 -13.0000801,0 0,3.9666667 0,4.5333346 0,8.5000021 z" />
+    <rect style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none" id="rect3937" width="18" height="1" x="3" y="10" />
+    <path style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.41000001;color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" d="M 5.34375,0 A 0.50001093,0.50001093 0 0 0 5,0.5 L 5,7 6,7 6,1 c 3.9461392,9.56e-5 11.37307,-9.56e-5 12,0 l 0,6 1,0 0,-6.5 A 0.50001093,0.50001093 0 0 0 18.5,0 L 5.5,0 A 0.50001093,0.50001093 0 0 0 5.40625,0 0.50001093,0.50001093 0 0 0 5.34375,0 z" id="path4289" />
+    <rect style="opacity:0.4;fill:#000000;fill-opacity:1;stroke:none" id="rect3948" width="13" height="1" x="5.5" y="9" />
+    <rect style="fill:#505050;fill-opacity:1;stroke:none" id="rect3950" width="14" height="1" x="5" y="-16" transform="scale(1,-1)" />
+    <rect style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none" id="rect3952" width="12" height="1" x="6" y="14" />
+    <rect y="16" x="5" height="1" width="14" id="rect3954" style="opacity:0.4;fill:#000000;fill-opacity:1;stroke:none" />
+    <path d="m 19,19.5 -0.49992,-4.50002 c 0,0 -7.333386,0 -13.00008,0 L 5,19.5 z" id="path4030" style="fill:url(#linearGradient4032);fill-opacity:1;stroke:none;display:inline" />
+    <path style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.61000001;color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" d="m 5,14.875 -0.5,4.5 C 4.4225572,19.67445 4.6908541,20.009821 5,20 l 14,0 c 0.309146,0.0098 0.577443,-0.32555 0.5,-0.625 l -0.5,-4.5 0,0.125 -0.90625,0 0,0.5 0,0 0.25,3.5 -0.25,0 0,0.03125 L 7,19.03125 7,19 l -1.34375,0 0.25,-3.5 0,0 0,-0.5 L 5,15 z" id="path4034" />
+    <rect style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none" id="rect4046" width="9" height="1" x="7" y="16" />
+  </g>
+  <g id="layer2" transform="translate(0,2)" />
+  <path inkscape:connector-curvature="0" style="display:inline;fill:#1a1a1a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" id="path3220" d="m 18.059092,15.538027 c -0.05196,0.02159 -0.10096,0.05148 -0.145102,0.08852 l -0.877041,0.617836 c -0.133428,0.08765 -0.227006,0.22977 -0.25477,0.386927 -0.02776,0.157157 0.01324,0.312631 0.111642,0.423282 l 5.307086,5.790109 c 0.09142,0.105822 0.225514,0.162049 0.368811,0.154646 0.143297,-0.0074 0.282269,-0.07774 0.38222,-0.193447 l 0.90914,-1.051287 c 0.185999,-0.219769 0.18513,-0.537725 -0.002,-0.721685 L 18.519917,15.676274 C 18.407175,15.547627 18.232686,15.49528 18.059092,15.538027 Z" />
+  <path inkscape:connector-curvature="0" style="fill:#fafafa;fill-opacity:0.53333321;fill-rule:evenodd;stroke:#1a1a1a;stroke-width:1.88733149;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path2447" d="m 19.056334,13 c 0,2.240252 -1.816082,4.056334 -4.056335,4.056334 -2.240251,0 -4.056333,-1.816082 -4.056333,-4.056334 0,-2.240252 1.816082,-4.0563349 4.056333,-4.0563349 2.240253,0 4.056335,1.8160829 4.056335,4.0563349 z" />
+</svg>

--- a/actions/32/document-print-preview.svg
+++ b/actions/32/document-print-preview.svg
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.1" width="32" height="32" id="svg4151" sodipodi:docname="document-print-preview.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview132" showgrid="false" inkscape:zoom="22.627417" inkscape:cx="13.792354" inkscape:cy="9.2289082" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg4151">
+    <inkscape:grid type="xygrid" id="grid1282" />
+  </sodipodi:namedview>
+  <defs id="defs4153">
+    <linearGradient id="linearGradient4251">
+      <stop id="stop4253" style="stop-color:#000000;stop-opacity:1" offset="0" />
+      <stop id="stop4255" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient x1="20" y1="26.000008" x2="20" y2="13.000008" id="linearGradient4045" xlink:href="#linearGradient3680-6-6-6-3-7-4" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.66257291,0,0,0.66257291,0.5523975,1.3766086)" />
+    <linearGradient id="linearGradient3680-6-6-6-3-7-4">
+      <stop id="stop3682-4-6-1-3-7-5" style="stop-color:#dcdcdc;stop-opacity:1" offset="0" />
+      <stop id="stop3684-8-5-8-0-2-3" style="stop-color:#ffffff;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="23.99999" y1="4.999989" x2="23.99999" y2="43" id="linearGradient3174" xlink:href="#linearGradient3924-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.62162164,0,0,0.62162164,1.0810794,2.0810903)" />
+    <linearGradient id="linearGradient3924-0">
+      <stop id="stop3926-6" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop3928-3" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.06316455" />
+      <stop id="stop3930-2" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.95056331" />
+      <stop id="stop3932-62" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    </linearGradient>
+    <radialGradient cx="7.1183534" cy="9.9571075" r="12.671875" fx="7.1183534" fy="9.9571075" id="radialGradient4019" xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,5.8591313,-7.1931417,0,88.15562,-48.953545)" />
+    <linearGradient id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
+      <stop id="stop3750-1-0-7-6-6-1-3-9-3" style="stop-color:#505050;stop-opacity:1" offset="0" />
+      <stop id="stop3752-3-7-4-0-32-8-923-0-7" style="stop-color:#2b2b2b;stop-opacity:1" offset="0.26238" />
+      <stop id="stop3754-1-8-5-2-7-6-7-1-9" style="stop-color:#0a0a0a;stop-opacity:1" offset="0.704952" />
+      <stop id="stop3756-1-6-2-6-6-1-96-6-0" style="stop-color:#000000;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <radialGradient cx="4.9929786" cy="43.5" r="2.5" fx="4.9929786" fy="43.5" id="radialGradient2976" xlink:href="#linearGradient3688-166-749-6" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient id="linearGradient3688-166-749-6">
+      <stop id="stop2883-8" style="stop-color:#181818;stop-opacity:1" offset="0" />
+      <stop id="stop2885-3" style="stop-color:#181818;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <radialGradient cx="4.9929786" cy="43.5" r="2.5" fx="4.9929786" fy="43.5" id="radialGradient2978" xlink:href="#linearGradient3688-464-309-7" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient id="linearGradient3688-464-309-7">
+      <stop id="stop2889-0" style="stop-color:#181818;stop-opacity:1" offset="0" />
+      <stop id="stop2891-66" style="stop-color:#181818;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient x1="25.058096" y1="47.027729" x2="25.058096" y2="39.999443" id="linearGradient2980" xlink:href="#linearGradient3702-501-757-3" gradientUnits="userSpaceOnUse" />
+    <linearGradient id="linearGradient3702-501-757-3">
+      <stop id="stop2895-3" style="stop-color:#181818;stop-opacity:0" offset="0" />
+      <stop id="stop2897-28" style="stop-color:#181818;stop-opacity:1" offset="0.5" />
+      <stop id="stop2899-8" style="stop-color:#181818;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient x1="23.99999" y1="4.999989" x2="23.99999" y2="43" id="linearGradient3043" xlink:href="#linearGradient3924-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.72972973,0,0,0.29729729,-1.5135153,13.864869)" />
+    <linearGradient id="linearGradient5048">
+      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
+      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
+      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient id="linearGradient5060">
+      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
+      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient id="linearGradient3600-4">
+      <stop id="stop3602-7" style="stop-color:#f4f4f4;stop-opacity:1" offset="0" />
+      <stop id="stop3604-6" style="stop-color:#dbdbdb;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient id="linearGradient3977">
+      <stop id="stop3979" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop3981" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.03626217" />
+      <stop id="stop3983" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.95056331" />
+      <stop id="stop3985" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    </linearGradient>
+    <linearGradient x1="23.99999" y1="5.5641499" x2="23.99999" y2="43" id="linearGradient4059" xlink:href="#linearGradient3977" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.45945946,0,0,0.72972971,4.9729758,-0.5135062)" />
+    <linearGradient x1="33.210621" y1="46.353771" x2="33.210621" y2="11.28877" id="linearGradient4062" xlink:href="#linearGradient3600-4" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.54285587,0,0,0.22814772,2.971419,20.424493)" />
+    <linearGradient x1="23.99999" y1="5.5641499" x2="23.99999" y2="43" id="linearGradient4059-4" xlink:href="#linearGradient3977-6" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.45945946,0,0,0.72972971,4.9729758,0.4865328)" />
+    <linearGradient id="linearGradient3977-6">
+      <stop id="stop3979-5" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop3981-9" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.03626217" />
+      <stop id="stop3983-2" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.95056331" />
+      <stop id="stop3985-4" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    </linearGradient>
+    <linearGradient x1="25.132275" y1="0.98520643" x2="25.132275" y2="47.013336" id="linearGradient4062-6" xlink:href="#linearGradient3600-4-3" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.54285587,0,0,0.63012397,2.971419,0.9103523)" />
+    <linearGradient id="linearGradient3600-4-3">
+      <stop id="stop3602-7-9" style="stop-color:#f4f4f4;stop-opacity:1" offset="0" />
+      <stop id="stop3604-6-6" style="stop-color:#dbdbdb;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="25.132275" y1="0.98520643" x2="25.132275" y2="62.706093" id="linearGradient4087" xlink:href="#linearGradient3600-4-3" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.54285587,0,0,0.14123431,2.971419,3.1437485)" />
+    <linearGradient x1="23.99999" y1="4.999989" x2="23.99999" y2="43" id="linearGradient3043-2" xlink:href="#linearGradient3924-0-9" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.72972973,0,0,0.32432432,-1.5135153,13.716219)" />
+    <linearGradient id="linearGradient3924-0-9">
+      <stop id="stop3926-6-0" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop3928-3-5" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.06316455" />
+      <stop id="stop3930-2-1" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.95056331" />
+      <stop id="stop3932-62-5" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    </linearGradient>
+    <linearGradient x1="23.99999" y1="11.666668" x2="23.99999" y2="36.333336" id="linearGradient4247" xlink:href="#linearGradient3924-0-9" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.72972973,0,0,0.08108108,-1.5135153,10.054054)" />
+    <linearGradient x1="17" y1="14" x2="17" y2="10" id="linearGradient4257" xlink:href="#linearGradient4251" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,1.3333333,0,-4.333333)" />
+    <linearGradient id="linearGradient3680-6-6-6-3-7-4-4">
+      <stop id="stop3682-4-6-1-3-7-5-0" style="stop-color:#dcdcdc;stop-opacity:1" offset="0" />
+      <stop id="stop3684-8-5-8-0-2-3-6" style="stop-color:#ffffff;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="54.596001" y1="42.034893" x2="54.596001" y2="9.693037" id="linearGradient3024-0" xlink:href="#linearGradient3680-6-6-6-3-7-4-4" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.66257291,0,0,0.66257291,-25.726932,1.3766086)" />
+    <radialGradient cx="7.1183534" cy="9.9571075" r="12.671875" fx="7.1183534" fy="9.9571075" id="radialGradient3033" xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-9" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,5.8591313,-8.3440444,0,99.700519,-48.953545)" />
+    <linearGradient x1="23.99999" y1="4.999989" x2="23.99999" y2="43" id="linearGradient3030" xlink:href="#linearGradient3924-0-8" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.72972972,0,0,0.62162164,-1.5135153,2.0810903)" />
+    <linearGradient id="linearGradient3702-501-757-3-4">
+      <stop id="stop2895-3-1" style="stop-color:#181818;stop-opacity:0" offset="0" />
+      <stop id="stop2897-28-8" style="stop-color:#181818;stop-opacity:1" offset="0.5" />
+      <stop id="stop2899-8-6" style="stop-color:#181818;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient x1="25.058096" y1="47.027729" x2="25.058096" y2="39.999443" id="linearGradient2980-4" xlink:href="#linearGradient3702-501-757-3-4" gradientUnits="userSpaceOnUse" />
+    <linearGradient id="linearGradient3688-464-309-7-6">
+      <stop id="stop2889-0-5" style="stop-color:#181818;stop-opacity:1" offset="0" />
+      <stop id="stop2891-66-6" style="stop-color:#181818;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <radialGradient cx="4.9929786" cy="43.5" r="2.5" fx="4.9929786" fy="43.5" id="radialGradient2978-5" xlink:href="#linearGradient3688-464-309-7-6" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient id="linearGradient3688-166-749-6-0">
+      <stop id="stop2883-8-4" style="stop-color:#181818;stop-opacity:1" offset="0" />
+      <stop id="stop2885-3-8" style="stop-color:#181818;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <radialGradient cx="4.9929786" cy="43.5" r="2.5" fx="4.9929786" fy="43.5" id="radialGradient2976-0" xlink:href="#linearGradient3688-166-749-6-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-9">
+      <stop id="stop3750-1-0-7-6-6-1-3-9-3-3" style="stop-color:#505050;stop-opacity:1" offset="0" />
+      <stop id="stop3752-3-7-4-0-32-8-923-0-7-1" style="stop-color:#2b2b2b;stop-opacity:1" offset="0.26238" />
+      <stop id="stop3754-1-8-5-2-7-6-7-1-9-8" style="stop-color:#0a0a0a;stop-opacity:1" offset="0.704952" />
+      <stop id="stop3756-1-6-2-6-6-1-96-6-0-0" style="stop-color:#000000;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient id="linearGradient3924-0-8">
+      <stop id="stop3926-6-2" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop3928-3-2" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.06316455" />
+      <stop id="stop3930-2-8" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.95056331" />
+      <stop id="stop3932-62-55" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    </linearGradient>
+    <linearGradient x1="23.99999" y1="4.999989" x2="23.99999" y2="43" id="linearGradient4392" xlink:href="#linearGradient3924-0-8" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.72972972,0,0,0.62162164,-34.333444,5.29499)" />
+    <radialGradient cx="7.1183534" cy="9.9571075" r="12.671875" fx="7.1183534" fy="9.9571075" id="radialGradient4396" xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-9" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,5.8591313,-8.3440444,0,99.355433,-44.574628)" />
+    <radialGradient cx="7.1183534" cy="9.9571075" r="12.671875" fx="7.1183534" fy="9.9571075" id="radialGradient4396-4" xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-9-4" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,5.8591313,-8.3440444,0,99.355433,-44.574628)" />
+    <linearGradient id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-9-4">
+      <stop id="stop3750-1-0-7-6-6-1-3-9-3-3-3" style="stop-color:#505050;stop-opacity:1" offset="0" />
+      <stop id="stop3752-3-7-4-0-32-8-923-0-7-1-1" style="stop-color:#2b2b2b;stop-opacity:1" offset="0.26238" />
+      <stop id="stop3754-1-8-5-2-7-6-7-1-9-8-6" style="stop-color:#0a0a0a;stop-opacity:1" offset="0.704952" />
+      <stop id="stop3756-1-6-2-6-6-1-96-6-0-0-6" style="stop-color:#000000;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <radialGradient cx="7.1183534" cy="9.9571075" r="12.671875" fx="7.1183534" fy="9.9571075" id="radialGradient4420" xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-9-4" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,5.8591313,-8.3440444,0,98.200518,-53.453544)" />
+    <linearGradient id="linearGradient3277-442">
+      <stop id="stop3378" style="stop-color:#575757;stop-opacity:1" offset="0" />
+      <stop id="stop3380" style="stop-color:#333333;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="32.892574" y1="27.988184" x2="31.364458" y2="29.484051" id="linearGradient2543" xlink:href="#linearGradient3277-442" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.47697068,0,0,0.462207,9.7626102,11.903063)" />
+    <linearGradient id="linearGradient11114-516">
+      <stop id="stop3372" style="stop-color:#242424;stop-opacity:0.99215686" offset="0" />
+      <stop id="stop3374" style="stop-color:#656565;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="-172.65306" y1="99.667191" x2="-164.71831" y2="91.972626" id="linearGradient2541" xlink:href="#linearGradient11114-516" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.18565627,0,0,0.1799097,57.644134,9.108757)" />
+    <linearGradient id="linearGradient3294">
+      <stop id="stop3296" style="stop-color:#ffffff;stop-opacity:0.19520548" offset="0" />
+      <stop id="stop3298" style="stop-color:#ffffff;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient x1="212.04402" y1="123.74026" x2="210.58083" y2="74.261711" id="linearGradient2538" xlink:href="#linearGradient3294" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.18565627,0,0,0.1799097,-13.847234,10.847413)" />
+    <linearGradient id="linearGradient4454-600">
+      <stop id="stop3408" style="stop-color:#ffffff;stop-opacity:0.64726025" offset="0" />
+      <stop id="stop3410" style="stop-color:#ffffff;stop-opacity:0.19520548" offset="1" />
+    </linearGradient>
+    <radialGradient cx="18.240929" cy="21.817987" r="8.3085051" fx="18.240929" fy="21.817987" id="radialGradient2514" xlink:href="#linearGradient4454-600" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.66815678,0,0,0.6866873,7.0470546,5.5085513)" />
+    <linearGradient id="linearGradient4467-402">
+      <stop id="stop3390" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop3392" style="stop-color:#ffffff;stop-opacity:0.29019609" offset="1" />
+    </linearGradient>
+    <radialGradient cx="15.414371" cy="13.078408" r="6.65625" fx="15.414371" fy="13.078408" id="radialGradient2533" xlink:href="#linearGradient4467-402" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3780896,0,0,1.1280465,-4.3977158,0.09367866)" />
+    <linearGradient id="linearGradient11104-770">
+      <stop id="stop3402" style="stop-color:#333333;stop-opacity:1" offset="0" />
+      <stop id="stop3404" style="stop-color:#333333;stop-opacity:0.6122449" offset="1" />
+    </linearGradient>
+    <linearGradient x1="41.541653" y1="68.291702" x2="41.485142" y2="4.5362983" id="linearGradient2530" xlink:href="#linearGradient11104-770" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.18118896,0,0,0.1908549,10.657809,11.561649)" />
+    <linearGradient id="linearGradient2300-465">
+      <stop id="stop3396" style="stop-color:#343434;stop-opacity:0.97647059" offset="0" />
+      <stop id="stop3398" style="stop-color:#929292;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="173.09576" y1="75.31868" x2="173.09576" y2="11.949074" id="linearGradient2528" xlink:href="#linearGradient2300-465" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.18118896,0,0,0.1908549,-12.844422,10.125294)" />
+    <linearGradient id="linearGradient6209-717">
+      <stop id="stop3366" style="stop-color:#979797;stop-opacity:1" offset="0" />
+      <stop id="stop3368" style="stop-color:#000000;stop-opacity:0.34117648" offset="1" />
+    </linearGradient>
+    <linearGradient x1="173.09576" y1="75.31868" x2="173.09576" y2="11.949074" id="linearGradient2525" xlink:href="#linearGradient6209-717" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.17255541,0,0,0.1817607,-11.302239,10.407547)" />
+  </defs>
+  <metadata id="metadata4156">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g transform="matrix(0.79999968,0,0,0.3333336,-3.2000003,13.33333)" id="g2036-2" style="display:inline">
+    <g transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)" id="g3712-3" style="opacity:0.4">
+      <rect width="5" height="7" x="38" y="40" id="rect2801-0" style="fill:url(#radialGradient2976);fill-opacity:1;stroke:none" />
+      <rect width="5" height="7" x="-10" y="-47" transform="scale(-1,-1)" id="rect3696-2" style="fill:url(#radialGradient2978);fill-opacity:1;stroke:none" />
+      <rect width="28" height="7.0000005" x="10" y="40" id="rect3700-1" style="fill:url(#linearGradient2980);fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+  <path d="m 3.5,9.5 c 9.000001,0 16,0 25,0 1.297092,0 2,3.324604 2,5 0,4.178255 0,7.822113 0,12.000368 0.01033,0.964169 -1.033653,1.068845 -1.762738,1 -8.745754,0 -17.491508,0 -26.2372625,0 -0.9641691,0.01033 -1.0688452,-1.033653 -1,-1.762737 l 0,-11.237631 c 0,0 0.474654,-5 2.0000005,-5 z" id="rect5505-21" style="opacity:0.9;color:#000000;fill:url(#radialGradient4396-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <rect width="27" height="11" x="2.499999" y="15.5" id="rect6741-7-4" style="opacity:0.25;fill:none;stroke:url(#linearGradient3043);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path d="m 3.5,9.5 c 0,0 16,0 25,0 1.449291,0 1.999999,5 1.999999,5 0,0 0,7.701952 0,11.99961 0.0082,0.980409 -1.057344,1.065948 -1.793221,1 -8.735593,0 -17.471186,0 -26.2067787,0 -0.9804089,0.0082 -1.0659481,-1.057345 -1,-1.793221 l 0,-11.206389 c 0,0 0.5269137,-5 2.0000007,-5 z" id="rect5505-6" style="opacity:0.7;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <rect width="28" height="1" rx="0" ry="0" x="2" y="-15" transform="scale(1,-1)" id="rect3957" style="opacity:0.4;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <rect width="2" height="2" x="26.5" y="17" id="rect3991" style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0cceff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+  <path d="m 6.4999609,23.000039 c 4.3538641,0 18.9999761,6.7e-4 18.9999761,6.7e-4 l 2.4e-5,8.49933 c 0,0 -12.666667,0 -19.0000001,0 0,-3.5 0,-4.999999 0,-8.5 z" id="path4160-3" style="fill:url(#linearGradient4062);fill-opacity:1;stroke:none;display:inline" />
+  <path d="m 24.5,30.5 -17.0000001,0 0,-7 L 24.5,23.5 z" id="rect6741-1" style="fill:none;stroke:url(#linearGradient4059);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path d="m 6.4999609,22.499961 c 4.3538821,0 19.0000551,5.73e-4 19.0000551,5.73e-4 l 2.3e-5,8.999505 c 0,0 -12.666718,0 -19.0000781,0 0,-3.000026 0,-6.000052 0,-9.000077 z" id="path4160-3-4" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path d="m 10,24 0,1 6.65625,0 0,-1 L 10,24 z m 9.34375,0 0,1 L 22,25 22,24 19.34375,24 z M 10,26 l 0,1 4,0 0,-1 -4,0 z m 6.65625,0 0,1 L 22,27 22,26 16.65625,26 z M 10,28 l 0,1 12,0 0,-1 -12,0 z" id="rect3981" style="opacity:0.15;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <rect width="20" height="1" x="6" y="23" id="rect4124-5" style="opacity:0.15;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path d="m 4,10.499998 24,0 c 0.835818,0 1.499999,3 1.499999,3 -9,0 -27,0 -27,0 0,0 0.579915,-3 1.500001,-3 z" id="rect6741-7-4-2" style="opacity:0.1;fill:none;stroke:url(#linearGradient4247);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path d="m 6.4999609,3.5000391 c 4.3538641,0 18.9999761,4.146e-4 18.9999761,4.146e-4 l 2.4e-5,8.4995853 c 0,0 -12.666667,0 -19.0000001,0 0,-2.1666665 0,-6.3333327 0,-8.4999999 z" id="path4160-3-8" style="fill:url(#linearGradient4087);fill-opacity:1;stroke:none;display:inline" />
+  <path d="m 24.5,11.500039 -17.0000001,0 0,-6.9999999 17.0000001,0 z" id="rect6741-1-8" style="fill:none;stroke:url(#linearGradient4059-4);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path d="m 6.4999609,3.5 19.0000551,0.00185 2.3e-5,8.998189 -19.0000781,0 z" id="path4160-3-4-7" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <rect width="20" height="4" x="6" y="9" id="rect4249" style="opacity:0.3;color:#000000;fill:url(#linearGradient4257);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#linearGradient2541);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2543);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path11112" d="m 23.124307,22.500025 8.301196,7.486728 -1.150662,1.513272 -8.271133,-8.098638 z" />
+  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#linearGradient2538);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" id="path11122" d="m 30.288837,31.008593 -6.657396,-8.044248 8.054628,6.849559 z" />
+  <path inkscape:connector-curvature="0" style="display:inline;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:0.26709315" id="path13082" d="m 31.812599,29.896618 a 0.69032762,1.2696161 46.570305 1 1 -1.699408,1.864762 0.69032762,1.2696161 46.570305 1 1 1.699408,-1.864762 z" />
+  <path inkscape:connector-curvature="0" style="display:inline;visibility:visible;opacity:0.4;fill:url(#radialGradient2514);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.61258024;marker:none" id="path4452" d="m 24.350836,18.197359 a 5.551384,5.7053449 0 1 1 -11.102768,0 5.551384,5.7053449 0 1 1 11.102768,0 z" />
+  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:url(#radialGradient2533);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" id="path4462" d="m 18.570772,13.285851 c -2.767693,0 -5.008892,2.112213 -5.008892,4.72062 0,0.753319 0.06206,1.531409 0.395217,2.163593 0.665607,0.231216 1.533993,0.303562 2.284438,0.303562 3.279696,0 6.100627,-2.562574 6.303023,-5.6057 -0.91996,-1.024577 -2.439179,-1.582075 -3.973786,-1.582075 z" />
+  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#linearGradient2528);fill-opacity:1;stroke:url(#linearGradient2530);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path2298" d="m 18.67741,12.500025 c -3.409348,0 -6.177412,2.68861 -6.17741,6 0,3.311391 2.768062,6 6.17741,6 3.409346,0 6.177411,-2.688609 6.177411,-6 0,-3.31139 -2.768064,-6 -6.177411,-6 z m 0.07361,0.393639 c 3.051387,0 5.531925,2.404077 5.531925,5.367793 0,2.963715 -2.480538,5.367794 -5.531926,5.367794 -3.051388,0 -5.526262,-2.404078 -5.526262,-5.367794 0,-2.963716 2.474874,-5.367793 5.526263,-5.367793 z" />
+  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#linearGradient2525);fill-opacity:1;stroke:none;stroke-width:1" id="path4267" d="m 18.717047,12.672989 c -3.246893,0 -5.877317,2.560114 -5.877317,5.713719 0,3.153603 2.630422,5.713716 5.877317,5.713716 3.246894,0 5.882979,-2.560114 5.882979,-5.713716 0,-3.153605 -2.636087,-5.713719 -5.882979,-5.713719 z m 0.03398,0.220676 c 3.051386,0 5.289937,2.404078 5.289937,5.367793 0,2.963715 -2.238551,5.112895 -5.289937,5.112895 -3.051389,0 -5.324606,-2.149179 -5.324606,-5.112895 0,-2.963715 2.273217,-5.367793 5.324606,-5.367793 z" />
+</svg>

--- a/actions/48/document-print-preview.svg
+++ b/actions/48/document-print-preview.svg
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="48" height="48" id="svg11300" sodipodi:docname="document-print-preview.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview78" showgrid="true" inkscape:zoom="11.313708" inkscape:cx="30.898079" inkscape:cy="15.194309" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg11300">
+    <inkscape:grid type="xygrid" id="grid885" />
+  </sodipodi:namedview>
+  <metadata id="metadata99">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id="defs3">
+    <linearGradient id="linearGradient3512">
+      <stop id="stop3514" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop3516" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.03402857" />
+      <stop id="stop3518" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="1" />
+      <stop id="stop3520" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    </linearGradient>
+    <linearGradient id="linearGradient3688-166-749-6">
+      <stop id="stop2883-8" style="stop-color:#181818;stop-opacity:1" offset="0" />
+      <stop id="stop2885-3" style="stop-color:#181818;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient id="linearGradient3688-464-309-7">
+      <stop id="stop2889-0" style="stop-color:#181818;stop-opacity:1" offset="0" />
+      <stop id="stop2891-66" style="stop-color:#181818;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient id="linearGradient3702-501-757-3">
+      <stop id="stop2895-3" style="stop-color:#181818;stop-opacity:0" offset="0" />
+      <stop id="stop2897-28" style="stop-color:#181818;stop-opacity:1" offset="0.5" />
+      <stop id="stop2899-8" style="stop-color:#181818;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-9-4-5">
+      <stop offset="0" style="stop-color:#505050;stop-opacity:1" id="stop3750-1-0-7-6-6-1-3-9-3-3-3-6" />
+      <stop offset="0.26238" style="stop-color:#2b2b2b;stop-opacity:1" id="stop3752-3-7-4-0-32-8-923-0-7-1-1-4" />
+      <stop offset="0.704952" style="stop-color:#0a0a0a;stop-opacity:1" id="stop3754-1-8-5-2-7-6-7-1-9-8-6-2" />
+      <stop offset="1" style="stop-color:#000000;stop-opacity:1" id="stop3756-1-6-2-6-6-1-96-6-0-0-6-2" />
+    </linearGradient>
+    <linearGradient id="linearGradient3924-0-9-4">
+      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop3926-6-0-8" />
+      <stop offset="0.06316455" style="stop-color:#ffffff;stop-opacity:0.23529412" id="stop3928-3-5-9" />
+      <stop offset="0.95056331" style="stop-color:#ffffff;stop-opacity:0.15686275" id="stop3930-2-1-9" />
+      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0.39215687" id="stop3932-62-5-8" />
+    </linearGradient>
+    <linearGradient id="linearGradient3600-4-3">
+      <stop offset="0" style="stop-color:#f4f4f4;stop-opacity:1" id="stop3602-7-9" />
+      <stop offset="1" style="stop-color:#dbdbdb;stop-opacity:1" id="stop3604-6-6" />
+    </linearGradient>
+    <linearGradient id="linearGradient3977-6">
+      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop3979-5" />
+      <stop offset="0.03626217" style="stop-color:#ffffff;stop-opacity:0.23529412" id="stop3981-9" />
+      <stop offset="0.95056331" style="stop-color:#ffffff;stop-opacity:0.15686275" id="stop3983-2" />
+      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0.39215687" id="stop3985-4" />
+    </linearGradient>
+    <linearGradient id="linearGradient3977">
+      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop3979" />
+      <stop offset="0.03626217" style="stop-color:#ffffff;stop-opacity:0.23529412" id="stop3981" />
+      <stop offset="0.95056331" style="stop-color:#ffffff;stop-opacity:0.15686275" id="stop3983" />
+      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0.39215687" id="stop3985" />
+    </linearGradient>
+    <linearGradient id="linearGradient3600-4">
+      <stop offset="0" style="stop-color:#f4f4f4;stop-opacity:1" id="stop3602-7" />
+      <stop offset="1" style="stop-color:#dbdbdb;stop-opacity:1" id="stop3604-6" />
+    </linearGradient>
+    <linearGradient id="linearGradient4251-1">
+      <stop offset="0" style="stop-color:#000000;stop-opacity:1" id="stop4253-8" />
+      <stop offset="1" style="stop-color:#000000;stop-opacity:0" id="stop4255-2" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3702-501-757-3" id="linearGradient3471" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.84210526,0,0,0.42857134,-1.1257809,20.857146)" x1="25.058096" y1="47.027729" x2="25.058096" y2="39.999443" />
+    <radialGradient xlink:href="#linearGradient3688-464-309-7" id="radialGradient3473" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-1.687397,0,0,-0.59999988,15.72632,65.599994)" cx="4.9929786" cy="43.5" fx="4.9929786" fy="43.5" r="2.5" />
+    <radialGradient xlink:href="#linearGradient3688-166-749-6" id="radialGradient3475" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.899529,0,0,0.59999988,36.206774,13.329547)" cx="3.0032907" cy="43.787853" fx="3.0032907" fy="43.787853" r="2.5" />
+    <linearGradient xlink:href="#linearGradient4251-1" id="linearGradient3739" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3,0,0,1.6666666,3.199998,-2.6666663)" x1="17" y1="14" x2="17" y2="10" />
+    <linearGradient xlink:href="#linearGradient3977-6" id="linearGradient3743" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.62162161,0,0,1.042471,9.081084,1.7664208)" x1="23.99999" y1="5.5641499" x2="23.99999" y2="43" />
+    <linearGradient xlink:href="#linearGradient3600-4-3" id="linearGradient3746" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.68571268,0,0,0.19108172,7.542894,6.5179604)" x1="25.132275" y1="0.98520643" x2="25.132275" y2="62.706093" />
+    <linearGradient xlink:href="#linearGradient3924-0-9-4" id="linearGradient3749" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.99277432,0,0,0.10810811,0.173416,15.905407)" x1="23.99999" y1="10.124985" x2="23.99999" y2="37.874985" />
+    <linearGradient xlink:href="#linearGradient3977" id="linearGradient3755" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.62162161,0,0,1.042471,9.081085,-0.80500837)" x1="23.99999" y1="5.5641499" x2="23.99999" y2="43" />
+    <linearGradient xlink:href="#linearGradient3600-4" id="linearGradient3758" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.68571268,0,0,0.30867042,7.542894,29.015438)" x1="33.210621" y1="46.353771" x2="33.210621" y2="11.28877" />
+    <linearGradient xlink:href="#linearGradient3512" id="linearGradient3764" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.99999999,0,0,0.43243241,0,20.12163)" x1="23.99999" y1="6.6562309" x2="23.99999" y2="41.343731" />
+    <radialGradient xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-9-4-5" id="radialGradient3767" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,7.8046631,-11.214713,0,136.04426,-56.530174)" cx="7.1183534" cy="9.9571075" fx="7.1183534" fy="9.9571075" r="12.671875" />
+    <linearGradient id="linearGradient3277-442">
+      <stop id="stop3378" style="stop-color:#575757;stop-opacity:1" offset="0" />
+      <stop id="stop3380" style="stop-color:#333333;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="32.892574" y1="27.988184" x2="31.364458" y2="29.484051" id="linearGradient2543" xlink:href="#linearGradient3277-442" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.5018785,0,0,0.462207,-0.3803386,1.9030377)" />
+    <linearGradient id="linearGradient11114-516">
+      <stop id="stop3372" style="stop-color:#242424;stop-opacity:0.99215686" offset="0" />
+      <stop id="stop3374" style="stop-color:#656565;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="-172.65306" y1="99.667191" x2="-164.71831" y2="91.972626" id="linearGradient2541" xlink:href="#linearGradient11114-516" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.1953514,0,0,0.1799097,50.0016,-0.8912687)" />
+    <linearGradient id="linearGradient3294">
+      <stop id="stop3296" style="stop-color:#ffffff;stop-opacity:0.19520548" offset="0" />
+      <stop id="stop3298" style="stop-color:#ffffff;stop-opacity:0" offset="1" />
+    </linearGradient>
+    <linearGradient x1="212.04402" y1="123.74026" x2="210.58083" y2="74.261711" id="linearGradient2538" xlink:href="#linearGradient3294" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.1953514,0,0,0.1799097,-25.223109,0.847388)" />
+    <linearGradient id="linearGradient4454-600">
+      <stop id="stop3408" style="stop-color:#ffffff;stop-opacity:0.64726025" offset="0" />
+      <stop id="stop3410" style="stop-color:#ffffff;stop-opacity:0.19520548" offset="1" />
+    </linearGradient>
+    <radialGradient cx="18.240929" cy="21.817987" r="8.3085051" fx="18.240929" fy="21.817987" id="radialGradient2514" xlink:href="#linearGradient4454-600" gradientUnits="userSpaceOnUse" />
+    <linearGradient id="linearGradient4467-402">
+      <stop id="stop3390" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
+      <stop id="stop3392" style="stop-color:#ffffff;stop-opacity:0.24761905" offset="1" />
+    </linearGradient>
+    <radialGradient cx="15.414371" cy="13.078408" r="6.65625" fx="15.414371" fy="13.078408" id="radialGradient2533" xlink:href="#linearGradient4467-402" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.4500546,0,0,1.1280465,-15.280129,-9.906347)" />
+    <linearGradient id="linearGradient11104-770">
+      <stop id="stop3402" style="stop-color:#333333;stop-opacity:1" offset="0" />
+      <stop id="stop3404" style="stop-color:#333333;stop-opacity:0.6122449" offset="1" />
+    </linearGradient>
+    <linearGradient x1="41.541653" y1="68.291702" x2="41.485142" y2="4.5362983" id="linearGradient2530" xlink:href="#linearGradient11104-770" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.1906508,0,0,0.1908549,0.5616077,1.5616236)" />
+    <linearGradient id="linearGradient2300-465">
+      <stop id="stop3396" style="stop-color:#343434;stop-opacity:0.97647059" offset="0" />
+      <stop id="stop3398" style="stop-color:#929292;stop-opacity:1" offset="1" />
+    </linearGradient>
+    <linearGradient x1="173.09576" y1="75.31868" x2="173.09576" y2="11.949074" id="linearGradient2528" xlink:href="#linearGradient2300-465" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.1906508,0,0,0.1908549,-24.167929,0.1252679)" />
+    <linearGradient id="linearGradient6209-717">
+      <stop id="stop3366" style="stop-color:#979797;stop-opacity:1" offset="0" />
+      <stop id="stop3368" style="stop-color:#000000;stop-opacity:0.34117648" offset="1" />
+    </linearGradient>
+    <linearGradient x1="173.09576" y1="75.31868" x2="173.09576" y2="11.949074" id="linearGradient2525" xlink:href="#linearGradient6209-717" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.1815664,0,0,0.1817607,-22.545212,0.4075216)" />
+  </defs>
+  <path style="opacity:0.4;fill:url(#radialGradient3475);fill-opacity:1;stroke:none" d="m 41.874219,38 4.210526,0 0,2.999999 -4.210526,0 z" id="rect2801-0" />
+  <path style="opacity:0.4;fill:url(#radialGradient3473);fill-opacity:1;stroke:none" d="m 7.2952717,40.999999 -4.2105263,0 0,-2.999999 4.2105263,0 z" id="rect3696-2" />
+  <path style="opacity:0.4;fill:url(#linearGradient3471);fill-opacity:1;stroke:none" d="m 7.2952717,38 34.5721453,0 0,2.999999 -34.5721453,0 z" id="rect3700-1" />
+  <path d="m 7.210907,15.5 c 12.096344,0 21.504609,0 33.600952,0 1.743341,0 2.688076,4.428543 2.688076,6.660257 0,5.565649 0,10.419455 0,15.985104 0.01388,1.284323 -1.389269,1.423756 -2.369187,1.332051 -11.754627,0 -23.509253,0 -35.263879,0 -1.295881,0.01376 -1.43657,-1.376878 -1.344038,-2.348055 l 0,-14.9691 c 0,0 0.637953,-6.660257 2.688076,-6.660257 z" id="rect5505-21-9" style="opacity:0.9;color:#000000;fill:url(#radialGradient3767);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <rect width="37" height="16" x="5.4999981" y="22.500004" id="rect6741-7-4-4" style="opacity:0.25;fill:none;stroke:url(#linearGradient3764);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path d="m 7.210906,15.499999 c 0,0 21.504609,0 33.600952,0 1.947903,0 2.688075,6.660527 2.688075,6.660527 0,0 0,10.259812 0,15.984746 0.01102,1.306008 -1.42111,1.419954 -2.410157,1.332105 -11.74097,0 -23.48194,0 -35.22291,0 -1.317707,0.01092 -1.432675,-1.408495 -1.344038,-2.38876 l 0,-14.928091 c 0,0 0.708193,-6.660527 2.688078,-6.660527 z" id="rect5505-6-9" style="opacity:0.7;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <rect width="38" height="1" rx="0" ry="0" x="4.9999981" y="-22" transform="scale(1,-1)" id="rect3957-0" style="opacity:0.4;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path d="m 12,32.5 c 5.499618,0 23.99997,9.06e-4 23.99997,9.06e-4 L 36,44 c 0,0 -16.000001,0 -24,0 0,-4.735294 0,-6.764705 0,-11.5 z" id="path4160-3" style="fill:url(#linearGradient3758);fill-opacity:1;stroke:none;display:inline" />
+  <path d="m 35.5,43.5 -23,0 0,-10 23,0 z" id="rect6741-1" style="fill:none;stroke:url(#linearGradient3755);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path d="m 11.499961,32.499961 c 5.728787,0 25.000048,7.63e-4 25.000048,7.63e-4 l 3e-5,11.999315 c 0,0 -16.666717,0 -25.000078,0 0,-4.000026 0,-8.000052 0,-12.000077 z" id="path4160-3-4" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <rect width="26" height="1" x="10.999998" y="32" id="rect4124-5-6" style="opacity:0.15;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path d="m 7.674381,16.5 32.651243,0 c 1.137104,0 2.040702,4 2.040702,4 -12.244217,0 -36.73265,0 -36.73265,0 0,0 0.788956,-4 2.040705,-4 z" id="rect6741-7-4-2-7" style="opacity:0.1;fill:none;stroke:url(#linearGradient3749);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path d="m 12,7.0000001 c 5.499618,0 23.99997,5.61e-4 23.99997,5.61e-4 L 36,18.5 c 0,0 -16.000001,0 -24,0 0,-2.931373 0,-8.5686269 0,-11.4999999 z" id="path4160-3-8" style="fill:url(#linearGradient3746);fill-opacity:1;stroke:none;display:inline" />
+  <path d="m 35.499999,17.5 -23,0 0,-9.9999999 23,0 z" id="rect6741-1-8" style="fill:none;stroke:url(#linearGradient3743);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path d="m 11.499961,6.4999402 25.000048,0.0026 3e-5,11.9974988 -25.000078,0 z" id="path4160-3-4-7" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <rect width="26" height="5" x="10.999998" y="14" id="rect4249-5" style="opacity:0.3;color:#000000;fill:url(#linearGradient3739);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none" d="m 16,36 0,1 16,0 0,-1 -16,0 z m 0,2 0,1 9,0 0,-1 -9,0 z m 11,0 0,1 3,0 0,-1 -3,0 z m -11,2 0,1 4,0 0,-1 -4,0 z m 5,0 0,1 10,0 0,-1 -10,0 z" id="rect4731" />
+  <path style="color:#000000;fill:#0cceff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 39,25 2,0 0,2 -2,0 z" id="rect3991" />
+  <g id="layer1" transform="matrix(1.1459442,0,0,1.2090938,16.713,18.324921)" style="stroke-width:0.84954882">
+    <path d="M 13.679117,12.5 22.413809,19.986728 21.203058,21.5 12.5,13.401362 Z" id="path11112" style="display:inline;fill:url(#linearGradient2541);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2543);stroke-width:0.84954882;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" inkscape:connector-curvature="0" />
+    <path d="m 21.217785,21.008568 -7.005051,-8.044248 8.475248,6.849559 z" id="path11122" style="display:inline;fill:url(#linearGradient2538);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.84954882" inkscape:connector-curvature="0" />
+    <path d="m 247.90924,110.29199 a 4.86685,2.6562012 0 1 1 -9.7337,0 4.86685,2.6562012 0 1 1 9.7337,0 z" transform="matrix(0.1837074,-0.1915779,0.2354746,0.1427652,-48.692604,51.644667)" id="path13082" style="display:inline;fill:#3e3e3e;fill-opacity:1;stroke:none;stroke-width:0.84954882" inkscape:connector-curvature="0" />
+    <path d="m 25.897786,18.478292 a 8.3085051,8.3085051 0 1 1 -16.61701,0 8.3085051,8.3085051 0 1 1 16.61701,0 z" transform="matrix(0.7030485,0,0,0.6866873,-3.2377028,-4.4914744)" id="path4452" style="display:inline;visibility:visible;opacity:0.4;fill:url(#radialGradient2514);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.74899542;marker:none" inkscape:connector-curvature="0" />
+    <path d="m 8.8877932,3.285826 c -2.9122238,0 -5.2704608,2.112213 -5.2704608,4.7206197 0,0.7533185 0.065298,1.5314093 0.4158554,2.1635933 0.7003648,0.231216 1.6140995,0.303562 2.4037328,0.303562 3.4509655,0 6.4192074,-2.5625743 6.6321734,-5.6057008 C 12.101092,3.8433232 10.502538,3.285826 8.8877932,3.285826 Z" id="path4462" style="display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:url(#radialGradient2533);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.84954882;marker:none" inkscape:connector-curvature="0" />
+    <path d="M 9.0000005,2.5 C 5.4126135,2.5 2.499998,5.1886101 2.5,8.4999999 2.5,11.811391 5.4126135,14.5 9.0000005,14.5 12.587385,14.5 15.5,11.811391 15.5,8.4999999 15.5,5.1886101 12.587386,2.5 9.0000005,2.5 Z m 0.077451,0.3936385 c 3.2107345,0 5.8208075,2.4040776 5.8208075,5.3677935 0,2.963715 -2.610073,5.367794 -5.8208075,5.367794 -3.2107343,0 -5.8148483,-2.404078 -5.8148483,-5.367794 0,-2.9637159 2.604114,-5.3677935 5.8148483,-5.3677935 z" id="path2298" style="display:inline;fill:url(#linearGradient2528);fill-opacity:1;stroke:url(#linearGradient2530);stroke-width:0.84954882;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" inkscape:connector-curvature="0" />
+    <path d="m 9.0417066,2.6729635 c -3.4164491,0 -6.1842359,2.5601138 -6.1842359,5.7137188 0,3.1536037 2.7677849,5.7137167 6.1842359,5.7137167 3.4164494,0 6.1901934,-2.560114 6.1901934,-5.7137167 0,-3.153605 -2.773746,-5.7137188 -6.1901934,-5.7137188 z m 0.035747,0.220676 c 3.2107324,0 5.5661824,2.4040786 5.5661824,5.3677936 0,2.9637149 -2.35545,5.1128949 -5.5661824,5.1128949 -3.2107351,0 -5.6026612,-2.149179 -5.6026612,-5.1128949 0,-2.963715 2.3919261,-5.3677936 5.6026612,-5.3677936 z" id="path4267" style="display:inline;fill:url(#linearGradient2525);fill-opacity:1;stroke:none;stroke-width:0.84954882" inkscape:connector-curvature="0" />
+  </g>
+</svg>


### PR DESCRIPTION
New colored versions of document-print-preview.
Fixes #535.

Looks like this:
![screenshot from 2018-09-30 01-05-31](https://user-images.githubusercontent.com/4886639/46253250-01693c80-c44d-11e8-90ee-3c0b67f4f528.png)
