### PR TITLE
Add office-database-new icons

### DIFF
--- a/mimes/128/office-database-new.svg
+++ b/mimes/128/office-database-new.svg
@@ -1,0 +1,473 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="office-database-new.svg"
+   id="svg3984"
+   height="128"
+   width="128"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:current-layer="svg3984"
+     inkscape:window-maximized="1"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:cy="64"
+     inkscape:cx="78.103506"
+     inkscape:zoom="1"
+     inkscape:snap-global="false"
+     showgrid="false"
+     id="namedview65"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       id="grid890"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3986">
+    <linearGradient
+       gradientTransform="matrix(2.7142855,0,0,1.5526313,-1.142856,-60.03947)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3923-3-7"
+       id="linearGradient3805"
+       y2="44.137077"
+       x2="21.381216"
+       y1="5.0524864"
+       x1="21.381216" />
+    <linearGradient
+       id="linearGradient3923-3-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3925-9-0" />
+      <stop
+         offset="0.15463558"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3927-4-4" />
+      <stop
+         offset="0.86484742"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3929-6-8" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3931-4-0" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(1.9320946,0,0,1.9506404,-136.83097,-6.130683)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3844-5"
+       id="linearGradient2588-5"
+       y2="-24.582239"
+       x2="102.30806"
+       y1="-2.3925467"
+       x1="102.30806" />
+    <linearGradient
+       id="linearGradient3844-5">
+      <stop
+         offset="0"
+         style="stop-color:#a5a6a8;stop-opacity:1"
+         id="stop3846-5" />
+      <stop
+         offset="1"
+         style="stop-color:#e8e8e8;stop-opacity:1"
+         id="stop3848-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.9320946,0,0,1.9506404,-136.83097,-6.130683)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2509-6"
+       id="linearGradient2590-0"
+       y2="-2.3757858"
+       x2="109.95628"
+       y1="-24.91135"
+       x1="109.95628" />
+    <linearGradient
+       id="linearGradient2509-6">
+      <stop
+         offset="0"
+         style="stop-color:#a7a7a7;stop-opacity:1"
+         id="stop2511-2" />
+      <stop
+         offset="0.5107249"
+         style="stop-color:#b2b2b2;stop-opacity:1"
+         id="stop3899" />
+      <stop
+         offset="1"
+         style="stop-color:#dadada;stop-opacity:1"
+         id="stop2513-6" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(1.9223659,0,0,1.8830359,-135.87519,14.64858)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-9-2"
+       id="linearGradient3868"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       id="linearGradient2793-9-2">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795-2-2" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797-9-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(4.1988227,0,0,4.3559956,-331.39547,-109.31273)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-5-1"
+       id="linearGradient3870"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient3858-5-1">
+      <stop
+         offset="0"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         id="stop3860-5-7" />
+      <stop
+         offset="1"
+         style="stop-color:#4a4a4a;stop-opacity:1"
+         id="stop3862-3-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.7142855,0,0,1.4619556,-1.142856,-33.095074)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3923-3-3"
+       id="linearGradient3805-6"
+       y2="44.137077"
+       x2="21.381216"
+       y1="5.0524864"
+       x1="21.381216" />
+    <linearGradient
+       id="linearGradient3923-3-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3925-9-8" />
+      <stop
+         offset="0.15463558"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3927-4-0" />
+      <stop
+         offset="0.86484742"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3929-6-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3931-4-7" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(1.9223659,0,0,1.8830359,-135.87519,37.648581)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-9"
+       id="linearGradient2597-8"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       id="linearGradient2793-9">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795-2" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(4.1988227,0,0,4.3559956,-331.39547,-86.312732)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-5"
+       id="linearGradient2599-6"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient3858-5">
+      <stop
+         offset="0"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         id="stop3860-5" />
+      <stop
+         offset="1"
+         style="stop-color:#4a4a4a;stop-opacity:1"
+         id="stop3862-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.7142855,0,0,1.399922,-1.1428559,-7.396618)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3923-3"
+       id="linearGradient3921-9"
+       y2="44.137077"
+       x2="21.381216"
+       y1="5.0524864"
+       x1="21.381216" />
+    <linearGradient
+       id="linearGradient3923-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3925-9" />
+      <stop
+         offset="0.41662526"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3927-4" />
+      <stop
+         offset="0.77040929"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3929-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3931-4" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(1.9223659,0,0,1.8928987,-135.87519,60.68077)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-9"
+       id="linearGradient2575-7"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       gradientTransform="matrix(4.1988227,0,0,4.3788112,-331.39547,-63.929815)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-5"
+       id="linearGradient2577-3"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient23419-0">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop23421-2" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop23423-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.5377469,0,0,0.99421549,4.7830057,0.104808)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient23419-0"
+       id="radialGradient3982"
+       fy="41.63604"
+       fx="23.334524"
+       r="22.627417"
+       cy="41.63604"
+       cx="23.334524" />
+    <radialGradient
+       gradientTransform="matrix(0,2.4235253,-2.6392787,0,226.36903,-84.88818)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
+       id="radialGradient3381"
+       fy="48.76759"
+       fx="66.127159"
+       r="31.000002"
+       cy="48.76759"
+       cx="66.127159" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58-06">
+      <stop
+         id="stop3244-5-8-5-6-4-3-8"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0-7"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35-9"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40-4"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.1134672,0,0,1.645562,50.724212,61.899946)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4361"
+       id="linearGradient3030-3"
+       y2="37.130203"
+       x2="24.138529"
+       y1="9.1762295"
+       x1="24.138529" />
+    <linearGradient
+       id="linearGradient4361">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4363" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4365" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4367" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4369" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.6592445,0,0,2.0928522,60.832154,51.571789)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4351"
+       id="linearGradient3030-1"
+       y2="26.484531"
+       x2="24.138529"
+       y1="19.795095"
+       x1="24.138529" />
+    <linearGradient
+       id="linearGradient4351">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4353" />
+      <stop
+         offset="0.00000015"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4355" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4357" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4359" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3989">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,64)">
+    <path
+       style="opacity:0.3;fill:url(#radialGradient3982);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path23417"
+       d="M 121.42277,41.499995 C 121.42777,53.92583 95.717235,63.99999 64.000115,63.99999 32.282995,63.99999 6.5725666,53.92583 6.5774625,41.499995 6.5726025,29.074149 32.282995,18.999992 64.000115,18.999992 c 31.71712,0 57.427555,10.074157 57.422655,22.500003 z" />
+    <path
+       style="fill:url(#linearGradient2575-7);fill-opacity:1;stroke:url(#linearGradient2577-3);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2561"
+       d="M 112.20024,35.092015 C 112.20024,45.805218 90.581649,54.5 63.944494,54.5 c -26.637197,0 -48.25579,-8.694782 -48.25579,-19.407985 0,-31.044585 -5.8981753,-19.003956 48.25579,-19.407986 55.394176,-0.416865 48.255746,-14.30824 48.255746,19.407986 z" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3921-9);stroke-width:1;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3145"
+       y="0.30295089"
+       x="16.5"
+       ry="19.5"
+       rx="47.5"
+       height="53.197044"
+       width="95" />
+    <path
+       style="fill:#868688;fill-opacity:1;stroke:#d8d8d8;stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2563"
+       d="m 112.5,14.499995 c 0,11.045706 -21.714188,20.000007 -48.499996,20.000007 -26.785812,0 -48.500003,-8.954301 -48.500003,-20.000007 0,-11.045704 21.714191,-20.000012 48.500003,-20.000012 26.785808,0 48.499996,8.954308 48.499996,20.000012 l 0,0 z" />
+    <path
+       style="fill:url(#linearGradient2597-8);fill-opacity:1;stroke:url(#linearGradient2599-6);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2536"
+       d="m 112.20024,12.193132 c 0,10.6574 -21.618591,19.30687 -48.255746,19.30687 -26.637197,0 -48.25579,-8.64947 -48.25579,-19.30687 C 15.688704,6.823773 15.5,-7.999999 15.5,-7.999999 l 97,0 c -0.0715,2.47287 -0.29976,16.84656 -0.29976,20.193131 z" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3805-6);stroke-width:1;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3145-8"
+       y="-25.054317"
+       x="16.5"
+       ry="19.5"
+       rx="47.5"
+       height="55.554321"
+       width="95" />
+    <path
+       style="fill:#868688;fill-opacity:1;stroke:#d8d8d8;stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2538"
+       d="m 112.5,-8.500004 c 0,11.045705 -21.714188,20.000006 -48.499996,20.000006 -26.785812,0 -48.500003,-8.954301 -48.500003,-20.000006 l 96.999999,0 z" />
+    <path
+       style="fill:url(#linearGradient3868);fill-opacity:1;stroke:url(#linearGradient3870);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2536-7"
+       d="m 112.20024,-10.806869 c 0,10.6574 -21.618591,19.30687 -48.255746,19.30687 -26.637197,0 -48.25579,-8.64947 -48.25579,-19.30687 C 15.688704,-16.176228 15.5,-31 15.5,-31 l 97,0 c -0.0715,2.47287 -0.29976,16.84656 -0.29976,20.193131 z" />
+    <path
+       style="fill:url(#linearGradient2588-5);fill-opacity:1;stroke:url(#linearGradient2590-0);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3880"
+       d="m 112.5,-32.50001 c 0,11.045705 -21.71419,20.000011 -48.499998,20.000011 -26.785812,0 -48.500001,-8.954306 -48.500001,-20.000011 0,-11.045701 21.714189,-20.00001 48.500001,-20.00001 26.785808,0 48.499998,8.954309 48.499998,20.00001 l 0,0 z" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3805);stroke-width:1;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3145-4"
+       y="-51.5"
+       x="16.5"
+       ry="19.5"
+       rx="47.5"
+       height="59"
+       width="95" />
+  </g>
+  <g
+     style="stroke-width:1.0003"
+     transform="matrix(0.99970262,0,0,0.99970262,0.02914133,0.02974509)"
+     id="g4390">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3381);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98572;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2262"
+       d="M 89.5,91.499992 V 75.492705 h 17 v 16.007287 h 16.00729 V 108.5 H 106.5 v 16.00729 h -17 V 108.5 H 73.492714 V 91.499992 Z" />
+    <path
+       d="M 90.500004,93.012938 V 76.500001 H 105.5 V 92.987062 M 105.5,107 v 16.5 H 90.500004 V 107"
+       id="path2272-4"
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030-3);stroke-width:1.0003;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 106,92.556134 15.5,-0.05434 v 14.943816 l -15.5,0.0544 m -16,0 -15.5,-0.0544 V 92.501794 l 15.5,0.05434"
+       id="path2272-2"
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030-1);stroke-width:1.0003;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1.0003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path2262-8"
+       d="M 89.5,91.499992 V 75.492705 h 17 v 16.007287 h 16.00729 V 108.5 H 106.5 v 16.00729 h -17 V 108.5 H 73.492714 V 91.499992 Z" />
+  </g>
+</svg>

