### PR TITLE
Add Inkscape's  Distributions Icons

### DIFF
--- a/actions/16/distribute-graph.svg
+++ b/actions/16/distribute-graph.svg
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="distribute-graph.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient1130"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop1122" />
+      <stop
+         offset="0.01028906"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop1124" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop1126" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop1128" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient939"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop935" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop937" />
+    </linearGradient>
+    <linearGradient
+       id="f-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-69.999916"
+       x2="-69.999916"
+       xlink:href="#linearGradient874"
+       y1="-200.00011"
+       y2="-208.00011"
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="e-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-73.999916"
+       x2="-73.999916"
+       xlink:href="#linearGradient990"
+       y1="-201.72723"
+       y2="-206.27272"
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)" />
+    <linearGradient
+       y2="41.526306"
+       y1="6.4736748"
+       x2="23.99999"
+       x1="23.99999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       id="linearGradient990">
+      <stop
+         id="stop981"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop984"
+         stop-opacity=".235294"
+         stop-color="#fff"
+         offset="0.00000079" />
+      <stop
+         id="stop986"
+         stop-opacity=".156863"
+         stop-color="#fff"
+         offset="1" />
+      <stop
+         id="stop988"
+         stop-opacity=".392157"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient891"
+       id="linearGradient893"
+       x1="-7.0092854"
+       y1="4.8999996"
+       x2="-0.064285286"
+       y2="4.8999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop887" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop889" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     inkscape:snap-others="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.8"
+     inkscape:cx="7.7979142"
+     inkscape:cy="4.1684941"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     inkscape:snap-grids="false"
+     showguides="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       id="path874"
+       style="opacity:1;fill:none;stroke:#95a3ab;stroke-width:0.52916667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:transform-center-y="-0.16250598"
+       d="M 3.5718752,1.7534083 3.1169504,3.5718752 H 1.1163831 L 0.66145819,1.7534083 2.1166668,0.66145837 Z"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:0.26458334;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:0.5"
+       d="M 2.1132812 0.39648438 A 0.26460996 0.26460996 0 0 0 1.9570312 0.44921875 L 0.50195312 1.5410156 A 0.26460996 0.26460996 0 0 0 0.40429688 1.8183594 L 0.859375 3.6367188 A 0.26460996 0.26460996 0 0 0 1.1171875 3.8359375 L 3.1171875 3.8359375 A 0.26460996 0.26460996 0 0 0 3.3730469 3.6367188 L 3.828125 1.8183594 A 0.26460996 0.26460996 0 0 0 3.7304688 1.5410156 L 2.2753906 0.44921875 A 0.26460996 0.26460996 0 0 0 2.1132812 0.39648438 z M 2.1171875 0.9921875 L 3.2714844 1.859375 L 2.9101562 3.3066406 L 1.3222656 3.3066406 L 0.9609375 1.859375 L 2.1171875 0.9921875 z "
+       id="path1304" />
+    <circle
+       style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       id="circle1191"
+       cx="2.1166668"
+       cy="0.66145837"
+       r="0.5291667" />
+    <circle
+       r="0.5291667"
+       cy="0.66145837"
+       cx="2.1166668"
+       id="circle1239"
+       style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       r="0.5291667"
+       cy="0.66145837"
+       cx="2.1166668"
+       id="circle1237"
+       style="opacity:0.5;fill:none;stroke:#002e99;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="circle1241"
+       style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       d="M 2.1037476,0.13229167 A 0.52916671,0.52916671 0 0 0 1.5875,0.66145835 0.52916671,0.52916671 0 0 0 1.6045533,0.79426678 0.52916671,0.52916671 0 0 1 2.1166667,0.39687501 0.52916671,0.52916671 0 0 1 2.6287802,0.79323326 0.52916671,0.52916671 0 0 0 2.6458334,0.66145835 0.52916671,0.52916671 0 0 0 2.1166667,0.13229167 a 0.52916671,0.52916671 0 0 0 -0.012919,0 z" />
+    <g
+       id="g1268"
+       transform="translate(1.4552084,1.0919499)">
+      <circle
+         style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         id="circle1260"
+         cx="2.1166668"
+         cy="0.66145837"
+         r="0.5291667" />
+      <circle
+         r="0.5291667"
+         cy="0.66145837"
+         cx="2.1166668"
+         id="circle1262"
+         style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         r="0.5291667"
+         cy="0.66145837"
+         cx="2.1166668"
+         id="circle1264"
+         style="opacity:0.5;fill:none;stroke:#002e99;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1266"
+         style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.799997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         d="M 7.9511719,0.5 A 2.0000001,2.0000001 0 0 0 6,2.5 2.0000001,2.0000001 0 0 0 6.0644531,3.0019531 2.0000001,2.0000001 0 0 1 8,1.5 2.0000001,2.0000001 0 0 1 9.9355469,2.9980469 2.0000001,2.0000001 0 0 0 10,2.5 a 2.0000001,2.0000001 0 0 0 -2,-2 2.0000001,2.0000001 0 0 0 -0.048828,0 z"
+         transform="scale(0.26458334)" />
+    </g>
+    <g
+       transform="translate(-1.4552086,1.0919499)"
+       id="g1278">
+      <circle
+         r="0.5291667"
+         cy="0.66145837"
+         cx="2.1166668"
+         id="circle1270"
+         style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         id="circle1272"
+         cx="2.1166668"
+         cy="0.66145837"
+         r="0.5291667" />
+      <circle
+         style="opacity:0.5;fill:none;stroke:#002e99;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         id="circle1274"
+         cx="2.1166668"
+         cy="0.66145837"
+         r="0.5291667" />
+      <path
+         transform="scale(0.26458334)"
+         d="M 7.9511719,0.5 A 2.0000001,2.0000001 0 0 0 6,2.5 2.0000001,2.0000001 0 0 0 6.0644531,3.0019531 2.0000001,2.0000001 0 0 1 8,1.5 2.0000001,2.0000001 0 0 1 9.9355469,2.9980469 2.0000001,2.0000001 0 0 0 10,2.5 a 2.0000001,2.0000001 0 0 0 -2,-2 2.0000001,2.0000001 0 0 0 -0.048828,0 z"
+         style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.799997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         id="path1276" />
+    </g>
+    <g
+       id="g1288"
+       transform="translate(1.0002836,2.9104168)">
+      <circle
+         style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         id="circle1280"
+         cx="2.1166668"
+         cy="0.66145837"
+         r="0.5291667" />
+      <circle
+         r="0.5291667"
+         cy="0.66145837"
+         cx="2.1166668"
+         id="circle1282"
+         style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         r="0.5291667"
+         cy="0.66145837"
+         cx="2.1166668"
+         id="circle1284"
+         style="opacity:0.5;fill:none;stroke:#002e99;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1286"
+         style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.799997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         d="M 7.9511719,0.5 A 2.0000001,2.0000001 0 0 0 6,2.5 2.0000001,2.0000001 0 0 0 6.0644531,3.0019531 2.0000001,2.0000001 0 0 1 8,1.5 2.0000001,2.0000001 0 0 1 9.9355469,2.9980469 2.0000001,2.0000001 0 0 0 10,2.5 a 2.0000001,2.0000001 0 0 0 -2,-2 2.0000001,2.0000001 0 0 0 -0.048828,0 z"
+         transform="scale(0.26458334)" />
+    </g>
+    <g
+       transform="translate(-1.0002837,2.9104168)"
+       id="g1298">
+      <circle
+         r="0.5291667"
+         cy="0.66145837"
+         cx="2.1166668"
+         id="circle1290"
+         style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         id="circle1292"
+         cx="2.1166668"
+         cy="0.66145837"
+         r="0.5291667" />
+      <circle
+         style="opacity:0.5;fill:none;stroke:#002e99;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         id="circle1294"
+         cx="2.1166668"
+         cy="0.66145837"
+         r="0.5291667" />
+      <path
+         transform="scale(0.26458334)"
+         d="M 7.9511719,0.5 A 2.0000001,2.0000001 0 0 0 6,2.5 2.0000001,2.0000001 0 0 0 6.0644531,3.0019531 2.0000001,2.0000001 0 0 1 8,1.5 2.0000001,2.0000001 0 0 1 9.9355469,2.9980469 2.0000001,2.0000001 0 0 0 10,2.5 a 2.0000001,2.0000001 0 0 0 -2,-2 2.0000001,2.0000001 0 0 0 -0.048828,0 z"
+         style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.799997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         id="path1296" />
+    </g>
+  </g>
+</svg>

