### PR TITLE
Refresh clock-related symbolics

### DIFF
--- a/actions/symbolic/appointment-new-symbolic.svg
+++ b/actions/symbolic/appointment-new-symbolic.svg
@@ -1,7 +1,38 @@
-<svg height='16' width='16' xmlns='http://www.w3.org/2000/svg'>
-    <g transform='translate(-693 23)'>
-        <path color='#000' d='M700.5-23c-4.13 0-7.5 3.37-7.5 7.5s3.37 7.5 7.5 7.5c.514 0 1.015-.051 1.5-.15v-2.06c-.477.133-.979.21-1.5.21-3.05 0-5.5-2.45-5.5-5.5s2.45-5.5 5.5-5.5a5.485 5.485 0 0 1 5.29 7h2.06c.099-.485.15-.986.15-1.5 0-4.13-3.37-7.5-7.5-7.5zm2.965 4.002a.5.5 0 0 0-.072.008v.008a.5.5 0 0 0-.25.156l-2.657 2.649-1.656-1.649a.5.5 0 1 0-.687.688l2 2a.5.5 0 0 0 .687 0l3-3a.5.5 0 0 0-.365-.86z' fill='#666' font-family='sans-serif' font-weight='400' overflow='visible' style='line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal' white-space='normal'/>
-        
-        <path color='#bebebe' d='M705-12.997v1.996h-2v1.998h2v1.996h2v-1.996h2v-1.998h-2v-1.996z' fill='#666' overflow='visible' style='marker:none'/>
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   width="16"
+   height="16">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <path
+     id="path828"
+     d="m 11.393566,5.0004676 c -0.02819,0.00116 -0.0566,0.00427 -0.08434,0.00977 -0.10923,0.034009 -0.211782,0.149012 -0.291721,0.2052579 L 7.9179494,8.5290165 5.9852787,6.4666236 C 5.6178839,5.8242619 4.5833856,6.9337908 5.183038,7.3267684 l 2.333791,2.5022397 c 0.2249168,0.2279899 0.5773239,0.2279899 0.8022407,0 L 11.819756,6.0756487 c 0.386089,-0.3982162 0.109186,-1.0962769 -0.42619,-1.0751811 z"
+     style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#666666;stroke:none;stroke-width:1.00000012;stroke-opacity:1" />
+  <path
+     d="m 12,10.003 v 1.996 h -2 v 1.998 h 2 v 1.996 h 2 v -1.996 h 2 v -1.998 h -2 v -1.996 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;fill:#666666;marker:none"
+     id="path4" />
+  <path
+     id="path830"
+     d="M 8 0 A 8 8 0 0 0 0 8 A 8 8 0 0 0 8 16 A 8 8 0 0 0 9 15.925781 L 9 14.921875 A 7 7 0 0 1 8 15 A 7 7 0 0 1 1 8 A 7 7 0 0 1 8 1 A 7 7 0 0 1 15 8 A 7 7 0 0 1 14.919922 9 L 15.923828 9 A 8 8 0 0 0 16 8 A 8 8 0 0 0 8 0 z "
+     style="opacity:1;fill:#666666;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/actions/symbolic/appointment-symbolic.svg
+++ b/actions/symbolic/appointment-symbolic.svg
@@ -1,6 +1,33 @@
-<svg height='16' width='16' xmlns='http://www.w3.org/2000/svg'>
-    <g color='#000' transform='translate(-673 23)'>
-        <path d='M680.5-23c-4.13 0-7.5 3.37-7.5 7.5s3.37 7.5 7.5 7.5 7.5-3.37 7.5-7.5-3.37-7.5-7.5-7.5zm0 2c3.05 0 5.5 2.45 5.5 5.5s-2.45 5.5-5.5 5.5-5.5-2.45-5.5-5.5 2.45-5.5 5.5-5.5zm2.965 2.002a.5.5 0 0 0-.072.008v.008a.5.5 0 0 0-.25.156l-2.657 2.649-1.656-1.649a.5.5 0 1 0-.687.688l2 2a.5.5 0 0 0 .687 0l3-3a.5.5 0 0 0-.365-.86z' fill='#666' font-family='sans-serif' font-weight='400' overflow='visible' style='line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal' white-space='normal'/>
-        
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg6"
+   version="1.1"
+   width="16"
+   height="16">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path825"
+     d="M 8 0 A 8 8 0 0 0 0 8 A 8 8 0 0 0 8 16 A 8 8 0 0 0 16 8 A 8 8 0 0 0 8 0 z M 8 1 A 7 7 0 0 1 15 8 A 7 7 0 0 1 8 15 A 7 7 0 0 1 1 8 A 7 7 0 0 1 8 1 z "
+     style="opacity:1;fill:#666666;fill-opacity:0.99024391;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path828"
+     d="m 11.393566,5.0004674 c -0.02819,0.00116 -0.0566,0.00427 -0.08434,0.00977 -0.10923,0.034009 -0.211782,0.149012 -0.291721,0.2052579 L 7.9179494,8.5290163 5.9852787,6.4666234 C 5.6178839,5.8242617 4.5833856,6.9337906 5.183038,7.3267682 l 2.333791,2.5022393 c 0.2249168,0.2279905 0.5773239,0.2279905 0.8022407,0 l 3.5006863,-3.753359 c 0.386089,-0.3982162 0.109186,-1.0962769 -0.42619,-1.0751811 z"
+     style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#666666;stroke:none;stroke-width:1.00000012;stroke-opacity:1;fill-opacity:1" />
 </svg>