--- a/mimes/16/office-database-new.svg
+++ b/mimes/16/office-database-new.svg
@@ -1,0 +1,350 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="office-database-new.svg"
+   id="svg3202"
+   height="16"
+   width="16"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:current-layer="svg3202"
+     inkscape:window-maximized="0"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:cy="8"
+     inkscape:cx="8"
+     inkscape:zoom="37.4375"
+     showgrid="false"
+     id="namedview51"
+     inkscape:window-height="937"
+     inkscape:window-width="1875"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <defs
+     id="defs3204">
+    <linearGradient
+       gradientTransform="matrix(0.31428569,0,0,0.34210527,0.45714243,15.618423)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3125"
+       id="linearGradient3110"
+       y2="44.137077"
+       x2="21.381216"
+       y1="5.0524864"
+       x1="21.381216" />
+    <linearGradient
+       id="linearGradient3125">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3127" />
+      <stop
+         offset="0.08125819"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3129" />
+      <stop
+         offset="0.92327863"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3131" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3133" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2793">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3858">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         id="stop3860" />
+      <stop
+         offset="1"
+         style="stop-color:#4a4a4a;stop-opacity:1"
+         id="stop3862" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2793-4">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3858-22">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         id="stop3860-52" />
+      <stop
+         offset="1"
+         style="stop-color:#4a4a4a;stop-opacity:1"
+         id="stop3862-32" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2793-3-0">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795-3-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797-7-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3858-4-6">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         id="stop3860-9-8" />
+      <stop
+         offset="1"
+         style="stop-color:#4a4a4a;stop-opacity:1"
+         id="stop3862-9-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3844-4-1">
+      <stop
+         offset="0"
+         style="stop-color:#a5a6a8;stop-opacity:1"
+         id="stop3846-6-6" />
+      <stop
+         offset="1"
+         style="stop-color:#e8e8e8;stop-opacity:1"
+         id="stop3848-9-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2509-9-1">
+      <stop
+         offset="0"
+         style="stop-color:#b3b3b3;stop-opacity:1"
+         id="stop2511-0-9" />
+      <stop
+         offset="1"
+         style="stop-color:#dadada;stop-opacity:1"
+         id="stop2513-3-1" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.25894051,0,0,0.19506397,-18.915491,21.136932)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3844-4-1"
+       id="linearGradient3029"
+       y2="-24.582239"
+       x2="102.30806"
+       y1="-2.3925467"
+       x1="102.30806" />
+    <linearGradient
+       gradientTransform="matrix(0.25894051,0,0,0.19506397,-18.915491,21.136932)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2509-9-1"
+       id="linearGradient3031"
+       y2="-2.3757858"
+       x2="109.95628"
+       y1="-24.91135"
+       x1="109.95628" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.25763669,0,0,0.2519943,-18.787395,24.390022)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-3-0"
+       id="linearGradient3034"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       gradientTransform="matrix(0.56272887,0,0,0.58293421,-44.991146,7.8010968)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-4-6"
+       id="linearGradient3036"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.25763669,0,0,0.25599322,-18.787395,28.335879)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-4"
+       id="linearGradient3040"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       gradientTransform="matrix(0.56272887,0,0,0.59218484,-44.991146,11.483703)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-22"
+       id="linearGradient3042"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.25763669,0,0,0.25599322,-18.787395,32.335879)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793"
+       id="linearGradient3046"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       gradientTransform="matrix(0.56272887,0,0,0.59218484,-44.991146,15.483703)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858"
+       id="linearGradient3048"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <radialGradient
+       cx="64.575233"
+       cy="48.605404"
+       r="31.000002"
+       fx="64.575233"
+       fy="48.605404"
+       id="radialGradient3259"
+       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.38528829,-0.41958841,0,32.389496,-16.793007)" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58-06">
+      <stop
+         id="stop3244-5-8-5-6-4-3-8"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0-7"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35-9"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40-4"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3207">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-16)">
+    <path
+       style="fill:url(#linearGradient3046);fill-opacity:1;stroke:url(#linearGradient3048);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4834"
+       d="m 14.459827,29.5 c 0,1.198813 -2.897339,2 -6.4672665,2 -3.5699332,0 -6.4672704,-0.801187 -6.4672704,-2 0,-4.634373 -0.79047651,-3.194781 6.4672704,-3.249422 C 15.416523,26.194208 14.459827,24.840267 14.459827,29.5 z" />
+    <path
+       style="fill:none;stroke:#d8d8d8;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4838"
+       d="m 14.5,26.5 c 0,1.10457 -2.91015,2 -6.4999994,2 C 4.4101495,28.5 1.5,27.60457 1.5,26.5 c 0,-1.10457 2.9101495,-2 6.5000006,-2 C 11.58985,24.5 14.5,25.39543 14.5,26.5 l 0,0 z" />
+    <path
+       style="fill:url(#linearGradient3040);fill-opacity:1;stroke:url(#linearGradient3042);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4834-7"
+       d="m 14.459827,25.5 c 0,1.157142 -2.897339,2 -6.4672665,2 -3.5699332,0 -6.4672704,-0.801187 -6.4672704,-2 0,-4.634373 -0.79047651,-3.194781 6.4672704,-3.249422 C 15.416523,22.194208 14.459827,20.840267 14.459827,25.5 z" />
+    <path
+       style="fill:none;stroke:#d8d8d8;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4838-3"
+       d="m 14.5,22.5 c 0,1.10457 -2.91015,2 -6.4999994,2 C 4.4101495,24.5 1.5,23.60457 1.5,22.5 c 0,-1.10457 2.9101495,-2 6.5000006,-2 C 11.58985,20.5 14.5,21.39543 14.5,22.5 l 0,0 z" />
+    <path
+       style="fill:url(#linearGradient3034);fill-opacity:1;stroke:url(#linearGradient3036);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3878"
+       d="m 14.459827,21.5 c 0,1.217851 -2.897339,2 -6.4672665,2 -3.5699332,0 -6.4672704,-0.948833 -6.4672704,-2 0,-4.344467 -0.79047651,-3.046433 6.4672704,-3.10022 7.4239625,-0.0555 6.4672665,-0.829521 6.4672665,3.10022 z" />
+    <path
+       style="fill:url(#linearGradient3029);fill-opacity:1;stroke:url(#linearGradient3031);stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3880"
+       d="m 14.5,18.5 c 0,1.104569 -2.91015,2 -6.4999994,2 C 4.4101495,20.5 1.5,19.604569 1.5,18.5 c 0,-1.104569 2.9101495,-2 6.5000006,-2 C 11.58985,16.5 14.5,17.395431 14.5,18.5 l 0,0 z" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3110);stroke-width:1;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3145"
+       y="17.5"
+       x="2.5"
+       ry="1.5"
+       rx="17.5"
+       height="13"
+       width="11" />
+  </g>
+  <g
+     transform="translate(0.0072863,0.0072863)"
+     id="g4351">
+    <path
+       d="M 10.5,10.5 V 8.4927137 h 3 V 10.5 h 2.007286 v 3 H 13.5 v 2.007286 h -3 V 13.5 H 8.4927137 v -3 z"
+       id="path2262"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3259);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.985427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="M 10.5,10.5 V 8.4927137 h 3 V 10.5 h 2.007286 v 3 H 13.5 v 2.007286 h -3 V 13.5 H 8.4927137 v -3 z"
+       id="path2262-5"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <rect
+       y="9"
+       x="11"
+       height="1"
+       width="2"
+       id="rect4304"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <rect
+       y="14"
+       x="11"
+       height="1"
+       width="2"
+       id="rect4304-6"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <rect
+       y="11"
+       x="9"
+       height="1"
+       width="2"
+       id="rect4304-6-2"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <rect
+       y="11"
+       x="13"
+       height="1"
+       width="2"
+       id="rect4304-6-2-4"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  </g>
+</svg>