--- a/actions/16/distribute-randomize.svg
+++ b/actions/16/distribute-randomize.svg
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="distribute-randomize.svg"
+   inkscape:version="1.0 (1.0+r73+1)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 4.2333333 4.2333335"
+   height="16"
+   width="16">
+  <defs
+     id="defs2">
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient939">
+      <stop
+         id="stop935"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         id="stop937"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)"
+       y2="-208.00011"
+       y1="-200.00011"
+       xlink:href="#linearGradient874"
+       x2="-69.999916"
+       x1="-69.999916"
+       gradientUnits="userSpaceOnUse"
+       id="f-3" />
+    <linearGradient
+       id="linearGradient874"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop870" />
+      <stop
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop872" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)"
+       y2="-206.27272"
+       y1="-201.72723"
+       xlink:href="#linearGradient990"
+       x2="-73.999916"
+       x1="-73.999916"
+       gradientUnits="userSpaceOnUse"
+       id="e-5" />
+    <linearGradient
+       id="linearGradient990"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop981" />
+      <stop
+         offset="0.00000079"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop984" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop986" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop988" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)"
+       gradientUnits="userSpaceOnUse"
+       y2="4.8999996"
+       x2="-0.064285286"
+       y1="4.8999996"
+       x1="-7.0092854"
+       id="linearGradient893"
+       xlink:href="#linearGradient891" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         id="stop887"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         id="stop889"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient874"
+       id="linearGradient867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09921876,0,0,0.17008928,10.897514,35.422455)"
+       x1="-69.999916"
+       y1="-200.00011"
+       x2="-69.999916"
+       y2="-208.00011" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient990"
+       id="linearGradient975"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06783794,0,0,-0.13567507,8.5596465,-26.953464)"
+       x1="-73.999916"
+       y1="-201.72723"
+       x2="-73.999916"
+       y2="-206.27272" />
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0.09921876,0,0,0.17008928,10.181936,38.203943)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1082"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(0.06783794,0,0,-0.13567507,7.8440688,-24.171976)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1084"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0.09921876,0,0,0.17008928,8.1160256,36.138033)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1099"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(0.06783794,0,0,-0.13567507,5.7781581,-26.237886)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1101"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:window-height="1377"
+     inkscape:window-width="2560"
+     showguides="false"
+     inkscape:snap-grids="false"
+     units="px"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="px"
+     inkscape:cy="8.418795"
+     inkscape:cx="6.9842598"
+     inkscape:zoom="44.8"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true">
+    <inkscape:grid
+       id="grid833"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       style="fill:url(#linearGradient867);fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3"
+       id="use895"
+       stroke-miterlimit="3"
+       d="M 2.9104167,0.1289287 H 4.1010416 V 1.3195536 H 2.9104167 Z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="use905"
+       stroke-miterlimit="3"
+       d="M 2.9137799,0.1322917 H 4.0976784 V 1.3161906 H 2.9137799 Z" />
+    <path
+       id="use921"
+       stroke-miterlimit="3"
+       d="M 3.1665395,1.0634308 H 3.8449188 V 0.3850515 H 3.1665395 Z"
+       style="fill:none;stroke:url(#linearGradient975);stroke-width:0.247662;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       d="M 2.194839,2.9104167 H 3.385464 V 4.1010416 H 2.194839 Z"
+       stroke-miterlimit="3"
+       id="path1074"
+       style="fill:url(#linearGradient1082);fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       d="M 2.1982023,2.9137797 H 3.3821008 V 4.0976786 H 2.1982023 Z"
+       stroke-miterlimit="3"
+       id="path1076"
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1084);stroke-width:0.247662;stroke-miterlimit:3;stroke-dasharray:none"
+       d="M 2.4509618,3.8449188 H 3.1293412 V 3.1665395 H 2.4509618 Z"
+       stroke-miterlimit="3"
+       id="path1078" />
+    <path
+       style="fill:url(#linearGradient1099);fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3"
+       id="path1091"
+       stroke-miterlimit="3"
+       d="M 0.1289283,0.8445063 H 1.3195532 V 2.0351312 H 0.1289283 Z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1093"
+       stroke-miterlimit="3"
+       d="M 0.1322915,0.8478693 H 1.31619 V 2.0317682 H 0.1322915 Z" />
+    <path
+       id="path1095"
+       stroke-miterlimit="3"
+       d="M 0.3850511,1.7790084 H 1.0634304 V 1.1006291 H 0.3850511 Z"
+       style="fill:none;stroke:url(#linearGradient1101);stroke-width:0.247662;stroke-miterlimit:3;stroke-dasharray:none" />
+  </g>
+</svg>

