### PR TITLE
Add 16px night-light icons

### DIFF
--- a/status/16/night-light-disabled-symbolic.svg
+++ b/status/16/night-light-disabled-symbolic.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   id="svg2"
+   version="1.1"
+   sodipodi:docname="night-light-disabled-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1635"
+     inkscape:window-height="893"
+     id="namedview7"
+     showgrid="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.7460048"
+     inkscape:cy="7.0965257"
+     inkscape:window-x="0"
+     inkscape:window-y="33"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid16" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;vector-effect:none;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 2.4921875 2.8183594 L 1.7949219 3.5351562 L 12.683594 14.078125 L 13.378906 13.359375 L 11.109375 11.162109 C 11.662343 10.415093 12.000002 9.4996353 12 8.5 C 12 6.0170549 9.9829429 4 7.5 4 C 6.4481483 4 5.4965122 4.3800076 4.7324219 4.9882812 L 2.4921875 2.8183594 z M 7.4179688 4.8691406 L 7.4199219 4.8691406 C 7.4428229 4.8689247 7.4653802 4.8689247 7.4882812 4.8691406 L 7.4941406 4.8691406 C 6.9267316 5.2930238 6.5348788 5.8971512 6.3671875 6.5703125 L 5.3320312 5.5683594 C 5.9032125 5.146564 6.6133031 4.8845782 7.4179688 4.8691406 z M 3.6113281 6.2773438 C 3.2336976 6.9357193 3 7.6874911 3 8.5 C 3 10.982946 5.0170522 13 7.5 13 C 8.3644776 13 9.1655004 12.743861 9.8515625 12.320312 L 9.2304688 11.71875 C 7.6843824 12.549713 5.6022413 12.215798 4.4765625 10.564453 C 3.6702325 9.3816346 3.6744915 7.9926036 4.2324219 6.8808594 L 3.6113281 6.2773438 z M 10.853516 9.9101562 C 10.75461 10.148505 10.634381 10.368152 10.498047 10.568359 L 10.134766 10.21875 C 10.385669 10.147365 10.627113 10.044799 10.853516 9.9101562 z "
+     id="path28" />
+  <rect
+     style="opacity:0.4;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect828"
+     width="2"
+     height="1"
+     x="0"
+     y="8"
+     ry="0.33898306" />
+  <rect
+     ry="0.33898306"
+     y="8"
+     x="13"
+     height="1"
+     width="2"
+     id="rect830"
+     style="opacity:0.4;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="opacity:0.4;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect832"
+     width="2"
+     height="1"
+     x="-3"
+     y="7"
+     ry="0.33898306"
+     transform="rotate(-90)" />
+  <rect
+     transform="rotate(-90)"
+     ry="0.33898306"
+     y="7"
+     x="-16"
+     height="1"
+     width="2"
+     id="rect834"
+     style="opacity:0.4;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="opacity:0.4;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4560"
+     width="2"
+     height="1"
+     x="4.7654757"
+     y="-12.167262"
+     ry="0.33898306"
+     transform="matrix(0.70710678,-0.70710678,-0.70710678,-0.70710678,0,0)" />
+  <rect
+     style="opacity:0.4;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4564"
+     width="2"
+     height="1"
+     x="6.1834173"
+     y="10.548541"
+     ry="0.33898306"
+     transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)" />
+</svg>

--- a/status/16/night-light-symbolic.svg
+++ b/status/16/night-light-symbolic.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   id="svg2"
+   version="1.1"
+   sodipodi:docname="night-light-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1635"
+     inkscape:window-height="893"
+     id="namedview7"
+     showgrid="true"
+     inkscape:zoom="32"
+     inkscape:cx="7.3559322"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="33"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid16" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 7.5,4 C 5.0170522,4 3,6.0170549 3,8.5 3,10.982946 5.0170522,13 7.5,13 9.9829429,13 12.000005,10.982946 12,8.5 12,6.0170549 9.9829429,4 7.5,4 Z M 7.418501,4.8693181 h 0.00164 c 0.022901,-2.159e-4 0.04581,-2.159e-4 0.068711,0 h 0.00483 C 6.7278458,5.4414364 6.2761105,6.3407628 6.2743923,7.2966975 6.2729196,8.9746821 7.6326289,10.335821 9.3106143,10.336115 9.8540826,10.334561 10.387183,10.187238 10.854293,9.909446 9.7443374,12.584278 6.1085784,12.958098 4.4774578,10.565282 2.8462702,8.1724662 4.5230501,4.9248676 7.418501,4.8693181 Z"
+     id="path28"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssscscccccccsc" />
+  <rect
+     style="opacity:1;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect828"
+     width="2"
+     height="1"
+     x="0"
+     y="8"
+     ry="0.33898306" />
+  <rect
+     ry="0.33898306"
+     y="8"
+     x="13"
+     height="1"
+     width="2"
+     id="rect830"
+     style="opacity:1;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="opacity:1;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect832"
+     width="2"
+     height="1"
+     x="-3"
+     y="7"
+     ry="0.33898306"
+     transform="rotate(-90)" />
+  <rect
+     transform="rotate(-90)"
+     ry="0.33898306"
+     y="7"
+     x="-16"
+     height="1"
+     width="2"
+     id="rect834"
+     style="opacity:1;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     transform="rotate(-135)"
+     ry="0.33898306"
+     y="-1.2310673"
+     x="-5.8171649"
+     height="1"
+     width="2"
+     id="rect855"
+     style="opacity:1;fill:#696363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="opacity:1;fill:#696363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4560"
+     width="2"
+     height="1"
+     x="4.7654757"
+     y="-12.167262"
+     ry="0.33898306"
+     transform="matrix(0.70710678,-0.70710678,-0.70710678,-0.70710678,0,0)" />
+  <rect
+     transform="rotate(45)"
+     ry="0.33898306"
+     y="0.032194629"
+     x="16.788158"
+     height="1"
+     width="2"
+     id="rect4562"
+     style="opacity:1;fill:#696363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="opacity:1;fill:#696363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4564"
+     width="2"
+     height="1"
+     x="6.1834173"
+     y="10.548541"
+     ry="0.33898306"
+     transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)" />
+</svg>


### PR DESCRIPTION
Not sure if you even care about 16px versions of the symbolic status icons you have in 24 now. However I wanted/needed one for night-light (I also want to use the icon in the xfce panel, which can have 16px symbolic icons) so I created it.
If you generally want this icon, I can also create the missing files night-light-disabled-[10..90]-symbolic.svg