--- a/mimes/24/office-database-new.svg
+++ b/mimes/24/office-database-new.svg
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="office-database-new.svg"
+   id="svg3202"
+   height="24"
+   width="24"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:current-layer="svg3202"
+     inkscape:window-maximized="0"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:cy="13.111714"
+     inkscape:cx="10.23608"
+     inkscape:zoom="24.958333"
+     showgrid="false"
+     id="namedview57"
+     inkscape:window-height="928"
+     inkscape:window-width="1760"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <defs
+     id="defs3204">
+    <linearGradient
+       gradientTransform="matrix(0.48571425,0,0,0.5,0.34285661,7.750001)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3125"
+       id="linearGradient3110"
+       y2="44.137077"
+       x2="21.381216"
+       y1="5.0524864"
+       x1="21.381216" />
+    <linearGradient
+       id="linearGradient3125">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3127" />
+      <stop
+         offset="0.08125819"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3129" />
+      <stop
+         offset="0.92327863"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3131" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3133" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.48613594,0,0,0.19884311,0.65625012,19.220963)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient23419"
+       id="radialGradient3984"
+       fy="41.63604"
+       fx="23.334524"
+       r="22.627417"
+       cy="41.63604"
+       cx="23.334524" />
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop23423" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.37654594,0,0,0.35839049,-27.150809,31.67023)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793"
+       id="linearGradient2864"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       id="linearGradient2793">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.8224499,0,0,0.82905873,-65.448598,8.0771844)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858"
+       id="linearGradient2866"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient3858">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         id="stop3860" />
+      <stop
+         offset="1"
+         style="stop-color:#4a4a4a;stop-opacity:1"
+         id="stop3862" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.37654594,0,0,0.35839049,-27.150809,26.670231)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-4"
+       id="linearGradient3813"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       id="linearGradient2793-4">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.8224499,0,0,0.82905873,-65.448598,3.077185)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-22"
+       id="linearGradient3815"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient3858-22">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         id="stop3860-52" />
+      <stop
+         offset="1"
+         style="stop-color:#4a4a4a;stop-opacity:1"
+         id="stop3862-32" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.37654594,0,0,0.352792,-27.150809,21.746031)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-3-0"
+       id="linearGradient3878"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       id="linearGradient2793-3-0">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795-3-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797-7-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.8224499,0,0,0.81610786,-65.448598,-1.478464)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-4-6"
+       id="linearGradient3880"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient3858-4-6">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         id="stop3860-9-8" />
+      <stop
+         offset="1"
+         style="stop-color:#4a4a4a;stop-opacity:1"
+         id="stop3862-9-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3844-4-1">
+      <stop
+         offset="0"
+         style="stop-color:#a5a6a8;stop-opacity:1"
+         id="stop3846-6-6" />
+      <stop
+         offset="1"
+         style="stop-color:#e8e8e8;stop-opacity:1"
+         id="stop3848-9-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2509-9-1">
+      <stop
+         offset="0"
+         style="stop-color:#b3b3b3;stop-opacity:1"
+         id="stop2511-0-9" />
+      <stop
+         offset="1"
+         style="stop-color:#dadada;stop-opacity:1"
+         id="stop2513-3-1" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.37845152,0,0,0.34136193,-27.338025,17.61463)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3844-4-1"
+       id="linearGradient3198"
+       y2="-24.582239"
+       x2="102.30806"
+       y1="-2.3925467"
+       x1="102.30806" />
+    <linearGradient
+       gradientTransform="matrix(0.37845152,0,0,0.34136193,-27.338025,17.61463)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2509-9-1"
+       id="linearGradient3200"
+       y2="-2.3757858"
+       x2="109.95628"
+       y1="-24.91135"
+       x1="109.95628" />
+    <radialGradient
+       gradientTransform="matrix(0,0.52544994,-0.5716256,0,46.193389,-21.123812)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
+       id="radialGradient3900-3"
+       fy="48.216358"
+       fx="65.297462"
+       r="31.000002"
+       cy="48.216358"
+       cx="65.297462" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58-06">
+      <stop
+         id="stop3244-5-8-5-6-4-3-8"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0-7"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35-9"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40-4"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.2817955,0,0,0.2800956,12.196562,12.014885)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4154-3"
+       id="linearGradient3030"
+       y2="35.62291"
+       x2="24.138529"
+       y1="10.631441"
+       x1="24.138529" />
+    <linearGradient
+       id="linearGradient4154-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4156-4" />
+      <stop
+         offset="0.00000002"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4158-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4160-52" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4162-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.2817955,0,0,0.2800956,12.178741,12.02218)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4333"
+       id="linearGradient3030-1"
+       y2="24.912279"
+       x2="24.138529"
+       y1="21.34207"
+       x1="24.138529" />
+    <linearGradient
+       id="linearGradient4333">
+      <stop
+         id="stop4335"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4337"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00000019" />
+      <stop
+         id="stop4339"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4341"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3207">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-8)">
+    <g
+       id="layer1-0">
+      <path
+         style="opacity:0.3;fill:url(#radialGradient3984);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible"
+         id="path23417"
+         d="M 23,27.500001 C 23.000931,29.985169 18.075796,32 12,32 5.9242042,32 0.99906174,29.985169 1.0000001,27.500001 0.99906089,25.014831 5.9242042,23 12,23 c 6.075796,0 11.000939,2.014831 11,4.500001 z" />
+      <path
+         style="fill:url(#linearGradient2864);fill-opacity:1;stroke:url(#linearGradient2866);stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path4834"
+         d="m 21.441286,26.825403 c 0,2.028375 -4.234572,3.674596 -9.452159,3.674596 -5.2175947,0 -9.4521646,-1.646221 -9.4521646,-3.674596 0,-6.488122 -1.1553118,-3.598097 9.4521646,-3.674595 10.850407,-0.07892 9.452159,-2.849032 9.452159,3.674595 z" />
+      <path
+         style="fill:none;stroke:#d8d8d8;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path4838"
+         d="M 21.5,23.000001 C 21.5,24.932997 17.246704,26.5 12.000001,26.5 6.7532954,26.5 2.5,24.932997 2.5,23.000001 2.5,21.067003 6.7532954,19.5 12.000001,19.5 17.246704,19.5 21.5,21.067003 21.5,23.000001 l 0,0 z" />
+      <path
+         style="fill:url(#linearGradient3813);fill-opacity:1;stroke:url(#linearGradient3815);stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path4834-7"
+         d="m 21.441286,21.825404 c 0,2.028375 -4.234572,3.674596 -9.452159,3.674596 -5.2175947,0 -9.4521646,-1.646221 -9.4521646,-3.674596 0,-6.488122 -1.1553118,-3.598097 9.4521646,-3.674595 10.850407,-0.07892 9.452159,-2.849032 9.452159,3.674595 z" />
+      <path
+         style="fill:none;stroke:#d8d8d8;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path4838-3"
+         d="m 21.5,18.000002 c 0,1.932996 -4.253296,3.499999 -9.499999,3.499999 C 6.7532954,21.500001 2.5,19.932998 2.5,18.000002 c 0,-1.932998 4.2532954,-3.500001 9.500001,-3.500001 5.246703,0 9.499999,1.567003 9.499999,3.500001 l 0,0 z" />
+      <path
+         style="fill:url(#linearGradient3878);fill-opacity:1;stroke:url(#linearGradient3880);stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path3878"
+         d="m 21.441286,16.976886 c 0,1.99669 -4.234572,3.523114 -9.452159,3.523114 -5.2175947,0 -9.4521646,-1.526424 -9.4521646,-3.523114 0,-7.1907048 -1.1553118,-3.541892 9.4521646,-3.617194 10.850407,-0.0777 9.452159,-3.109574 9.452159,3.617194 z" />
+      <path
+         style="fill:url(#linearGradient3198);fill-opacity:1;stroke:url(#linearGradient3200);stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path3880"
+         d="m 21.5,13 c 0,1.932997 -4.253296,3.5 -9.499999,3.5 C 6.7532955,16.5 2.5,14.932997 2.5,13 2.5,11.067004 6.7532955,9.5 12.000001,9.5 17.246704,9.5 21.5,11.067004 21.5,13 l 0,0 z" />
+    </g>
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3110);stroke-width:1;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3145"
+       y="10.5"
+       x="3.5"
+       ry="3"
+       rx="17.5"
+       height="19"
+       width="17" />
+  </g>
+  <g
+     transform="translate(0.007286,-0.007295)"
+     id="g4474">
+    <path
+       d="m 16.482179,16.507295 v -3 h 4 v 3 h 3 v 4 h -3 v 2.999991 h -4 v -2.999991 h -2.989465 v -4 z"
+       id="path2262"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3900-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.985427;marker:none;enable-background:accumulate" />
+    <path
+       d="M 17.5,18.004404 V 14.5 h 2 V 18 m 0,1 v 3.5 h -2 V 19"
+       id="path2272"
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 16.482179,16.507295 v -3 h 4 v 3 h 3 v 4 h -3 v 2.999991 h -4 v -2.999991 h -2.989465 v -4 z"
+       id="path2262-2"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       d="m 20,17.507295 2.482179,-0.0073 v 2 L 20,19.507295 m -3,0 -2.5,-0.0073 v -2 l 2.5,0.0073"
+       id="path2272-2"
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030-1);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/mimes/32/office-database-new.svg
+++ b/mimes/32/office-database-new.svg
@@ -1,0 +1,370 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="office-database-new.svg"
+   id="svg3234"
+   height="32"
+   width="32"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:current-layer="svg3234"
+     inkscape:window-maximized="0"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:cy="16"
+     inkscape:cx="16"
+     inkscape:zoom="18.71875"
+     showgrid="false"
+     id="namedview44"
+     inkscape:window-height="896"
+     inkscape:window-width="1771"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       id="grid919"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3236">
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.4581255,0,0,0.4388939,-31.619713,14.933095)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3844"
+       id="linearGradient3136"
+       y2="-24.582239"
+       x2="102.30806"
+       y1="-2.3925467"
+       x1="102.30806" />
+    <linearGradient
+       id="linearGradient3844">
+      <stop
+         offset="0"
+         style="stop-color:#a5a6a8;stop-opacity:1"
+         id="stop3846" />
+      <stop
+         offset="1"
+         style="stop-color:#e8e8e8;stop-opacity:1"
+         id="stop3848" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.4581255,0,0,0.4388939,-31.619713,14.933095)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2509"
+       id="linearGradient3138"
+       y2="-2.3757858"
+       x2="109.95628"
+       y1="-24.91135"
+       x1="109.95628" />
+    <linearGradient
+       id="linearGradient2509">
+      <stop
+         offset="0"
+         style="stop-color:#b3b3b3;stop-opacity:1"
+         id="stop2511" />
+      <stop
+         offset="1"
+         style="stop-color:#dadada;stop-opacity:1"
+         id="stop2513" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.4578345,0,0,0.432286,-31.591968,18.911518)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793"
+       id="linearGradient3141"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       id="linearGradient2793">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-78.157465,-9.546111)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858"
+       id="linearGradient3143"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient3858">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         id="stop3860" />
+      <stop
+         offset="1"
+         style="stop-color:#4a4a4a;stop-opacity:1"
+         id="stop3862" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.4578345,0,0,0.432286,-31.591968,24.911518)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793"
+       id="linearGradient3147"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       gradientTransform="translate(-78.157465,-3.546111)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858"
+       id="linearGradient3149"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.4578345,0,0,0.432286,-31.591968,30.911518)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793"
+       id="linearGradient3153"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       gradientTransform="translate(-78.157465,2.453889)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858"
+       id="linearGradient3155"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop23423" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.59999998,0,0,0.60526317,1.6000001,2.1710523)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3125"
+       id="linearGradient3098"
+       y2="44.137077"
+       x2="21.381216"
+       y1="5.0524864"
+       x1="21.381216" />
+    <linearGradient
+       id="linearGradient3125">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3127" />
+      <stop
+         offset="0.08125819"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3129" />
+      <stop
+         offset="0.92327863"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3131" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3133" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.5745243,0,0,0.2209368,2.59375,17.801069)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient23419"
+       id="radialGradient3232"
+       fy="41.63604"
+       fx="23.334524"
+       r="22.627417"
+       cy="41.63604"
+       cx="23.334524" />
+    <radialGradient
+       gradientTransform="matrix(0,0.68597915,-0.7462606,0,60.288383,-27.737493)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
+       id="radialGradient3343"
+       fy="48.709068"
+       fx="65.325226"
+       r="31.000002"
+       cy="48.709068"
+       cx="65.325226" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58-06">
+      <stop
+         id="stop3244-5-8-5-6-4-3-8"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0-7"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35-9"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40-4"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.42269325,0,0,0.38513145,14.544843,15.082967)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4154"
+       id="linearGradient3030"
+       y2="36.135799"
+       x2="24.138529"
+       y1="10.170639"
+       x1="24.138529" />
+    <linearGradient
+       id="linearGradient4154">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4156" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4158" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4160" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4162" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.38833389,0,0,0.41842122,15.301011,14.318351)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4333"
+       id="linearGradient3030-1"
+       y2="25.52846"
+       x2="24.138529"
+       y1="20.748587"
+       x1="24.138529" />
+    <linearGradient
+       id="linearGradient4333">
+      <stop
+         id="stop4335"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4337"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00000003" />
+      <stop
+         id="stop4339"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4341"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3239">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="opacity:0.3;fill:url(#radialGradient3232);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path23417"
+       d="m 29,27 c 0.0011,2.761299 -5.819514,5 -13,5 C 8.819514,32 2.998891,29.761299 3,27 2.99889,24.238701 8.819514,22 16,22 c 7.180486,0 13.00111,2.238701 13,5 z" />
+    <path
+       style="fill:url(#linearGradient3153);fill-opacity:1;stroke:url(#linearGradient3155);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4834"
+       d="m 27.490168,25.06775 c 0,2.446601 -5.148729,4.43225 -11.492687,4.43225 -6.343968,0 -11.492695,-1.985649 -11.492695,-4.43225 0.11446,-5.469422 -1.40472,-4.33998 11.492695,-4.43225 13.192787,-0.0952 11.330827,-1.126702 11.492687,4.43225 z" />
+    <path
+       style="fill:#868688;fill-opacity:1;stroke:#d8d8d8;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4838"
+       d="m 27.499999,21 c 0,2.485282 -5.148726,4.5 -11.499999,4.5 -6.351275,0 -11.500001,-2.014718 -11.500001,-4.5 0,-2.485281 5.148726,-4.5 11.500001,-4.5 6.351273,0 11.499999,2.014719 11.499999,4.5 l 0,0 z" />
+    <path
+       style="fill:url(#linearGradient3147);fill-opacity:1;stroke:url(#linearGradient3149);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3866"
+       d="m 27.490168,19.06775 c 0,2.446601 -5.148729,4.43225 -11.492687,4.43225 -6.343968,0 -11.492695,-1.985649 -11.492695,-4.43225 0.11446,-5.469422 -1.40472,-4.33998 11.492695,-4.43225 13.192787,-0.0952 11.330827,-1.126702 11.492687,4.43225 z" />
+    <path
+       style="fill:#868688;fill-opacity:1;stroke:#d8d8d8;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3868"
+       d="m 27.499999,15 c 0,2.485282 -5.148726,4.5 -11.499999,4.5 -6.351275,0 -11.500001,-2.014718 -11.500001,-4.5 0,-2.485281 5.148726,-4.5 11.500001,-4.5 6.351273,0 11.499999,2.014719 11.499999,4.5 l 0,0 z" />
+    <path
+       style="fill:url(#linearGradient3141);fill-opacity:1;stroke:url(#linearGradient3143);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3878"
+       d="M 27.490168,13.06775 C 27.490168,15.514351 22.341439,17.5 15.997481,17.5 9.653513,17.5 4.504786,15.514351 4.504786,13.06775 4.619246,7.598328 3.100066,8.72777 15.997481,8.6355 29.190268,8.540298 27.328308,7.508798 27.490168,13.06775 z" />
+    <path
+       style="fill:url(#linearGradient3136);fill-opacity:1;stroke:url(#linearGradient3138);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3880"
+       d="m 27.499999,9 c 0,2.485282 -5.148726,4.5 -11.499999,4.5 C 9.648725,13.5 4.499999,11.485282 4.499999,9 4.499999,6.514719 9.648725,4.5 16,4.5 22.351273,4.5 27.499999,6.514719 27.499999,9 l 0,0 z" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3098);stroke-width:0.99999994;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3145"
+       y="5.499999"
+       x="5.5"
+       ry="4"
+       rx="17.5"
+       height="23"
+       width="21" />
+  </g>
+  <g
+     transform="translate(0.007286,0.021022)"
+     id="g4374">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.985427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2262"
+       d="m 21.5,21.5 v -4.021022 h 5 V 21.5 h 4.007287 v 5 H 26.5 v 4.007286 h -5 V 26.5 h -4.007286 v -5 z" />
+    <path
+       d="M 22.5,23.003028 V 18.5 h 3 v 4.496972 M 25.5,25 v 4.5 h -3 V 25"
+       id="path2272-4"
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 26,22.512298 3.499869,-0.01086 v 2.987703 L 26,25.500001 m -4,0 -3.500131,-0.01086 V 22.501438 L 22,22.512298"
+       id="path2272-2"
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030-1);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path2262-9"
+       d="m 21.5,21.5 v -4.021022 h 5 V 21.5 h 4.007287 v 5 H 26.5 v 4.007286 h -5 V 26.5 h -4.007286 v -5 z" />
+  </g>
+</svg>