--- a/actions/16/distribute-remove-overlaps.svg
+++ b/actions/16/distribute-remove-overlaps.svg
@@ -1,0 +1,412 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="distribute-remove-overlaps.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient1130"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop1122" />
+      <stop
+         offset="0.01028906"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop1124" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop1126" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop1128" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient939"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop935" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop937" />
+    </linearGradient>
+    <linearGradient
+       id="f-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-69.999916"
+       x2="-69.999916"
+       xlink:href="#linearGradient874"
+       y1="-200.00011"
+       y2="-208.00011"
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="e-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-73.999916"
+       x2="-73.999916"
+       xlink:href="#linearGradient990"
+       y1="-201.72723"
+       y2="-206.27272"
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)" />
+    <linearGradient
+       y2="41.526306"
+       y1="6.4736748"
+       x2="23.99999"
+       x1="23.99999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       id="linearGradient990">
+      <stop
+         id="stop981"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop984"
+         stop-opacity=".235294"
+         stop-color="#fff"
+         offset="0.00000079" />
+      <stop
+         id="stop986"
+         stop-opacity=".156863"
+         stop-color="#fff"
+         offset="1" />
+      <stop
+         id="stop988"
+         stop-opacity=".392157"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient891"
+       id="linearGradient893"
+       x1="-7.0092854"
+       y1="4.8999996"
+       x2="-0.064285286"
+       y2="4.8999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop887" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop889" />
+    </linearGradient>
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(-0.03738684,0,0,-0.18060597,-2.18998,-35.983718)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1080"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.14331599,-0.13229168,0,-26.39219,13.918169)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1086"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.12126737,-0.13229168,0,-26.392166,9.8942976)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1096"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.08819445,-0.1319767,0,-23.284124,7.2319326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1106"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.33072928,-0.15119052,0,-28.726198,26.755957)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1112"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.37897"
+       x2="-73.985489"
+       y1="-201.62358"
+       x1="-73.981499"
+       gradientTransform="matrix(-0.05061601,0,0,-0.68331145,-1.6542204,-137.27886)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1120"
+       xlink:href="#linearGradient1130"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.06614585,-0.13197668,0,-23.284122,7.1768151)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1143"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.06614584,-0.13197668,0,-23.29978,8.6320235)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1147"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient990"
+       id="linearGradient1035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03738684,0,0,-0.23352236,-2.18998,-44.397411)"
+       x1="-73.999916"
+       y1="-201.72723"
+       x2="-73.999916"
+       y2="-206.27272" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1130"
+       id="linearGradient1097"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03738682,0,0,-0.10123142,0.85380929,-19.989752)"
+       x1="-73.981499"
+       y1="-201.62358"
+       x2="-73.985489"
+       y2="-206.37897" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1130"
+       id="linearGradient1101"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03738682,0,0,-0.04831506,0.85380826,-7.6073133)"
+       x1="-73.981499"
+       y1="-201.62358"
+       x2="-73.985489"
+       y2="-206.37897" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1130"
+       id="linearGradient1105"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03738681,0,0,-0.04831506,0.85380907,-6.1521049)"
+       x1="-73.981499"
+       y1="-201.62358"
+       x2="-73.985489"
+       y2="-206.37897" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:snap-others="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="false"
+     inkscape:snap-center="false"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="-1.5235569"
+     inkscape:cy="10.355879"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     inkscape:snap-grids="true"
+     showguides="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:url(#linearGradient1096);fill-opacity:1;stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3"
+       id="path1074"
+       stroke-miterlimit="3"
+       d="M 1.0583558,0.1322906 V 1.587499 H 0.13231416 V 0.1322906 Z" />
+    <path
+       d="M 1.0583332,2.38125 V 4.1010417 H 0.13229149 V 2.38125 Z"
+       stroke-miterlimit="3"
+       id="path1084"
+       style="fill:url(#linearGradient1086);fill-opacity:1;stroke:none;stroke-width:0.129721;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       style="fill:url(#linearGradient1106);fill-opacity:1;stroke:none;stroke-width:0.129646;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1102"
+       stroke-miterlimit="3"
+       d="M 4.1010417,0.13229046 V 1.1906238 H 3.177205 V 0.13229046 Z" />
+    <path
+       d="M 2.6458333,0.13229022 V 4.1010412 H 1.5874999 V 0.13229022 Z"
+       stroke-miterlimit="3"
+       id="path1108"
+       style="fill:url(#linearGradient1112);fill-opacity:1;stroke:none;stroke-width:0.129721;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264584;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1110"
+       stroke-miterlimit="3"
+       d="M 2.645833,0.13229022 V 4.1010412 H 1.5875003 V 0.13229022 Z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1120);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 2.3697467,3.8249541 H 1.8635866 V 0.40837733 h 0.5061601 z"
+       stroke-miterlimit="3"
+       id="path1118" />
+    <path
+       d="m 4.1010417,1.8520834 v 0.79375 H 3.177205 v -0.79375 z"
+       stroke-miterlimit="3"
+       id="path1141"
+       style="fill:url(#linearGradient1143);fill-opacity:1;stroke:none;stroke-width:0.129721;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       style="fill:url(#linearGradient1147);fill-opacity:1;stroke:none;stroke-width:0.129721;stroke-linejoin:round;stroke-miterlimit:3"
+       id="path1145"
+       stroke-miterlimit="3"
+       d="m 4.0853834,3.3072917 v 0.79375 H 3.1615467 v -0.79375 z" />
+    <path
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1149"
+       stroke-miterlimit="3"
+       d="M 4.1010419,0.1322903 V 1.190624 H 3.1772047 V 0.1322903 Z" />
+    <path
+       d="M 1.0583558,0.1322906 V 1.587499 H 0.13231416 V 0.1322906 Z"
+       stroke-miterlimit="3"
+       id="path1027"
+       style="fill:url(#linearGradient1096);fill-opacity:1;stroke:#555761;stroke-width:0.26458334;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;opacity:0.5" />
+    <path
+       id="path1078"
+       stroke-miterlimit="3"
+       d="M 0.78226915,1.3114123 H 0.4084008 V 0.40837731 h 0.37386836 z"
+       style="fill:none;stroke:url(#linearGradient1080);stroke-width:0.28759;stroke-miterlimit:3" />
+    <path
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1031"
+       stroke-miterlimit="3"
+       d="M 1.0583332,2.38125 V 4.1010417 H 0.13229149 V 2.38125 Z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1035);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 0.78226915,3.8249551 H 0.4084008 V 2.6573367 h 0.37386836 z"
+       stroke-miterlimit="3"
+       id="path1033" />
+    <path
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1090"
+       stroke-miterlimit="3"
+       d="M 4.1010419,3.3072915 V 4.1010419 H 3.1772047 V 3.3072915 Z" />
+    <path
+       d="M 4.1010419,1.8520834 V 2.6458338 H 3.1772047 V 1.8520834 Z"
+       stroke-miterlimit="3"
+       id="path1092"
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       id="path1094"
+       stroke-miterlimit="3"
+       d="M 3.8260574,0.91453738 H 3.4521892 V 0.40837735 h 0.3738683 z"
+       style="fill:none;stroke:url(#linearGradient1097);stroke-width:0.28759;stroke-miterlimit:3" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1101);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 3.8260574,2.3697467 H 3.4521892 V 2.12817 h 0.3738683 z"
+       stroke-miterlimit="3"
+       id="path1099" />
+    <path
+       id="path1103"
+       stroke-miterlimit="3"
+       d="M 3.8260573,3.8249551 H 3.4521892 V 3.5833784 h 0.3738682 z"
+       style="fill:none;stroke:url(#linearGradient1105);stroke-width:0.28759;stroke-miterlimit:3" />
+  </g>
+</svg>

--- a/actions/16/distribute-unclump.svg
+++ b/actions/16/distribute-unclump.svg
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="distribute-unclump.svg"
+   inkscape:version="1.0 (1.0+r73+1)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 4.2333333 4.2333335"
+   height="16"
+   width="16">
+  <defs
+     id="defs2">
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient939">
+      <stop
+         id="stop935"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         id="stop937"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)"
+       y2="-208.00011"
+       y1="-200.00011"
+       xlink:href="#linearGradient874"
+       x2="-69.999916"
+       x1="-69.999916"
+       gradientUnits="userSpaceOnUse"
+       id="f-3" />
+    <linearGradient
+       id="linearGradient874"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop870" />
+      <stop
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop872" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)"
+       y2="-206.27272"
+       y1="-201.72723"
+       xlink:href="#linearGradient990"
+       x2="-73.999916"
+       x1="-73.999916"
+       gradientUnits="userSpaceOnUse"
+       id="e-5" />
+    <linearGradient
+       id="linearGradient990"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop981" />
+      <stop
+         offset="0.00000079"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop984" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop986" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop988" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)"
+       gradientUnits="userSpaceOnUse"
+       y2="4.8999996"
+       x2="-0.064285286"
+       y1="4.8999996"
+       x1="-7.0092854"
+       id="linearGradient893"
+       xlink:href="#linearGradient891" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         id="stop887"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         id="stop889"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient874"
+       id="linearGradient867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09921876,0,0,-0.17008928,10.897515,-31.192485)"
+       x1="-69.999916"
+       y1="-200.00011"
+       x2="-69.999916"
+       y2="-208.00011" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient990"
+       id="linearGradient975"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06783794,0,0,-0.13567507,8.5596465,-24.171976)"
+       x1="-73.999916"
+       y1="-201.72723"
+       x2="-73.999916"
+       y2="-206.27272" />
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0.09921876,0,0,-0.17008928,10.103764,-33.97061)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1082"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(0.06783794,0,0,-0.13567507,7.7658965,-26.950101)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1084"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0.09921876,0,0,-0.17008928,8.119389,-31.986235)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1099"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(0.06783794,0,0,-0.13567507,5.7815215,-24.965726)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1101"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:window-height="1377"
+     inkscape:window-width="2560"
+     showguides="false"
+     inkscape:snap-grids="false"
+     units="px"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="px"
+     inkscape:cy="11.336776"
+     inkscape:cx="8.2733101"
+     inkscape:zoom="22.627417"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true">
+    <inkscape:grid
+       id="grid833"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       id="path1103"
+       d="M 3.5057293,3.5057293 2.7119792,0.72760415 0.72760415,2.7119791 Z"
+       style="fill:none;stroke:#c6262e;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:nodetypes="cccc" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       id="path881"
+       d="M 2.84375,0.22265625 0.22265625,2.84375 m 0,0 L 3.890625,3.890625 3.7597656,3.4335938 2.84375,0.22265625 M 2.5800781,1.2324219 3.1210938,3.1210938 1.2324219,2.5800781 Z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1" />
+    <path
+       style="fill:url(#linearGradient867);fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3"
+       id="use895"
+       stroke-miterlimit="3"
+       d="M 2.9104168,4.1010417 H 4.1010417 V 2.9104168 H 2.9104168 Z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="use905"
+       stroke-miterlimit="3"
+       d="M 2.9104165,4.1010419 H 4.1010419 V 2.9104166 H 2.9104165 Z" />
+    <path
+       id="use921"
+       stroke-miterlimit="3"
+       d="M 3.1665396,3.8449189 H 3.8449189 V 3.1665396 H 3.1665396 Z"
+       style="fill:none;stroke:url(#linearGradient975);stroke-width:0.247662;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       d="m 2.1166667,1.3229166 h 1.190625 V 0.13229169 h -1.190625 z"
+       stroke-miterlimit="3"
+       id="path1074"
+       style="fill:url(#linearGradient1082);fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       d="M 2.1166668,1.3229168 H 3.3072917 V 0.1322915 H 2.1166668 Z"
+       stroke-miterlimit="3"
+       id="path1076"
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1084);stroke-width:0.247662;stroke-miterlimit:3;stroke-dasharray:none"
+       d="M 2.3727895,1.0667938 H 3.0511689 V 0.38841451 H 2.3727895 Z"
+       stroke-miterlimit="3"
+       id="path1078" />
+    <path
+       style="fill:url(#linearGradient1099);fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3"
+       id="path1091"
+       stroke-miterlimit="3"
+       d="M 0.13229169,3.3072915 H 1.3229166 V 2.1166667 H 0.13229169 Z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1093"
+       stroke-miterlimit="3"
+       d="M 0.1322915,3.3072918 H 1.3229168 V 2.1166665 H 0.1322915 Z" />
+    <path
+       id="path1095"
+       stroke-miterlimit="3"
+       d="M 0.38841451,3.0511688 H 1.0667938 V 2.3727895 H 0.38841451 Z"
+       style="fill:none;stroke:url(#linearGradient1101);stroke-width:0.247662;stroke-miterlimit:3;stroke-dasharray:none" />
+  </g>
+</svg>

