### PR TITLE
Round symbolic pan-* icons

### DIFF
--- a/actions/symbolic/pan-down-symbolic.svg
+++ b/actions/symbolic/pan-down-symbolic.svg
@@ -1,6 +1,30 @@
-<svg height='16' width='16' xmlns='http://www.w3.org/2000/svg'>
-    <g transform='translate(-553 -97)'>
-        <path d='M566 103l-5 5-5-5z' fill='#666'/>
-        
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg6">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path873-5"
+     style="opacity:1;fill:#555761;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="M 13,6.7783725 C 13,6.3471541 12.665354,6 12.249672,6 H 3.750326 C 3.334646,6 3,6.3471541 3,6.7783725 3,7.010782 3.09736,7.2182472 3.252062,7.3606318 l 4.2237847,4.4309712 c 0.1343797,0.13161 0.3149932,0.212837 0.5143854,0.212837 0.1993924,0 0.3800049,-0.08122 0.5143849,-0.212837 l 4.24332,-4.4309712 C 12.902647,7.2182472 13,7.010782 13,6.7783725 Z" />
 </svg>

--- a/actions/symbolic/pan-end-symbolic.svg
+++ b/actions/symbolic/pan-end-symbolic.svg
@@ -1,6 +1,30 @@
-<svg height='16' width='16' xmlns='http://www.w3.org/2000/svg'>
-    <g transform='translate(-513 -97)'>
-        <path d='M519 110l5-5-5-5z' fill='#666'/>
-        
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg6">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path873-5"
+     style="opacity:1;fill:#555761;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="M 6.778372,13 C 6.347154,13 6,12.665354 6,12.249672 V 3.750326 C 6,3.334646 6.347154,3 6.778372,3 c 0.23241,0 0.439875,0.09736 0.58226,0.252062 l 4.430971,4.2237847 c 0.13161,0.1343797 0.212837,0.3149932 0.212837,0.5143854 0,0.1993924 -0.08122,0.3800049 -0.212837,0.5143849 l -4.430971,4.24332 C 7.218247,12.902647 7.010782,13 6.778372,13 Z" />
 </svg>

--- a/actions/symbolic/pan-start-symbolic.svg
+++ b/actions/symbolic/pan-start-symbolic.svg
@@ -1,6 +1,30 @@
-<svg height='16' width='16' xmlns='http://www.w3.org/2000/svg'>
-    <g transform='translate(-493 -97)'>
-        <path d='M503 110l-5-5 5-5z' fill='#666'/>
-        
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg6">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path873-5"
+     style="opacity:1;fill:#555761;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="m 10.226068,13 c 0.431218,0 0.778372,-0.334646 0.778372,-0.750328 V 3.750326 C 11.00444,3.334646 10.657286,3 10.226068,3 9.993658,3 9.786193,3.09736 9.643808,3.252062 L 5.212837,7.4758467 C 5.081227,7.6102264 5,7.7908399 5,7.9902321 5,8.1896245 5.08122,8.370237 5.212837,8.504617 l 4.430971,4.24332 C 9.786193,12.902647 9.993658,13 10.226068,13 Z" />
 </svg>

--- a/actions/symbolic/pan-up-symbolic.svg
+++ b/actions/symbolic/pan-up-symbolic.svg
@@ -1,6 +1,30 @@
-<svg height='16' width='16' xmlns='http://www.w3.org/2000/svg'>
-    <g transform='translate(-533 -97)'>
-        <path d='M546 107l-5-5-5 5z' fill='#666'/>
-        
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg6">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path873-5"
+     style="opacity:1;fill:#555761;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="m 13,10.223848 c 0,0.431218 -0.334646,0.778372 -0.750328,0.778372 H 3.750326 C 3.334646,11.00222 3,10.655066 3,10.223848 3,9.991438 3.09736,9.783973 3.252062,9.641588 L 7.4758467,5.210617 C 7.6102264,5.079007 7.7908399,4.99778 7.9902321,4.99778 c 0.1993924,0 0.3800049,0.08122 0.5143849,0.212837 l 4.24332,4.430971 C 12.902647,9.783973 13,9.991438 13,10.223848 Z" />
 </svg>


### PR DESCRIPTION
Uses the same consistent arrow head shape as the new `go` icons