--- a/mimes/48/office-database-new.svg
+++ b/mimes/48/office-database-new.svg
@@ -1,0 +1,435 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="office-database-new.svg"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4007">
+  <sodipodi:namedview
+     inkscape:current-layer="svg4007"
+     inkscape:window-maximized="0"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:cy="24"
+     inkscape:cx="24"
+     inkscape:zoom="12.479167"
+     showgrid="false"
+     id="namedview52"
+     inkscape:window-height="917"
+     inkscape:window-width="1840"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       id="grid877"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4009">
+    <linearGradient
+       id="linearGradient4645">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25"
+         offset="0"
+         id="stop4647" />
+      <stop
+         id="stop4653"
+         offset="0.22935779"
+         style="stop-color:#000000;stop-opacity:0.3" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.3"
+         offset="0.82798165"
+         id="stop4655" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.5"
+         offset="1"
+         id="stop4649" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3923">
+      <stop
+         id="stop3925"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3927"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.1303179" />
+      <stop
+         id="stop3929"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.92186069" />
+      <stop
+         id="stop3931"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3844">
+      <stop
+         id="stop3846"
+         style="stop-color:#a5a6a8;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3848"
+         style="stop-color:#e8e8e8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2793">
+      <stop
+         id="stop2795"
+         style="stop-color:#868688;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2797"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         id="stop23421"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="102.30806"
+       y1="-2.3925467"
+       x2="102.30806"
+       y2="-24.582239"
+       id="linearGradient2588-6"
+       xlink:href="#linearGradient3844"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71706604,0,0,0.68272381,-50.534747,39.22926)"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="21.381216"
+       y1="6.0992155"
+       x2="21.381216"
+       y2="42.716518"
+       id="linearGradient3921-1-8"
+       xlink:href="#linearGradient3923"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.52631579,4.5626218e-4,20.605263)" />
+    <linearGradient
+       xlink:href="#linearGradient4645"
+       id="linearGradient4651"
+       x1="70.371254"
+       y1="4.383697"
+       x2="70.371254"
+       y2="44.988827"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.55,-45.999544,20.025)" />
+    <radialGradient
+       cx="23.334524"
+       cy="41.63604"
+       r="22.627417"
+       fx="23.334524"
+       fy="41.63604"
+       id="radialGradient4005-0"
+       xlink:href="#linearGradient23419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9516533,0,0,0.3655503,1.7940803,24.507202)" />
+    <linearGradient
+       x1="21.381216"
+       y1="6.0992155"
+       x2="21.381216"
+       y2="42.716518"
+       id="linearGradient3921-1-8-6"
+       xlink:href="#linearGradient3923"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.52631579,4.563e-4,11.605263)" />
+    <linearGradient
+       x1="102.30806"
+       y1="-2.3925467"
+       x2="102.30806"
+       y2="-24.582239"
+       id="linearGradient2588-6-8"
+       xlink:href="#linearGradient3844"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71706604,0,0,0.68272381,-50.534747,30.22926)"
+       spreadMethod="reflect" />
+    <linearGradient
+       xlink:href="#linearGradient4645"
+       id="linearGradient4651-4"
+       x1="70.371254"
+       y1="4.383697"
+       x2="70.371254"
+       y2="44.988827"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.55,-45.999544,11.025)" />
+    <linearGradient
+       x1="103.95014"
+       y1="-7.6656942"
+       x2="89.423676"
+       y2="-7.6656942"
+       id="linearGradient2593-0-3-8"
+       xlink:href="#linearGradient2793"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71661045,0,0,0.37825027,-50.507696,21.002811)"
+       spreadMethod="reflect" />
+    <linearGradient
+       xlink:href="#linearGradient4645"
+       id="linearGradient4651-4-7"
+       x1="70.371254"
+       y1="4.383697"
+       x2="70.371254"
+       y2="44.988827"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.55,-45.999544,2.025)" />
+    <linearGradient
+       x1="102.30806"
+       y1="-2.3925467"
+       x2="102.30806"
+       y2="-24.582239"
+       id="linearGradient2588-6-8-0"
+       xlink:href="#linearGradient3844"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71706604,0,0,0.68272381,-50.534747,21.22926)"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="21.381216"
+       y1="6.0992155"
+       x2="21.381216"
+       y2="42.716518"
+       id="linearGradient3921-1-8-6-0"
+       xlink:href="#linearGradient3923"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.52631579,4.563e-4,2.605263)" />
+    <radialGradient
+       gradientTransform="matrix(0,0.95936489,-1.0436697,0,87.757589,-35.865792)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
+       id="radialGradient3343"
+       fy="48.744953"
+       fx="65.59787"
+       r="31.000002"
+       cy="48.744953"
+       cx="65.59787" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58-06">
+      <stop
+         id="stop3244-5-8-5-6-4-3-8"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0-7"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35-9"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40-4"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.70448868,0,0,0.59520312,21.241407,23.219131)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4154"
+       id="linearGradient3030"
+       y2="36.594009"
+       x2="24.138529"
+       y1="9.712431"
+       x1="24.138529" />
+    <linearGradient
+       id="linearGradient4154">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4156" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4158" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4160" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4162" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.60015241,0,0,0.69748032,23.556108,20.861165)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4154"
+       id="linearGradient3030-1"
+       y2="26.006231"
+       x2="24.138529"
+       y1="20.271303"
+       x1="24.138529" />
+  </defs>
+  <metadata
+     id="metadata4012">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect4681"
+     width="321"
+     height="219"
+     x="-107"
+     y="-68"
+     rx="18.5"
+     ry="7.90804" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4005-0);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none"
+     id="path23417-9"
+     d="M 45.533912,39.727265 C 45.535712,44.295964 35.894354,48 24.000456,48 12.106558,48 2.4651643,44.295964 2.4670003,39.727265 2.4651783,35.158566 12.106558,31.45453 24.000456,31.45453 c 11.893898,0 21.535294,3.704036 21.533456,8.272735 z" />
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2593-0-3-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
+     id="rect3145-8-9-5"
+     y="23"
+     x="6.0004563"
+     ry="7.4362683"
+     rx="18"
+     height="21"
+     width="36" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient4651);stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3145-8-9"
+     y="22.5"
+     x="5.5004563"
+     ry="7.8645024"
+     rx="18.5"
+     height="22"
+     width="37" />
+  <path
+     style="fill:url(#linearGradient2588-6);fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3880-3"
+     d="M 42.000456,30.000001 C 42.000456,33.865995 33.941581,37 24.000457,37 14.05933,37 6.0004563,33.865995 6.0004563,30.000001 6.0004563,26.134007 14.05933,23 24.000457,23 c 9.941124,0 17.999999,3.134007 17.999999,7.000001 l 0,0 z" />
+  <path
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 5.8285813,31.5 c 1.62708,3.414852 9.1323057,6 18.1503907,6 9.018147,0 16.52535,-2.585104 18.152343,-6"
+     id="path3878-3-4-78" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3921-1-8);stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3145-5-7"
+     y="23.5"
+     x="6.5004563"
+     ry="7"
+     rx="17.5"
+     height="20"
+     width="35" />
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2593-0-3-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
+     id="rect3145-8-9-5-4"
+     y="14"
+     x="6.0004563"
+     ry="7.4362683"
+     rx="18"
+     height="21"
+     width="36" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient4651-4);stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3145-8-9-1"
+     y="13.5"
+     x="5.5004563"
+     ry="7.8645024"
+     rx="18.5"
+     height="22"
+     width="37" />
+  <path
+     style="fill:url(#linearGradient2588-6-8);fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3880-3-2"
+     d="M 42.000456,21.000001 C 42.000456,24.865995 33.941581,28 24.000457,28 14.05933,28 6.0004563,24.865995 6.0004563,21.000001 6.0004563,17.134007 14.05933,14 24.000457,14 c 9.941124,0 17.999999,3.134007 17.999999,7.000001 l 0,0 z" />
+  <path
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 5.8285813,22.5 c 1.62708,3.414852 9.1323057,6 18.1503907,6 9.018147,0 16.52535,-2.585104 18.152343,-6"
+     id="path3878-3-4-78-5" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3921-1-8-6);stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3145-5-7-5"
+     y="14.5"
+     x="6.5004563"
+     ry="7"
+     rx="17.5"
+     height="20"
+     width="35" />
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient2593-0-3-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect3145-8-9-5-4-6"
+     y="5"
+     x="6.0004563"
+     ry="7.4362683"
+     rx="18"
+     height="21"
+     width="36" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient4651-4-7);stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3145-8-9-1-0"
+     y="4.5"
+     x="5.5004563"
+     ry="7.8645024"
+     rx="18.5"
+     height="22"
+     width="37" />
+  <path
+     style="fill:url(#linearGradient2588-6-8-0);fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3880-3-2-3"
+     d="M 42.000456,12.000001 C 42.000456,15.865995 33.941581,19 24.000457,19 14.05933,19 6.0004563,15.865995 6.0004563,12.000001 6.0004563,8.134007 14.05933,5 24.000457,5 c 9.941124,0 17.999999,3.134007 17.999999,7.000001 l 0,0 z" />
+  <path
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 5.8285813,13.5 c 1.62708,3.414852 9.1323057,6 18.1503907,6 9.018147,0 16.52535,-2.585104 18.152343,-6"
+     id="path3878-3-4-78-5-4" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3921-1-8-6-0);stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3145-5-7-5-5"
+     y="5.5"
+     x="6.5004563"
+     ry="7"
+     rx="17.5"
+     height="20"
+     width="35" />
+  <g
+     transform="translate(0.007286,0.02737)"
+     id="g4429">
+    <path
+       d="m 33.500001,33.5 v -6.02737 h 7 V 33.5 h 6.007286 v 7 h -6.007286 v 6.007286 h -7 V 40.5 h -6.007287 v -7 z"
+       id="path2262"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3343);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.985427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2272-4"
+       d="M 34.500001,35.459225 V 28.5 h 5 v 6.949866 m 0,3.095588 V 45.5 h -5 v -6.954546" />
+    <path
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030-1);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2272-2"
+       d="m 40,34.519929 5.499798,-0.01811 v 4.980302 L 40,39.500231 m -6,0 -5.500203,-0.01811 V 34.501819 L 34,34.519929" />
+    <path
+       d="m 33.500001,33.5 v -6.02737 h 7 V 33.5 h 6.007286 v 7 h -6.007286 v 6.007286 h -7 V 40.5 h -6.007287 v -7 z"
+       id="path2262-2"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  </g>
+</svg>