--- a/actions/24/distribute-graph.svg
+++ b/actions/24/distribute-graph.svg
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.3500002"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="distribute-graph.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient1006"
+       inkscape:collect="always">
+      <stop
+         id="stop1002"
+         offset="0"
+         style="stop-color:#64baff;stop-opacity:1;" />
+      <stop
+         id="stop1004"
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1130"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop1122" />
+      <stop
+         offset="0.01028906"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop1124" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop1126" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop1128" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient939"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop935" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop937" />
+    </linearGradient>
+    <linearGradient
+       id="f-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-69.999916"
+       x2="-69.999916"
+       xlink:href="#linearGradient874"
+       y1="-200.00011"
+       y2="-208.00011"
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="e-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-73.999916"
+       x2="-73.999916"
+       xlink:href="#linearGradient990"
+       y1="-201.72723"
+       y2="-206.27272"
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)" />
+    <linearGradient
+       y2="41.526306"
+       y1="6.4736748"
+       x2="23.99999"
+       x1="23.99999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       id="linearGradient990">
+      <stop
+         id="stop981"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop984"
+         stop-opacity=".235294"
+         stop-color="#fff"
+         offset="0.00000079" />
+      <stop
+         id="stop986"
+         stop-opacity=".156863"
+         stop-color="#fff"
+         offset="1" />
+      <stop
+         id="stop988"
+         stop-opacity=".392157"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient891"
+       id="linearGradient893"
+       x1="-7.0092854"
+       y1="4.8999996"
+       x2="-0.064285286"
+       y2="4.8999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop887" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop889" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="2.207633"
+       x2="3.221812"
+       y1="0.3968749"
+       x1="3.2454355"
+       id="linearGradient1008"
+       xlink:href="#linearGradient1006"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:snap-others="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.8"
+     inkscape:cx="9.7367807"
+     inkscape:cy="11.914022"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     inkscape:snap-grids="false"
+     showguides="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       id="path874"
+       style="opacity:1;fill:none;stroke:#95a3ab;stroke-width:0.793681;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:transform-center-y="-0.22344569"
+       d="M 4.4070824,1.0194279 2.2622578,4.3440276 -1.6617331,3.0690456 -1.442893,-0.88134438 2.2010901,-2.1434207 Z"
+       sodipodi:nodetypes="cccccc"
+       transform="matrix(0.63409272,-0.20602922,0.20602922,0.63409272,2.2209121,2.9370954)" />
+    <path
+       transform="matrix(0.63409272,-0.20602922,0.20602922,0.63409272,2.2209121,2.9370954)"
+       id="path1038"
+       d="M 2.2128906 -2.5410156 A 0.3968802 0.3968802 0 0 0 2.0703125 -2.5175781 L -1.5722656 -1.2558594 A 0.3968802 0.3968802 0 0 0 -1.8398438 -0.90234375 L -2.0585938 3.046875 A 0.3968802 0.3968802 0 0 0 -1.7851562 3.4472656 L 2.1386719 4.7207031 A 0.3968802 0.3968802 0 0 0 2.5957031 4.5585938 L 4.7402344 1.234375 A 0.3968802 0.3968802 0 0 0 4.7324219 0.79296875 L 2.5273438 -2.3710938 A 0.3968802 0.3968802 0 0 0 2.2128906 -2.5410156 z M 2.046875 -1.6699219 L 3.9296875 1.0273438 L 2.09375 3.8730469 L -1.2480469 2.7851562 L -1.0605469 -0.59375 L 2.046875 -1.6699219 z "
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:0.39684055;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:0.5" />
+    <path
+       d="m 5.4114907,-1.2785999 a 0.66145832,0.66145832 0 0 0 -0.6614584,0.66145838 0.66145832,0.66145832 0 0 0 0.013436,0.1317749 0.66145832,0.66145832 0 0 1 0.6480225,-0.52864998 0.66145832,0.66145832 0 0 1 0.6480225,0.52968348 0.66145832,0.66145832 0 0 0 0.013436,-0.1328084 0.66145832,0.66145832 0 0 0 -0.6614586,-0.66145838 z"
+       style="opacity:0.2;fill:#fafafa;stroke:none;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       id="circle1195" />
+    <g
+       transform="translate(-0.07043545)"
+       id="g1024">
+      <circle
+         r="0.72760415"
+         cy="1.1244791"
+         cx="3.2454355"
+         id="circle1191"
+         style="fill:url(#linearGradient1008);fill-opacity:1;stroke:none;stroke-width:0.291041;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         id="circle992"
+         cx="3.2454355"
+         cy="1.1244791"
+         r="0.72760415" />
+      <path
+         id="circle1010"
+         style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+         d="m 12.265625,1.5 a 2.7499999,2.7499999 0 0 0 -2.75,2.75 A 2.7499999,2.7499999 0 0 0 9.5625,4.75 2.7499999,2.7499999 0 0 1 12.265625,2.5 2.7499999,2.7499999 0 0 1 14.96875,4.7480469 2.7499999,2.7499999 0 0 0 15.015625,4.25 a 2.7499999,2.7499999 0 0 0 -2.75,-2.75 z"
+         transform="scale(0.26458334)" />
+    </g>
+    <use
+       height="100%"
+       width="100%"
+       transform="translate(2.0505206,1.5510404)"
+       id="use1026"
+       xlink:href="#g1024"
+       y="0"
+       x="0" />
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g1024"
+       id="use1028"
+       transform="translate(1.3753899,4.1010414)"
+       width="100%"
+       height="100%" />
+    <use
+       height="100%"
+       width="100%"
+       transform="translate(-1.37539,4.1010414)"
+       id="use1030"
+       xlink:href="#g1024"
+       y="0"
+       x="0" />
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g1024"
+       id="use1032"
+       transform="translate(-2.0505208,1.5510404)"
+       width="100%"
+       height="100%" />
+  </g>
+</svg>

