### PR TITLE
Update missed bolt

### DIFF
--- a/categories/symbolic/preferences-system-power-symbolic.svg
+++ b/categories/symbolic/preferences-system-power-symbolic.svg
@@ -1,6 +1,58 @@
-<svg height='16' width='16.002' xmlns='http://www.w3.org/2000/svg'>
-    <g transform='translate(-952 -460)'>
-        <path color='#bebebe' d='M960 460c-4.424 0-8 3.576-8 8 0 4.424 3.576 8 8 8 4.424 0 8-3.576 8-8 0-4.424-3.576-8-8-8zm0 1c3.87 0 7 3.13 7 7s-3.13 7-7 7-7-3.13-7-7 3.13-7 7-7zm1 2l-3.5 6h2l-.5 4 3.5-6h-2z' fill='#666' overflow='visible' style='marker:none'/>
-        
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="preferences-system-power-symbolic.svg"
+   id="svg6"
+   version="1.1"
+   width="16.002"
+   height="16">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg6"
+     inkscape:window-maximized="1"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:cy="2.0806987"
+     inkscape:cx="95.577587"
+     inkscape:zoom="4"
+     showgrid="false"
+     id="namedview8"
+     inkscape:window-height="1373"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <g
+     id="g4"
+     transform="translate(-952 -460)">
+    <path
+       transform="translate(952,460)"
+       d="M 8 0 C 3.576 0 0 3.576 0 8 C 0 12.424 3.576 16 8 16 C 12.424 16 16 12.424 16 8 C 16 3.576 12.424 0 8 0 z M 8 1 C 11.87 1 15 4.13 15 8 C 15 11.87 11.87 15 8 15 C 4.13 15 1 11.87 1 8 C 1 4.13 4.13 1 8 1 z M 8.0019531 4 L 5.0019531 9 L 8.0019531 9 L 8.0019531 12 L 11.001953 7 L 8.0019531 7 L 8.0019531 4 z "
+       style="marker:none;fill:#666666"
+       id="path2" />
+  </g>
 </svg>


### PR DESCRIPTION
We missed `preferences-system-power-symbolic` when updating the lightning bolt shape for the other icons. This fixes that.