### PR TITLE
meson/symlink: create relative symlinks instead of absolute ones

### DIFF
--- a/meson/symlink.py
+++ b/meson/symlink.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python3
 
-import os
 import argparse
+import os
 
 parser = argparse.ArgumentParser(description='Create a symlink')
 parser.add_argument('--src', nargs=1)
 parser.add_argument('--dest', nargs=1)
 args = parser.parse_args()
 
-src = os.path.join(os.environ['MESON_INSTALL_PREFIX'], args.src[0])
-dest = os.path.join(os.environ['MESON_INSTALL_DESTDIR_PREFIX'], args.dest[0])
+inst_prefix = os.environ['MESON_INSTALL_PREFIX']
+dest_prefix = os.environ['MESON_INSTALL_DESTDIR_PREFIX']
+
+src = os.path.basename(os.path.join(inst_prefix, args.src[0]))
+dest = os.path.join(dest_prefix, args.dest[0])
 
 if os.path.exists(dest):
     if os.path.isdir(dest):
-        print ('Folder "' + dest + '" already exists, no symlink will be created')
+        print('Folder "' + dest + '" already exists, no symlink will be created')
     else:
-        print ('File "' + dest + '" already exists, no symlink will be created')
+        print('File "' + dest + '" already exists, no symlink will be created')
 else:
-    print ('Linking ' + dest + ' to ' + src)
+    print('Linking ' + dest + ' to ' + src)
     os.symlink(src, dest)


### PR DESCRIPTION
Fixes #832

Note that when using python's argparse library, non-optional arguments are usually only positional, not with keywords, which would make the whole "take the only item of a list of one" thing unnecessary (and fix some edge cases, where `--src 1 --src 2` is accepted but only stores `2`), but I didn't want to rewrite the whole script just to make it "idiomatic python".