--- a/actions/24/distribute-randomize.svg
+++ b/actions/24/distribute-randomize.svg
@@ -1,0 +1,431 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.3500002"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="distribute-randomize.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient939"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop935" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop937" />
+    </linearGradient>
+    <linearGradient
+       id="f-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-69.999916"
+       x2="-69.999916"
+       xlink:href="#linearGradient874"
+       y1="-200.00011"
+       y2="-208.00011"
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="e-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-73.999916"
+       x2="-73.999916"
+       xlink:href="#linearGradient990"
+       y1="-201.72723"
+       y2="-206.27272"
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)" />
+    <linearGradient
+       y2="41.526306"
+       y1="6.4736748"
+       x2="23.99999"
+       x1="23.99999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       id="linearGradient990">
+      <stop
+         id="stop981"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop984"
+         stop-opacity=".235294"
+         stop-color="#fff"
+         offset="0.00000079" />
+      <stop
+         id="stop986"
+         stop-opacity=".156863"
+         stop-color="#fff"
+         offset="1" />
+      <stop
+         id="stop988"
+         stop-opacity=".392157"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient874"
+       id="linearGradient887"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.13229168,-0.22678571,0,-42.163243,15.015089)"
+       x1="-69.999916"
+       y1="-200.00011"
+       x2="-69.999916"
+       y2="-208.00011" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient990"
+       id="linearGradient913"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.10353264,0,0,-0.20706405,-3.6121283,-37.081683)"
+       x1="-73.999916"
+       y1="-201.72723"
+       x2="-73.999916"
+       y2="-206.27272" />
+    <linearGradient
+       xlink:href="#linearGradient891"
+       id="linearGradient893"
+       x1="-7.0092854"
+       y1="4.8999996"
+       x2="-0.064285286"
+       y2="4.8999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop887" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop889" />
+    </linearGradient>
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0,0.13229168,-0.22678571,0,-41.104911,11.046338)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient867"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0.13229168,0,0,-0.22678571,11.046338,-45.153035)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient958"
+       xlink:href="#linearGradient939"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(0.10353264,0,0,-0.20706405,8.9037932,-41.129809)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient960"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0.13229168,0,0,-0.22678571,15.015088,-41.104911)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient962"
+       xlink:href="#linearGradient939"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(-0.10353264,0,0,-0.20706405,-2.5537942,-41.050434)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient975"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(-0.10353264,0,0,-0.20706405,-6.5225449,-39.9921)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient979"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0,0.13229168,-0.22678571,0,-45.073661,12.104672)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient985"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(0.10353264,0,0,-0.20706405,16.855981,-38.140017)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient992"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0.13229168,0,0,-0.22678571,18.998526,-42.163244)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient998"
+       xlink:href="#linearGradient891"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="4.8455841"
+     inkscape:cy="10.260131"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     inkscape:snap-grids="false"
+     showguides="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       d="m -3.0426754,4.1010122 h 2.11666632 V 0.66142885 H -3.0426754 Z"
+       stroke-miterlimit="3"
+       id="path41-0"
+       style="fill:url(#f-3);stroke:none;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       style="fill:none;stroke:url(#e-5);stroke-width:0.264583;stroke-miterlimit:3"
+       d="m -2.7780924,3.8364585 h 1.5875 V 0.92604178 h -1.5875 z"
+       stroke-miterlimit="3"
+       id="path43-6" />
+    <path
+       d="m -3.0426754,4.1010122 h 2.11666632 V 0.66142885 H -3.0426754 Z"
+       stroke-miterlimit="3"
+       id="path41-2-2"
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       style="fill:url(#linearGradient985);fill-opacity:1;stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3"
+       id="use897"
+       stroke-miterlimit="3"
+       d="M 1.984374,1.4552081 V 3.0427082 H 0.39687415 V 1.4552081 Z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="use907"
+       stroke-miterlimit="3"
+       d="M 1.9843744,1.4552083 V 3.0427077 H 0.3968746 V 1.4552083 Z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient979);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 1.7082873,2.766621 H 0.6729609 V 1.7312948 h 1.0353264 z"
+       stroke-miterlimit="3"
+       id="use919" />
+    <path
+       d="M 5.9531243,0.39687477 V 1.9843748 H 4.3656245 V 0.39687477 Z"
+       stroke-miterlimit="3"
+       id="use895"
+       style="fill:url(#linearGradient867);fill-opacity:1;stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       d="M 5.9531244,0.39687501 V 1.9843744 H 4.3656246 V 0.39687501 Z"
+       stroke-miterlimit="3"
+       id="use905"
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       style="fill:none;stroke:url(#linearGradient975);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 5.6770376,1.7082878 H 4.6417112 V 0.67296161 h 1.0353264 z"
+       stroke-miterlimit="3"
+       id="use921" />
+    <path
+       style="fill:url(#linearGradient887);fill-opacity:1;stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3"
+       id="path885"
+       stroke-miterlimit="3"
+       d="M 4.894791,4.3656247 V 5.9531246 H 3.3072911 V 4.3656247 Z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path901"
+       stroke-miterlimit="3"
+       d="M 4.8947911,4.365625 V 5.9531244 H 3.3072913 V 4.365625 Z" />
+    <path
+       id="path911"
+       stroke-miterlimit="3"
+       d="M 4.6187041,5.6770377 H 3.5833779 V 4.6417115 h 1.0353262 z"
+       style="fill:none;stroke:url(#linearGradient913);stroke-width:0.28759;stroke-miterlimit:3" />
+    <path
+       id="path918"
+       d="M 9.1428126,4.1010415 13.111563,5.1593749"
+       style="fill:none;stroke:#c6262e;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path920"
+       d="M 12.053229,1.1906248 9.1428122,4.1010412"
+       style="fill:none;stroke:#c6262e;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#c6262e;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 9.1428126,4.1010415 13.111563,5.1593749"
+       id="path922" />
+    <path
+       style="fill:#c6262e;stroke:#c6262e;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 13.111563,5.1593749 12.053229,1.1906247"
+       id="path924" />
+    <path
+       style="fill:none;stroke:#c6262e;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 12.053229,1.1906248 9.1428122,4.1010412"
+       id="path926" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       d="m 11.866251,1.0039062 -2.9101567,2.9101563 0.3730469,0.375 2.9121098,-2.9121094 z"
+       id="path928" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       d="M 9.2119537,3.8457031 9.075235,4.3574219 13.043985,5.4140625 13.180704,4.9042969 Z"
+       id="path930" />
+    <path
+       id="path932"
+       d="m 12.309981,1.1222122 -0.511719,0.1367187 1.058594,3.96875 0.509765,-0.1367187 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000" />
+    <path
+       style="fill:url(#linearGradient998);fill-opacity:1.0;stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3"
+       id="use934"
+       stroke-miterlimit="3"
+       d="m 8.3490622,4.8947912 h 1.5875 V 3.3072913 h -1.5875 z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#ad5f00;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="use936"
+       stroke-miterlimit="3"
+       d="M 8.3490629,4.8947913 H 9.9365623 V 3.3072915 H 8.3490629 Z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient992);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 8.625149,4.6187046 H 9.6604754 V 3.5833784 H 8.625149 Z"
+       stroke-miterlimit="3"
+       id="use938" />
+    <g
+       transform="translate(7.9521881)"
+       id="g948">
+      <path
+         d="m 4.3656244,5.9531246 h 1.5875 V 4.3656247 h -1.5875 z"
+         stroke-miterlimit="3"
+         id="path942"
+         style="fill:url(#linearGradient962);stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3" />
+      <path
+         d="M 4.3656248,5.9531246 H 5.9531242 V 4.3656248 H 4.3656248 Z"
+         stroke-miterlimit="3"
+         id="path944"
+         style="opacity:0.5;fill:none;stroke:#ad5f00;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+      <use
+         x="0"
+         y="0"
+         xlink:href="#path911"
+         id="use946"
+         transform="translate(1.0583334,3.9687499)"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       id="g956"
+       transform="translate(10.862605,0.07937459)">
+      <path
+         style="fill:url(#linearGradient958);stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3"
+         id="path950"
+         stroke-miterlimit="3"
+         d="M 0.39687435,1.9050001 H 1.9843743 V 0.31750024 H 0.39687435 Z" />
+      <path
+         style="opacity:0.5;fill:none;stroke:#ad5f00;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+         id="path952"
+         stroke-miterlimit="3"
+         d="M 0.39687483,1.905 H 1.9843742 V 0.31750024 H 0.39687483 Z" />
+      <path
+         id="path954"
+         stroke-miterlimit="3"
+         d="M 0.67296114,1.6289133 H 1.7082875 V 0.59358707 H 0.67296114 Z"
+         style="fill:none;stroke:url(#linearGradient960);stroke-width:0.28759;stroke-miterlimit:3" />
+    </g>
+  </g>
+</svg>

--- a/actions/24/distribute-remove-overlaps.svg
+++ b/actions/24/distribute-remove-overlaps.svg
@@ -1,0 +1,426 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.3500002"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="distribute-remove-overlaps.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient1130"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop1122" />
+      <stop
+         offset="0.01028906"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop1124" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop1126" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop1128" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient939"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop935" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop937" />
+    </linearGradient>
+    <linearGradient
+       id="f-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-69.999916"
+       x2="-69.999916"
+       xlink:href="#linearGradient874"
+       y1="-200.00011"
+       y2="-208.00011"
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="e-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-73.999916"
+       x2="-73.999916"
+       xlink:href="#linearGradient990"
+       y1="-201.72723"
+       y2="-206.27272"
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)" />
+    <linearGradient
+       y2="41.526306"
+       y1="6.4736748"
+       x2="23.99999"
+       x1="23.99999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       id="linearGradient990">
+      <stop
+         id="stop981"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop984"
+         stop-opacity=".235294"
+         stop-color="#fff"
+         offset="0.00000079" />
+      <stop
+         id="stop986"
+         stop-opacity=".156863"
+         stop-color="#fff"
+         offset="1" />
+      <stop
+         id="stop988"
+         stop-opacity=".392157"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient891"
+       id="linearGradient893"
+       x1="-7.0092854"
+       y1="4.8999996"
+       x2="-0.064285286"
+       y2="4.8999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop887" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop889" />
+    </linearGradient>
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(-0.07707435,0,0,-0.31289692,-4.6836807,-62.375754)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1080"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.17638894,-0.18898363,0,-37.494309,14.596161)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1082"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.20946183,-0.18898363,0,-37.494342,20.301235)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1086"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.17638894,-0.18898363,0,-37.494309,14.596161)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1096"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.12126741,-0.17008926,0,-29.340396,12.143262)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1106"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.46302093,-0.20788685,0,-39.074801,37.670002)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1112"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(-0.07707434,0,0,-0.39227151,-4.6837117,-75.327023)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1116"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.37897"
+       x2="-73.985489"
+       y1="-201.62358"
+       x1="-73.981499"
+       gradientTransform="matrix(-0.09030351,0,0,-1.0008096,-3.3934858,-200.99014)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1120"
+       xlink:href="#linearGradient1130"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.08819445,-0.17008926,0,-29.340396,7.4965161)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1143"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-204.58333"
+       x2="-68.49987"
+       y1="-204.58333"
+       x1="-80.49987"
+       gradientTransform="matrix(0,0.0992188,-0.17008926,0,-29.340396,12.749601)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1147"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(-0.06384518,0,0,-0.18060598,0.60135449,-33.734759)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1161"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(-0.06384518,0,0,-0.10123143,0.60135447,-19.725168)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1165"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(-0.06384518,0,0,-0.12768959,0.60135447,-20.69086)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1169"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:snap-others="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="false"
+     inkscape:snap-center="false"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="10.177962"
+     inkscape:cy="10.424251"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     inkscape:snap-grids="true"
+     showguides="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:url(#linearGradient1096);fill-opacity:1;stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3"
+       id="path1074"
+       stroke-miterlimit="3"
+       d="M 1.719792,0.39687503 V 2.5135421 H 0.39690673 V 0.39687503 Z" />
+    <path
+       d="M 1.7197602,3.4395837 V 5.9531255 H 0.39687499 V 3.4395837 Z"
+       stroke-miterlimit="3"
+       id="path1084"
+       style="fill:url(#linearGradient1086);fill-opacity:1;stroke:none;stroke-width:0.129721;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1094"
+       stroke-miterlimit="3"
+       d="M 1.7197602,3.4395837 V 5.9531255 H 0.39687499 V 3.4395837 Z" />
+    <path
+       style="fill:url(#linearGradient1106);fill-opacity:1;stroke:none;stroke-width:0.129721;stroke-linejoin:round;stroke-miterlimit:3"
+       id="path1102"
+       stroke-miterlimit="3"
+       d="M 5.9531247,2.3812499 V 3.8364588 H 4.7625001 V 2.3812499 Z" />
+    <path
+       d="M 1.719792,0.39687503 V 2.5135421 H 0.39690673 V 0.39687503 Z"
+       stroke-miterlimit="3"
+       id="path1092"
+       style="opacity:0.5;fill:url(#linearGradient1082);fill-opacity:1;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       id="path1078"
+       stroke-miterlimit="3"
+       d="M 1.443721,2.2374553 H 0.67297769 V 0.67296183 H 1.443721 Z"
+       style="fill:none;stroke:url(#linearGradient1080);stroke-width:0.28759;stroke-miterlimit:3" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1116);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 1.4436893,5.6770389 H 0.67294591 V 3.7156703 H 1.4436893 Z"
+       stroke-miterlimit="3"
+       id="path1114" />
+    <g
+       transform="translate(-0.09296848)"
+       id="g1139">
+      <path
+         style="fill:url(#linearGradient1112);fill-opacity:1;stroke:none;stroke-width:0.129721;stroke-linejoin:round;stroke-miterlimit:3"
+         id="path1108"
+         stroke-miterlimit="3"
+         d="M 4.0617182,0.3968745 V 5.9531251 H 2.6065105 V 0.3968745 Z" />
+      <path
+         d="M 4.0617182,0.3968745 V 5.9531251 H 2.6065105 V 0.3968745 Z"
+         stroke-miterlimit="3"
+         id="path1110"
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264584;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+      <path
+         id="path1118"
+         stroke-miterlimit="3"
+         d="M 3.7856319,5.6770381 H 2.8825969 V 0.67296148 h 0.903035 z"
+         style="fill:none;stroke:url(#linearGradient1120);stroke-width:0.28759;stroke-miterlimit:3" />
+    </g>
+    <path
+       d="M 5.9531247,0.39687419 V 1.4552076 H 4.7625001 V 0.39687419 Z"
+       stroke-miterlimit="3"
+       id="path1141"
+       style="fill:url(#linearGradient1143);fill-opacity:1;stroke:none;stroke-width:0.129721;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       style="fill:url(#linearGradient1147);fill-opacity:1;stroke:none;stroke-width:0.129721;stroke-linejoin:round;stroke-miterlimit:3"
+       id="path1145"
+       stroke-miterlimit="3"
+       d="M 5.9531247,4.7625001 V 5.9531257 H 4.7625001 V 4.7625001 Z" />
+    <path
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1149"
+       stroke-miterlimit="3"
+       d="M 5.9531246,2.38125 V 3.8364587 H 4.7625 V 2.38125 Z" />
+    <path
+       d="M 5.9531246,0.39687399 V 1.4552077 H 4.7625 V 0.39687399 Z"
+       stroke-miterlimit="3"
+       id="path1151"
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="path1153"
+       stroke-miterlimit="3"
+       d="M 5.9531246,4.7625002 V 5.9531256 H 4.7625 V 4.7625002 Z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1161);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 5.6770382,3.5603721 H 5.0385865 v -0.903035 h 0.6384517 z"
+       stroke-miterlimit="3"
+       id="path1159" />
+    <path
+       id="path1163"
+       stroke-miterlimit="3"
+       d="M 5.6770382,1.179121 H 5.0385865 V 0.67296089 h 0.6384517 z"
+       style="fill:none;stroke:url(#linearGradient1165);stroke-width:0.28759;stroke-miterlimit:3" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1169);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 5.6770382,5.6770384 H 5.0385865 V 5.0385867 h 0.6384517 z"
+       stroke-miterlimit="3"
+       id="path1167" />
+  </g>
+</svg>

