### PR TITLE
only re-add svg files which were already added

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -18,5 +18,5 @@ git diff --cached --name-status --diff-filter=ACMR | while read STATUS FILE; do
   fi
 done
 
-git add .
+git diff --cached --name-only | grep '.svg$' | xargs git add
 exit 0


### PR DESCRIPTION
in pre-commit, only re-add svg files which were already added to prevent wrong files to be committed unintentionally

The pre-commit hook used to automatically vacuum SVGs changes files, thus they have to be added again. This was done using `git add .` before. However, this can be considered hazardous, because it adds all files, tracked and untracked, added or not, to the commit, as the contributor might have experimented around leaving various files.

This change tries to minimize that risk by only considering files already marked for commit (but not files which are "only" tracked) and whose names also end in `.svg`.