--- a/mimes/64/office-database-new.svg
+++ b/mimes/64/office-database-new.svg
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="office-database-new.svg"
+   id="svg4095"
+   height="64"
+   width="64"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:current-layer="svg4095"
+     inkscape:window-maximized="0"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:cy="32"
+     inkscape:cx="32"
+     inkscape:zoom="9.359375"
+     showgrid="false"
+     id="namedview45"
+     inkscape:window-height="949"
+     inkscape:window-width="1783"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       id="grid870"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4097">
+    <linearGradient
+       gradientTransform="matrix(1.3428571,0,0,1.3684209,-0.228571,-1.0263131)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3923-3"
+       id="linearGradient3921-9"
+       y2="44.137077"
+       x2="21.381216"
+       y1="5.0524864"
+       x1="21.381216" />
+    <linearGradient
+       id="linearGradient3923-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3925-9" />
+      <stop
+         offset="0.08125819"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3927-4" />
+      <stop
+         offset="0.87818879"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3929-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3931-4" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.97600653,0,0,0.97531976,-69.450692,28.684658)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3844-5"
+       id="linearGradient2588-5"
+       y2="-24.582239"
+       x2="102.30806"
+       y1="-2.3925467"
+       x1="102.30806" />
+    <linearGradient
+       id="linearGradient3844-5">
+      <stop
+         offset="0"
+         style="stop-color:#a5a6a8;stop-opacity:1"
+         id="stop3846-5" />
+      <stop
+         offset="1"
+         style="stop-color:#e8e8e8;stop-opacity:1"
+         id="stop3848-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.97600653,0,0,0.97531976,-69.450692,28.684658)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2509-6"
+       id="linearGradient2590-0"
+       y2="-2.3757858"
+       x2="109.95628"
+       y1="-24.91135"
+       x1="109.95628" />
+    <linearGradient
+       id="linearGradient2509-6">
+      <stop
+         offset="0"
+         style="stop-color:#b3b3b3;stop-opacity:1"
+         id="stop2511-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dadada;stop-opacity:1"
+         id="stop2513-6" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.97109202,0,0,0.9306402,-68.967872,38.538767)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-9"
+       id="linearGradient2593-9"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       id="linearGradient2793-9">
+      <stop
+         offset="0"
+         style="stop-color:#868688;stop-opacity:1"
+         id="stop2795-2" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2797-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.1210547,0,0,2.1528346,-167.73585,-22.7258)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-5"
+       id="linearGradient2595-6"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient3858-5">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         id="stop3860-5" />
+      <stop
+         offset="1"
+         style="stop-color:#505050;stop-opacity:1"
+         id="stop3862-3" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.97109202,0,0,0.94151755,-68.967872,50.574288)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-9"
+       id="linearGradient2597-8"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       gradientTransform="matrix(2.1210547,0,0,2.1779969,-167.73585,-11.406342)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-5"
+       id="linearGradient2599-6"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.97109202,0,0,0.94644896,-68.967872,62.590384)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2793-9"
+       id="linearGradient2575-7"
+       y2="-7.6656942"
+       x2="89.423676"
+       y1="-7.6656942"
+       x1="103.95014" />
+    <linearGradient
+       gradientTransform="matrix(2.1210547,0,0,2.1894047,-167.73585,0.2851179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3858-5"
+       id="linearGradient2577-3"
+       y2="27.54611"
+       x2="89.01844"
+       y1="22.536863"
+       x1="89.01844" />
+    <linearGradient
+       id="linearGradient23419-0">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop23421-2" />
+      <stop
+         offset="0.76653445"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3788" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop23423-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,0.4876836,-1.197365,0,81.853543,39.620141)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient23419-0"
+       id="radialGradient4093"
+       fy="41.63604"
+       fx="23.334524"
+       r="22.627417"
+       cy="41.63604"
+       cx="23.334524" />
+    <radialGradient
+       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
+       id="radialGradient3106"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2420762,-1.3512236,0,114.60033,-44.65654)"
+       cx="65.916344"
+       cy="48.448635"
+       fx="65.916344"
+       fy="48.448635"
+       r="31.000002" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58-06">
+      <stop
+         id="stop3244-5-8-5-6-4-3-8"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0-7"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35-9"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40-4"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.9862841,0,0,0.8052748,26.937969,31.355295)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4154"
+       id="linearGradient3030-44"
+       y2="36.813152"
+       x2="24.138529"
+       y1="9.4932871"
+       x1="24.138529" />
+    <linearGradient
+       id="linearGradient4154">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4156" />
+      <stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4158" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4160" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4162" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.8119709,0,0,0.97655406,30.811339,27.403273)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4299"
+       id="linearGradient3030-1"
+       y2="26.211275"
+       x2="24.138529"
+       y1="20.067223"
+       x1="24.138529" />
+    <linearGradient
+       id="linearGradient4299">
+      <stop
+         id="stop4301"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4303"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4305"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4307"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4100">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="opacity:0.3;fill:url(#radialGradient4093);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path23417"
+       d="M 59,51.000001 C 59.002256,57.074857 46.913317,62 32,62 17.086683,62 4.9976982,57.074857 5.0000003,51.000001 4.9977151,44.925142 17.086683,40 32,40 c 14.913317,0 27.002304,4.925142 27,11.000001 z" />
+    <path
+       style="fill:url(#linearGradient2575-7);fill-opacity:1;stroke:url(#linearGradient2577-3);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2561"
+       d="m 56.348579,49.796012 c 0,5.356599 -10.920737,9.703989 -24.376619,9.703989 -13.455903,0 -24.376636,-4.34739 -24.376636,-9.703989 0,-15.522286 -2.9794899,-9.501974 24.376636,-9.703989 27.982623,-0.208432 24.376619,-7.154117 24.376619,9.703989 z" />
+    <path
+       style="fill:#868688;fill-opacity:1;stroke:#d8d8d8;stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2563"
+       d="m 56.500001,39.500002 c 0,5.52285 -10.969025,9.999999 -24.5,9.999999 C 18.469024,49.500001 7.5,45.022852 7.5,39.500002 7.5,33.977152 18.469024,29.5 32.000001,29.5 c 13.530975,0 24.5,4.477152 24.5,10.000002 l 0,0 z" />
+    <path
+       style="fill:url(#linearGradient2597-8);fill-opacity:1;stroke:url(#linearGradient2599-6);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2536"
+       d="M 56.348579,37.846569 C 56.348579,43.175267 45.427842,47.5 31.97196,47.5 18.516057,47.5 7.595324,43.175267 7.595324,37.846569 c 0,-17.080531 -2.9794899,-9.45246 24.376636,-9.65342 27.982623,-0.207343 24.376619,-7.436609 24.376619,9.65342 z" />
+    <path
+       style="fill:#868688;fill-opacity:1;stroke:#d8d8d8;stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path2538"
+       d="m 56.500001,27.500001 c 0,5.52285 -10.969025,9.999999 -24.5,9.999999 -13.530977,0 -24.5000012,-4.477149 -24.5000012,-9.999999 0,-5.522849 10.9690242,-10.000003 24.5000012,-10.000003 13.530975,0 24.5,4.477154 24.5,10.000003 l 0,0 z" />
+    <path
+       style="fill:url(#linearGradient2593-9);fill-opacity:1;stroke:url(#linearGradient2595-6);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3878"
+       d="M 56.348579,25.958099 C 56.348579,31.225227 45.427842,35.5 31.97196,35.5 18.516057,35.5 7.595324,31.225227 7.595324,25.958099 c 0,-18.0203734 -2.9794899,-9.343259 24.376636,-9.5419 27.982623,-0.20495 24.376619,-7.1573174 24.376619,9.5419 z" />
+    <path
+       style="fill:url(#linearGradient2588-5);fill-opacity:1;stroke:url(#linearGradient2590-0);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3880"
+       d="M 56.5,15.5 C 56.5,21.02285 45.530975,25.500001 32,25.500001 18.469023,25.500001 7.4999999,21.02285 7.4999999,15.5 7.4999999,9.977152 18.469023,5.4999989 32,5.4999989 45.530975,5.4999989 56.5,9.977152 56.5,15.5 l 0,0 z" />
+    <rect
+       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3921-9);stroke-width:0.99999994;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3145"
+       y="6.500001"
+       x="8.5"
+       ry="9"
+       rx="23.5"
+       height="51.999996"
+       width="47" />
+  </g>
+  <g
+     transform="translate(0.007286,0.03368)"
+     id="g4309">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3106);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.985427;marker:none;enable-background:accumulate"
+       id="path2262"
+       d="m 44.5,45.50002 v -8.0337 h 9.104416 L 53.5,45.50002 h 8.007287 v 9 H 53.5 v 8.0073 h -9 v -8.0073 h -8.007286 v -9 z" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path2262-9"
+       d="m 44.5,45.50002 v -8.0337 h 9.104416 L 53.5,45.50002 h 8.007287 v 9 H 53.5 v 8.0073 h -9 v -8.0073 h -8.007286 v -9 z" />
+    <path
+       d="m 45.5,47.006331 v -8.50633 h 6.999999 v 8.493668 m 0,6.006331 v 8.5 H 45.5 V 53"
+       id="path2272-4"
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030-44);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 53,46.527141 7.499861,-0.02535 v 6.973006 L 53,53.500147 m -8,0 -7.50014,-0.02535 V 46.501791 L 45,46.527141"
+       id="path2272-2"
+       style="display:inline;opacity:0.5;fill:none;stroke:url(#linearGradient3030-1);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
I'd like to propose the addition of the `office-database-new` mime icons.
This would be useful for SQL application, like Sequeler and Peeq, for toolbar buttons to create a new database.

Preview:
![office-database-new](https://user-images.githubusercontent.com/2527103/82526592-3bd39180-9ae9-11ea-83c6-9b9e31f91c25.png)