--- a/actions/24/distribute-unclump.svg
+++ b/actions/24/distribute-unclump.svg
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="distribute-unclump.svg"
+   inkscape:version="1.0 (1.0+r73+1)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 6.3499999 6.3500002"
+   height="24"
+   width="24">
+  <defs
+     id="defs2">
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient939">
+      <stop
+         id="stop935"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         id="stop937"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)"
+       y2="-208.00011"
+       y1="-200.00011"
+       xlink:href="#linearGradient874"
+       x2="-69.999916"
+       x1="-69.999916"
+       gradientUnits="userSpaceOnUse"
+       id="f-3" />
+    <linearGradient
+       id="linearGradient874"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop870" />
+      <stop
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop872" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)"
+       y2="-206.27272"
+       y1="-201.72723"
+       xlink:href="#linearGradient990"
+       x2="-73.999916"
+       x1="-73.999916"
+       gradientUnits="userSpaceOnUse"
+       id="e-5" />
+    <linearGradient
+       id="linearGradient990"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop981" />
+      <stop
+         offset="0.00000079"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop984" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop986" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop988" />
+    </linearGradient>
+    <linearGradient
+       y2="-208.00011"
+       x2="-69.999916"
+       y1="-200.00011"
+       x1="-69.999916"
+       gradientTransform="matrix(0.13229168,0,0,-0.22678571,13.956755,-45.07366)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient887"
+       xlink:href="#linearGradient874"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-206.27272"
+       x2="-73.999916"
+       y1="-201.72723"
+       x1="-73.999916"
+       gradientTransform="matrix(0.10353264,0,0,-0.20706405,11.81421,-41.050434)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient913"
+       xlink:href="#linearGradient990"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)"
+       gradientUnits="userSpaceOnUse"
+       y2="4.8999996"
+       x2="-0.064285286"
+       y1="4.8999996"
+       x1="-7.0092854"
+       id="linearGradient893"
+       xlink:href="#linearGradient891" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         id="stop887"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         id="stop889"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient874"
+       id="linearGradient867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13229168,0,0,-0.22678571,15.015088,-41.104911)"
+       x1="-69.999916"
+       y1="-200.00011"
+       x2="-69.999916"
+       y2="-208.00011" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient990"
+       id="linearGradient975"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10353264,0,0,-0.20706405,12.872543,-37.081684)"
+       x1="-73.999916"
+       y1="-201.72723"
+       x2="-73.999916"
+       y2="-206.27272" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient990"
+       id="linearGradient979"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10353264,0,0,-0.20706405,8.9037931,-38.140017)"
+       x1="-73.999916"
+       y1="-201.72723"
+       x2="-73.999916"
+       y2="-206.27272" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient874"
+       id="linearGradient985"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13229168,0,0,-0.22678571,11.046338,-42.163244)"
+       x1="-69.999916"
+       y1="-200.00011"
+       x2="-69.999916"
+       y2="-208.00011" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:window-height="1377"
+     inkscape:window-width="2560"
+     showguides="false"
+     inkscape:snap-grids="false"
+     units="px"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="px"
+     inkscape:cy="11.064969"
+     inkscape:cx="23.394795"
+     inkscape:zoom="22.4"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true">
+    <inkscape:grid
+       id="grid833"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       id="path892"
+       d="M 1.1906245,4.1010415 5.1593746,5.1593749"
+       style="fill:none;stroke:#c6262e;stroke-width:0.52916667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       id="path896"
+       d="M 4.101041,1.1906248 1.1906241,4.1010412"
+       style="fill:none;stroke:#c6262e;stroke-width:0.52916667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       style="fill:none;stroke:#c6262e;stroke-width:0.52916667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 1.1906245,4.1010415 5.1593746,5.1593749"
+       id="path886" />
+    <path
+       style="fill:#c6262e;stroke:#c6262e;stroke-width:0.52916667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 5.1593746,5.1593749 4.1010412,1.1906247"
+       id="path888" />
+    <path
+       style="fill:none;stroke:#c6262e;stroke-width:0.52916667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 4.101041,1.1906248 1.1906241,4.1010412"
+       id="path890" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:0.26458334;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:0.5"
+       d="M 3.9140625 1.0039062 L 1.0039062 3.9140625 L 1.3769531 4.2890625 L 4.2890625 1.3769531 L 3.9140625 1.0039062 z "
+       id="path910" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:0.26458334;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:0.5"
+       d="M 1.2597656 3.8457031 L 1.1230469 4.3574219 L 5.0917969 5.4140625 L 5.2285156 4.9042969 L 1.2597656 3.8457031 z "
+       id="path916" />
+    <path
+       id="path902"
+       d="M 4.3577926,1.1222122 3.8460738,1.2589309 4.9046676,5.2276809 5.4144332,5.0909622 Z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000" />
+    <path
+       d="m 0.3968741,4.8947912 h 1.5875 V 3.3072913 h -1.5875 z"
+       stroke-miterlimit="3"
+       id="use897"
+       style="fill:url(#linearGradient985);stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3;fill-opacity:1.0" />
+    <path
+       d="M 0.3968748,4.8947913 H 1.9843742 V 3.3072915 H 0.3968748 Z"
+       stroke-miterlimit="3"
+       id="use907"
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       id="use919"
+       stroke-miterlimit="3"
+       d="M 0.6729609,4.6187046 H 1.7082873 V 3.5833784 H 0.6729609 Z"
+       style="fill:none;stroke:url(#linearGradient979);stroke-width:0.28759;stroke-miterlimit:3" />
+    <path
+       style="fill:url(#linearGradient867);stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3;fill-opacity:1.0"
+       id="use895"
+       stroke-miterlimit="3"
+       d="m 4.3656244,5.9531246 h 1.5875 V 4.3656247 h -1.5875 z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none"
+       id="use905"
+       stroke-miterlimit="3"
+       d="M 4.3656248,5.9531246 H 5.9531242 V 4.3656248 H 4.3656248 Z" />
+    <path
+       id="use921"
+       stroke-miterlimit="3"
+       d="M 4.6417112,5.6770378 H 5.6770376 V 4.6417116 H 4.6417112 Z"
+       style="fill:none;stroke:url(#linearGradient975);stroke-width:0.28759;stroke-miterlimit:3" />
+    <path
+       d="M 3.3072911,1.9843747 H 4.894791 V 0.39687483 H 3.3072911 Z"
+       stroke-miterlimit="3"
+       id="path885"
+       style="fill:url(#linearGradient887);stroke:none;stroke-width:0.129722;stroke-linejoin:round;stroke-miterlimit:3;fill-opacity:1.0" />
+    <path
+       d="M 3.3072915,1.9843746 H 4.8947909 V 0.39687483 H 3.3072915 Z"
+       stroke-miterlimit="3"
+       id="path901"
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none" />
+    <path
+       style="fill:none;stroke:url(#linearGradient913);stroke-width:0.28759;stroke-miterlimit:3"
+       d="M 3.5833778,1.7082879 H 4.6187042 V 0.67296166 H 3.5833778 Z"
+       stroke-miterlimit="3"
+       id="path911" />
+  </g>
+</svg>

