### PR TITLE
Add missing application-x-generic

### DIFF
--- a/mimes/128/application-x-generic.svg
+++ b/mimes/128/application-x-generic.svg
@@ -1,0 +1,1 @@
+text-x-preview.svg

--- a/mimes/16/application-x-generic.svg
+++ b/mimes/16/application-x-generic.svg
@@ -1,0 +1,1 @@
+text-x-preview.svg

--- a/mimes/24/application-x-generic.svg
+++ b/mimes/24/application-x-generic.svg
@@ -1,0 +1,1 @@
+text-x-preview.svg

--- a/mimes/32/application-x-generic.svg
+++ b/mimes/32/application-x-generic.svg
@@ -1,0 +1,1 @@
+text-x-preview.svg

--- a/mimes/48/application-x-generic.svg
+++ b/mimes/48/application-x-generic.svg
@@ -1,0 +1,1 @@
+text-x-preview.svg

--- a/mimes/64/application-x-generic.svg
+++ b/mimes/64/application-x-generic.svg
@@ -1,0 +1,1 @@
+text-x-preview.svg


### PR DESCRIPTION
It looks like GLib.FileInfo returns this icon as a fallback for mimetype icons, so we need to have it