--- a/actions/symbolic/document-open-recent-symbolic.svg
+++ b/actions/symbolic/document-open-recent-symbolic.svg
@@ -1,7 +1,40 @@
-<svg height='16' width='16' xmlns='http://www.w3.org/2000/svg'>
-    <g color='#bebebe' transform='translate(-273 -77)'>
-        
-        <path d='M281.885 78c-3.705 0-6.754 2.44-7.087 6H273l2.655 3.333L278.309 84h-1.733c.328-2.596 2.584-4.26 5.31-4.26 2.95 0 5.345 2.356 5.345 5.26s-2.395 5.26-5.346 5.26c-1.6 0-3.038-.694-4.018-1.793l-1.3 1.185A7.145 7.145 0 0 0 281.885 92c3.928 0 7.115-3.136 7.115-7s-3.187-7-7.115-7z' fill='#666' overflow='visible' style='marker:none'/>
-        <path d='M282.334 80.667h-.667L281 85.333 284.334 88v-.667l-2-2.666z' fill='#666' overflow='visible' style='marker:none'/>
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   width="16"
+   height="16">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <path
+     id="path842"
+     d="M 8.4935723,3.9986153 A 0.50005,0.50005 0 0 0 8.0013848,4.5064278 V 8.2896309 L 6.1537286,10.13924 a 0.50005,0.50005 0 1 0 0.7070312,0.707031 L 8.8549004,8.8501778 A 0.50005,0.50005 0 0 0 9.0013848,8.4966622 V 4.5064278 A 0.50005,0.50005 0 0 0 8.4935723,3.9986153 Z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#666666;fill-opacity:0.99215686;fill-rule:nonzero;stroke:none;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     id="g4"
+     transform="matrix(-1,0,0,1,849,190.99945)">
+    <path
+       id="path2"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#666666"
+       overflow="visible"
+       font-weight="400"
+       d="M 841.488,-189.982 A 7.006,7.006 0 0 0 834,-183 a 7.006,7.006 0 0 0 5.192,6.762 c 3.059,0.819 6.293,-0.52 7.877,-3.262 a 0.50085527,0.50085527 0 1 0 -0.868,-0.5 5.999,5.999 0 0 1 -6.752,2.795 A 5.996,5.996 0 0 1 835,-183 a 5.996,5.996 0 0 1 10.71,-3.709 L 844,-185 h 4 v -4 l -1.58,1.58 a 7.012,7.012 0 0 0 -4.932,-2.562 z" />
+  </g>
 </svg>


### PR DESCRIPTION
Made them follow most newer symbolics, by dropping the 2px thick clock rim in favor of a 1px thick clock rim symbol.
This aligns them with the timer symbolic, for example.

They look like:
![Screenshot from 2020-07-13 12 58 08](https://user-images.githubusercontent.com/4886639/87326167-c4c6e200-c508-11ea-827b-51fbddd93039.png)