--- a/actions/symbolic/distribute-graph-symbolic.svg
+++ b/actions/symbolic/distribute-graph-symbolic.svg
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="distribute-graph-symbolic.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient1130"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop1122" />
+      <stop
+         offset="0.01028906"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop1124" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop1126" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop1128" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient939"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop935" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop937" />
+    </linearGradient>
+    <linearGradient
+       id="f-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-69.999916"
+       x2="-69.999916"
+       xlink:href="#linearGradient874"
+       y1="-200.00011"
+       y2="-208.00011"
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="e-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-73.999916"
+       x2="-73.999916"
+       xlink:href="#linearGradient990"
+       y1="-201.72723"
+       y2="-206.27272"
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)" />
+    <linearGradient
+       y2="41.526306"
+       y1="6.4736748"
+       x2="23.99999"
+       x1="23.99999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       id="linearGradient990">
+      <stop
+         id="stop981"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop984"
+         stop-opacity=".235294"
+         stop-color="#fff"
+         offset="0.00000079" />
+      <stop
+         id="stop986"
+         stop-opacity=".156863"
+         stop-color="#fff"
+         offset="1" />
+      <stop
+         id="stop988"
+         stop-opacity=".392157"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient891"
+       id="linearGradient893"
+       x1="-7.0092854"
+       y1="4.8999996"
+       x2="-0.064285286"
+       y2="4.8999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop887" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop889" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     inkscape:snap-others="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="9.5070027"
+     inkscape:cy="6.1166839"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     inkscape:snap-grids="false"
+     showguides="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       id="circle1191"
+       cx="2.1166668"
+       cy="0.66145837"
+       r="0.5291667" />
+    <path
+       d="M 2.6458335,0.66145837 A 0.5291667,0.5291667 0 0 1 2.1166668,1.1906251 0.5291667,0.5291667 0 0 1 1.5875001,0.66145837 0.5291667,0.5291667 0 0 1 2.1166668,0.13229167 0.5291667,0.5291667 0 0 1 2.6458335,0.66145837"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       id="circle1239" />
+    <circle
+       r="0.5291667"
+       cy="1.7534083"
+       cx="3.5718751"
+       id="circle1260"
+       style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="M 4.1010418,1.7534083 A 0.5291667,0.5291667 0 0 1 3.5718751,2.282575 0.5291667,0.5291667 0 0 1 3.0427084,1.7534083 0.5291667,0.5291667 0 0 1 3.5718751,1.2242416 0.5291667,0.5291667 0 0 1 4.1010418,1.7534083"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0973667;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       id="circle1262" />
+    <circle
+       style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       id="circle1270"
+       cx="0.66145819"
+       cy="1.7534083"
+       r="0.5291667" />
+    <path
+       d="M 1.1906249,1.7534083 A 0.5291667,0.5291667 0 0 1 0.66145819,2.282575 0.5291667,0.5291667 0 0 1 0.1322915,1.7534083 0.5291667,0.5291667 0 0 1 0.66145819,1.2242416 0.5291667,0.5291667 0 0 1 1.1906249,1.7534083"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       id="circle1272" />
+    <circle
+       r="0.5291667"
+       cy="3.5718751"
+       cx="3.1169505"
+       id="circle1280"
+       style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="M 3.6461172,3.5718751 A 0.5291667,0.5291667 0 0 1 3.1169505,4.1010418 0.5291667,0.5291667 0 0 1 2.5877838,3.5718751 0.5291667,0.5291667 0 0 1 3.1169505,3.0427084 0.5291667,0.5291667 0 0 1 3.6461172,3.5718751"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       id="circle1282" />
+    <circle
+       style="fill:#64baff;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       id="circle1290"
+       cx="1.1163831"
+       cy="3.5718751"
+       r="0.5291667" />
+    <path
+       d="M 1.6455498,3.5718751 A 0.5291667,0.5291667 0 0 1 1.1163831,4.1010418 0.5291667,0.5291667 0 0 1 0.58721638,3.5718751 0.5291667,0.5291667 0 0 1 1.1163831,3.0427084 0.5291667,0.5291667 0 0 1 1.6455498,3.5718751"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.211666;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       id="circle1292" />
+    <path
+       id="path938"
+       style="opacity:1;fill:none;stroke:#95a3ab;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:transform-center-y="-0.16250598"
+       d="M -1.5442018,1.7534049 -1.9991266,3.5718718 H -3.9996939 L -4.4546188,1.7534083 -2.9994102,0.66145495 Z"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path956"
+       d="M 2.109375 0.52929688 A 0.13230472 0.13230472 0 0 0 2.0371094 0.5546875 L 0.58203125 1.6464844 A 0.13230472 0.13230472 0 0 0 0.53320312 1.7851562 L 0.98828125 3.6035156 A 0.13230472 0.13230472 0 0 0 1.1152344 3.703125 L 3.1171875 3.703125 A 0.13230472 0.13230472 0 0 0 3.2441406 3.6035156 L 3.6992188 1.7851562 A 0.13230472 0.13230472 0 0 0 3.6503906 1.6464844 L 2.1953125 0.5546875 A 0.13230472 0.13230472 0 0 0 2.109375 0.52929688 z M 2.1171875 0.82617188 L 3.421875 1.8066406 L 3.0136719 3.4394531 L 1.21875 3.4394531 L 0.81054688 1.8066406 L 2.1171875 0.82617188 z "
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       d="M 8.1912466,-2.1506492 7.7363218,-0.33218229 H 5.7357545 L 5.2808296,-2.1506458 6.7360382,-3.2425991 Z"
+       inkscape:transform-center-y="-0.16250598"
+       style="opacity:1;fill:none;stroke:#555761;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path952" />
+  </g>
+</svg>

--- a/actions/symbolic/distribute-randomize-symbolic.svg
+++ b/actions/symbolic/distribute-randomize-symbolic.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="distribute-randomize-symbolic.svg"
+   inkscape:version="1.0 (1.0+r73+1)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 4.2333333 4.2333335"
+   height="16"
+   width="16">
+  <defs
+     id="defs2">
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient939">
+      <stop
+         id="stop935"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         id="stop937"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)"
+       y2="-208.00011"
+       y1="-200.00011"
+       xlink:href="#linearGradient874"
+       x2="-69.999916"
+       x1="-69.999916"
+       gradientUnits="userSpaceOnUse"
+       id="f-3" />
+    <linearGradient
+       id="linearGradient874"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop870" />
+      <stop
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop872" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)"
+       y2="-206.27272"
+       y1="-201.72723"
+       xlink:href="#linearGradient990"
+       x2="-73.999916"
+       x1="-73.999916"
+       gradientUnits="userSpaceOnUse"
+       id="e-5" />
+    <linearGradient
+       id="linearGradient990"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop981" />
+      <stop
+         offset="0.00000079"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop984" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop986" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop988" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)"
+       gradientUnits="userSpaceOnUse"
+       y2="4.8999996"
+       x2="-0.064285286"
+       y1="4.8999996"
+       x1="-7.0092854"
+       id="linearGradient893"
+       xlink:href="#linearGradient891" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         id="stop887"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         id="stop889"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:window-height="1377"
+     inkscape:window-width="2560"
+     showguides="false"
+     inkscape:snap-grids="false"
+     units="px"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="px"
+     inkscape:cy="5.2391751"
+     inkscape:cx="9.4917281"
+     inkscape:zoom="45.254834"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true">
+    <inkscape:grid
+       id="grid833"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3"
+       id="use895"
+       stroke-miterlimit="3"
+       d="M 2.9104168,0.13229169 H 4.1010417 V 1.3229166 H 2.9104168 Z" />
+    <path
+       d="m 2.1166667,2.9104168 h 1.190625 v 1.1906249 h -1.190625 z"
+       stroke-miterlimit="3"
+       id="path1074"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3" />
+    <path
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3"
+       id="path1091"
+       stroke-miterlimit="3"
+       d="M 0.13229169,0.92604189 H 1.3229166 V 2.1166667 H 0.13229169 Z" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:none;stroke:#555761;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M -1.7599753,3.5057293 -2.5537254,0.72760415 -4.5381005,2.7119791 Z"
+       id="path957" />
+  </g>
+</svg>

--- a/actions/symbolic/distribute-remove-overlaps-symbolic.svg
+++ b/actions/symbolic/distribute-remove-overlaps-symbolic.svg
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="distribute-remove-overlaps-symbolic.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient1130"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       gradientUnits="userSpaceOnUse"
+       x1="23.99999"
+       x2="23.99999"
+       y1="6.4736748"
+       y2="41.526306">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop1122" />
+      <stop
+         offset="0.01028906"
+         stop-color="#fff"
+         stop-opacity=".235294"
+         id="stop1124" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".156863"
+         id="stop1126" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity=".392157"
+         id="stop1128" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient939"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop935" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop937" />
+    </linearGradient>
+    <linearGradient
+       id="f-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-69.999916"
+       x2="-69.999916"
+       xlink:href="#linearGradient874"
+       y1="-200.00011"
+       y2="-208.00011"
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="e-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-73.999916"
+       x2="-73.999916"
+       xlink:href="#linearGradient990"
+       y1="-201.72723"
+       y2="-206.27272"
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)" />
+    <linearGradient
+       y2="41.526306"
+       y1="6.4736748"
+       x2="23.99999"
+       x1="23.99999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       id="linearGradient990">
+      <stop
+         id="stop981"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop984"
+         stop-opacity=".235294"
+         stop-color="#fff"
+         offset="0.00000079" />
+      <stop
+         id="stop986"
+         stop-opacity=".156863"
+         stop-color="#fff"
+         offset="1" />
+      <stop
+         id="stop988"
+         stop-opacity=".392157"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient891"
+       id="linearGradient893"
+       x1="-7.0092854"
+       y1="4.8999996"
+       x2="-0.064285286"
+       y2="4.8999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop887" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop889" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     inkscape:snap-others="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="false"
+     inkscape:snap-center="false"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="6.8637882"
+     inkscape:cy="6.6517307"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     inkscape:snap-grids="true"
+     showguides="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       id="path1074"
+       stroke-miterlimit="3"
+       d="M 1.0583558,0.1322906 V 1.587499 H 0.13231416 V 0.1322906 Z" />
+    <path
+       d="M 1.0583332,2.38125 V 4.1010417 H 0.13229149 V 2.38125 Z"
+       stroke-miterlimit="3"
+       id="path1084"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1" />
+    <path
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       id="path1102"
+       stroke-miterlimit="3"
+       d="M 4.1010417,0.13229046 V 1.1906238 H 3.177205 V 0.13229046 Z" />
+    <path
+       d="M 2.6458333,0.13229022 V 4.1010412 H 1.5874999 V 0.13229022 Z"
+       stroke-miterlimit="3"
+       id="path1108"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1" />
+    <path
+       d="m 4.1010417,1.8520834 v 0.79375 H 3.177205 v -0.79375 z"
+       stroke-miterlimit="3"
+       id="path1141"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1" />
+    <path
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0972914;stroke-linejoin:round;stroke-miterlimit:3;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       id="path1145"
+       stroke-miterlimit="3"
+       d="m 4.0853834,3.3072917 v 0.79375 H 3.1615467 v -0.79375 z" />
+  </g>
+</svg>

--- a/actions/symbolic/distribute-unclump-symbolic.svg
+++ b/actions/symbolic/distribute-unclump-symbolic.svg
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0 (1.0+r73+1)"
+   sodipodi:docname="distribute-unclump-symbolic.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient939"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop935" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop937" />
+    </linearGradient>
+    <linearGradient
+       id="f-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-69.999916"
+       x2="-69.999916"
+       xlink:href="#linearGradient874"
+       y1="-200.00011"
+       y2="-208.00011"
+       gradientTransform="matrix(0.17638888,0,0,-0.49136908,11.156608,-97.858069)" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="e-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-73.999916"
+       x2="-73.999916"
+       xlink:href="#linearGradient990"
+       y1="-201.72723"
+       y2="-206.27272"
+       gradientTransform="matrix(0.15875001,0,0,-0.58207989,9.8425139,-116.36303)" />
+    <linearGradient
+       y2="41.526306"
+       y1="6.4736748"
+       x2="23.99999"
+       x1="23.99999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.269687,-0.324319)"
+       id="linearGradient990">
+      <stop
+         id="stop981"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop984"
+         stop-opacity=".235294"
+         stop-color="#fff"
+         offset="0.00000079" />
+      <stop
+         id="stop986"
+         stop-opacity=".156863"
+         stop-color="#fff"
+         offset="1" />
+      <stop
+         id="stop988"
+         stop-opacity=".392157"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient891"
+       id="linearGradient893"
+       x1="-7.0092854"
+       y1="4.8999996"
+       x2="-0.064285286"
+       y2="4.8999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30238095,0,0,0.31750001,2.908689,-9.0094406)" />
+    <linearGradient
+       id="linearGradient891">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop887" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop889" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="9.2870885"
+     inkscape:cy="7.2243755"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     inkscape:snap-grids="false"
+     showguides="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       id="path1141"
+       d="M 2.7773438 0.47460938 L 0.47460938 2.7773438 L 3.6992188 3.6992188 L 3.6328125 3.46875 L 2.7773438 0.47460938 z M 2.6464844 0.97851562 L 3.3125 3.3125 L 0.97851562 2.6464844 L 2.6464844 0.97851562 z "
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1" />
+    <path
+       d="M 2.9104168,4.1010417 H 4.1010417 V 2.9104168 H 2.9104168 Z"
+       stroke-miterlimit="3"
+       id="use895"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0973667;stroke-linejoin:round;stroke-miterlimit:3;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1" />
+    <path
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0973667;stroke-linejoin:round;stroke-miterlimit:3;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       id="path1074"
+       stroke-miterlimit="3"
+       d="m 2.1166667,1.3229166 h 1.190625 V 0.13229169 h -1.190625 z" />
+    <path
+       d="M 0.13229169,3.3072915 H 1.3229166 V 2.1166667 H 0.13229169 Z"
+       stroke-miterlimit="3"
+       id="path1091"
+       style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.0973667;stroke-linejoin:round;stroke-miterlimit:3;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1" />
+    <path
+       id="path1128"
+       d="M -2.5611468,3.5057293 -3.3548969,0.72760415 -5.339272,2.7119791 Z"
+       style="fill:none;stroke:#c6262e;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>


### PR DESCRIPTION
Fixes #763 and then some. It also add `distribute-graph and symbolic icons of them.

This is how the icons look under elementary's light theme
![image](https://user-images.githubusercontent.com/51940383/86517272-dbf33900-be51-11ea-8635-0f17ae7900e3.png)
This is how the icons look under elementary's dark theme
![image](https://user-images.githubusercontent.com/51940383/86517302-16f56c80-be52-11ea-8f30-6dee018fcca4.png)
This is how the symbolic icons look under elementary's light theme
![image](https://user-images.githubusercontent.com/51940383/86517280-ea415500-be51-11ea-9684-05226216cbb2.png)
This is how the symbolic icons look under elementary's dark theme
![image](https://user-images.githubusercontent.com/51940383/86517290-fdecbb80-be51-11ea-8f31-4adbbf2e9301.png)

There is some things that is still in the file that I use in the design process of these icons. I'll be cleaning them up once these are finalized and approved.