### PR TITLE
Update the look of SSD and USB drives

### DIFF
--- a/devices/128/drive-harddisk-solidstate.svg
+++ b/devices/128/drive-harddisk-solidstate.svg
@@ -1,171 +1,1464 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="128" height="128" id="svg3486" sodipodi:docname="drive-harddisk-solidstate-128.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview82" showgrid="true" inkscape:zoom="1" inkscape:cx="46.669433" inkscape:cy="17.390444" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3486">
-    <inkscape:grid type="xygrid" id="grid1420" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="128"
+   height="128"
+   id="svg3486"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1370"
+     inkscape:window-height="794"
+     id="namedview82"
+     showgrid="false"
+     inkscape:zoom="3.2817574"
+     inkscape:cx="40.724513"
+     inkscape:cy="73.385633"
+     inkscape:window-x="7"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3486"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1420" />
   </sodipodi:namedview>
-  <metadata id="metadata83">
+  <metadata
+     id="metadata83">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3488">
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+  <defs
+     id="defs3488">
+    <linearGradient
+       id="linearGradient4459">
+      <stop
+         id="stop4455"
+         style="stop-color:#fafaff;stop-opacity:0.5"
+         offset="0" />
+      <stop
+         id="stop4457"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2624" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.2086243,0,0,0.05625201,-11.402788,87.091152)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2621" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.122534,0,0,0.05625201,40.472356,87.091152)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2618" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.122534,0,0,0.05625201,87.527672,87.091152)" />
-    <linearGradient id="linearGradient2215">
-      <stop id="stop2223" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2714" xlink:href="#linearGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.7797939,0,0,2.0106954,-16.614014,15.013338)" />
-    <linearGradient id="linearGradient3484">
-      <stop id="stop3486" style="stop-color:#969696;stop-opacity:1" offset="0" />
-      <stop id="stop3488" style="stop-color:#b4b4b4;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2624"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2086243,0,0,0.05625201,-11.402788,87.091152)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2621"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.122534,0,0,0.05625201,40.472356,87.091152)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2618"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.122534,0,0,0.05625201,87.527672,87.091152)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#7a7a7a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#474747;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="17.813944" y1="29.796696" x2="18.072828" y2="10.000001" id="linearGradient2710" xlink:href="#linearGradient3484" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.7717117,0,0,2.8041475,-2.5210903,-6.9397837)" />
-    <linearGradient id="linearGradient7056">
-      <stop id="stop7064" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="29.9375"
+       y1="41"
+       x2="30"
+       y2="49.999996"
+       id="linearGradient2714"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7797939,0,0,2.0106954,-16.614014,15.013338)" />
+    <linearGradient
+       id="linearGradient3484">
+      <stop
+         id="stop3486"
+         style="stop-color:#969696;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3488"
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="11.734284" cy="8.4900017" r="23.047892" fx="11.734284" fy="8.4900017" id="radialGradient2708" xlink:href="#linearGradient7056" gradientUnits="userSpaceOnUse" gradientTransform="matrix(3.8158369,1.9550356,-1.297462,2.5920017,-2.657338,-12.37557)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient2704" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.9720948,-0.0142358,0.00719451,0.8190959,-77.067288,-77.616391)" />
-    <linearGradient id="linearGradient7609">
-      <stop id="stop7611" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop7677" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop7613" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop7617" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop7615" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="17.813944"
+       y1="29.796696"
+       x2="18.072828"
+       y2="10.000001"
+       id="linearGradient2710"
+       xlink:href="#linearGradient3484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7717117,0,0,2.8041475,-2.5210903,-6.9397837)" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         id="stop7064"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient2701" xlink:href="#linearGradient7609" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.4932064,0,0,-0.3486482,-8.2964585,119.46245)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2697" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-1.0068548,0,0,0.9756095,124.84131,-3.2068583)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2693" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.7477745,-0.1585924,0.084228,0.6299819,-68.769481,-18.546726)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2689" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.7564903,0.1411284,-0.07792703,0.6130007,24.07117,-50.778011)" />
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <radialGradient
+       cx="11.734284"
+       cy="8.4900017"
+       r="23.047892"
+       fx="11.734284"
+       fy="8.4900017"
+       id="radialGradient2708"
+       xlink:href="#linearGradient7056"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.8158369,1.9550356,-1.297462,2.5920017,-2.657338,-12.37557)" />
+    <radialGradient
+       cx="141.74666"
+       cy="206.42612"
+       r="78.728165"
+       fx="141.74666"
+       fy="206.42612"
+       id="radialGradient2704"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9720948,-0.0142358,0.00719451,0.8190959,-77.067288,-77.616391)" />
+    <linearGradient
+       id="linearGradient7609">
+      <stop
+         id="stop7611"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7677"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop7613"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.67183787" />
+      <stop
+         id="stop7617"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop7615"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient2686" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.8154099,0,0,2.6966282,0.4945617,11.359533)" />
-    <linearGradient id="linearGradient4236">
-      <stop id="stop4238" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
+    <radialGradient
+       cx="142.62215"
+       cy="191.85428"
+       r="78.728165"
+       fx="142.62215"
+       fy="191.85428"
+       id="radialGradient2701"
+       xlink:href="#linearGradient7609"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4932064,0,0,-0.3486482,-8.2964585,119.46245)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2697"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0068548,0,0,0.9756095,124.84131,-3.2068583)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2693"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7477745,-0.1585924,0.084228,0.6299819,-68.769481,-18.546726)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2689"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7564903,0.1411284,-0.07792703,0.6130007,24.07117,-50.778011)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient2683" xlink:href="#linearGradient4236" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.7758664,0,0,2.9914128,-1.725507,4.105388)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="7.0625"
+       y1="35.28125"
+       x2="24.6875"
+       y2="35.28125"
+       id="linearGradient2686"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8154099,0,0,2.6966282,0.4945617,11.359533)" />
+    <linearGradient
+       id="linearGradient4236">
+      <stop
+         id="stop4238"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient2680" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.5208152,-0.07516752,0.01692892,0.3022039,-21.928264,5.2860233)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient4241" gradientUnits="userSpaceOnUse">
-      <stop id="stop4243" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4245" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop4247" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop4249" style="stop-color:#555555;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient2683"
+       xlink:href="#linearGradient4236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7758664,0,0,2.9914128,-1.725507,4.105388)" />
+    <linearGradient
+       id="linearGradient4035">
+      <stop
+         id="stop4037"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4039"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop4041"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.69348532" />
+      <stop
+         id="stop4043"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop4045"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="127.31733"
+       cy="143.82751"
+       r="78.728165"
+       fx="127.31733"
+       fy="143.82751"
+       id="radialGradient2680"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5208152,-0.07516752,0.01692892,0.3022039,-21.928264,5.2860233)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient4241"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop4243"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4245"
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="0.16" />
+      <stop
+         id="stop4247"
+         style="stop-color:#888888;stop-opacity:1"
+         offset="0.4675" />
+      <stop
+         id="stop4249"
+         style="stop-color:#555555;stop-opacity:1"
+         offset="1" />
     </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2676" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0068545,0,0,0.9756095,3.158733,-3.2068583)" />
-    <linearGradient id="linearGradient6310-8">
-      <stop id="stop6312-6" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop6314-6" style="stop-color:#ffffff;stop-opacity:0" offset="1" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2676"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0068545,0,0,0.9756095,3.158733,-3.2068583)" />
+    <linearGradient
+       id="linearGradient6310-8">
+      <stop
+         id="stop6312-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6314-6"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="24" cy="42" r="21" fx="24" fy="42" id="radialGradient2673" xlink:href="#linearGradient6310-8" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.8095237,-3.195635e-8,7.8140219e-8,1.0714284,-3.428568,61.499973)" />
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2714-3" xlink:href="#linearGradient4236" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.7797939,0,0,2.0106954,-16.614014,15.013338)" />
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4236" id="radialGradient937" cx="64" cy="106.49996" fx="64" fy="106.49996" r="62.535988" gradientTransform="matrix(1,0,0,0.12850201,0,92.814502)" gradientUnits="userSpaceOnUse" />
-    <linearGradient id="linearGradient1139" inkscape:collect="always">
-      <stop id="stop1135" offset="0" style="stop-color:#d1ff82;stop-opacity:1;" />
-      <stop id="stop1137" offset="1" style="stop-color:#9bdb4d;stop-opacity:1" />
+    <radialGradient
+       cx="24"
+       cy="42"
+       r="21"
+       fx="24"
+       fy="42"
+       id="radialGradient2673"
+       xlink:href="#linearGradient6310-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8095237,-3.195635e-8,7.8140219e-8,1.0714284,-3.428568,61.499973)" />
+    <linearGradient
+       x1="29.9375"
+       y1="41"
+       x2="30"
+       y2="49.999996"
+       id="linearGradient2714-3"
+       xlink:href="#linearGradient4236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7797939,0,0,2.0106954,-16.614014,15.013338)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4236"
+       id="radialGradient937"
+       cx="64"
+       cy="106.49996"
+       fx="64"
+       fy="106.49996"
+       r="62.535988"
+       gradientTransform="matrix(1,0,0,0.12850201,0,92.814502)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient1139"
+       inkscape:collect="always">
+      <stop
+         id="stop1135"
+         offset="0"
+         style="stop-color:#d1ff82;stop-opacity:1;" />
+      <stop
+         id="stop1137"
+         offset="1"
+         style="stop-color:#9bdb4d;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient1131" inkscape:collect="always">
-      <stop id="stop1127" offset="0" style="stop-color:#ffe16b;stop-opacity:1" />
-      <stop style="stop-color:#d39220;stop-opacity:1;" offset="0.51300955" id="stop1133" />
-      <stop id="stop1129" offset="1" style="stop-color:#f9c440;stop-opacity:1" />
+    <linearGradient
+       id="linearGradient1131"
+       inkscape:collect="always">
+      <stop
+         id="stop1127"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         style="stop-color:#d39220;stop-opacity:1;"
+         offset="0.51300955"
+         id="stop1133" />
+      <stop
+         id="stop1129"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient1101">
-      <stop id="stop1091" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop1093" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.25" />
-      <stop id="stop1095" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop1097" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop1099" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1101">
+      <stop
+         id="stop1091"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1093"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.25" />
+      <stop
+         id="stop1095"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.67183787" />
+      <stop
+         id="stop1097"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop1099"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1045">
-      <stop id="stop1041" style="stop-color:#333333;stop-opacity:1" offset="0" />
-      <stop id="stop1043" style="stop-color:#555761;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         id="stop1041"
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1043"
+         style="stop-color:#555761;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient gradientTransform="matrix(0.1018087,0,0,0.02745099,-82.243162,61.941754)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5048" id="linearGradient2566" y2="609.50507" x2="302.85715" y1="366.64789" x1="302.85715" />
-    <radialGradient gradientTransform="matrix(0.05979662,0,0,0.02745099,-56.928085,61.941754)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="radialGradient2563" fy="486.64789" fx="605.71429" r="117.14286" cy="486.64789" cx="605.71429" />
-    <radialGradient gradientTransform="matrix(-0.05979662,0,0,0.02745099,-33.965085,61.941754)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="radialGradient2560" fy="486.64789" fx="605.71429" r="117.14286" cy="486.64789" cx="605.71429" />
-    <linearGradient gradientTransform="matrix(1.3573591,0,0,1.0098512,-84.809999,25.225035)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2215" id="linearGradient2557" y2="49.999996" x2="30" y1="41" x1="29.9375" />
-    <linearGradient gradientTransform="matrix(1.3526366,0,0,1.3652569,-77.909869,15.838829)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3484" id="linearGradient2553" y2="10.000001" x2="18.072828" y1="29.796696" x1="17.813944" />
-    <radialGradient gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-77.97636,13.192304)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7056" id="radialGradient2551" fy="8.4900017" fx="11.734284" r="23.047892" cy="8.4900017" cx="11.734284" />
-    <radialGradient gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4035" id="radialGradient2547" fy="206.42612" fx="141.74666" r="78.728165" cy="206.42612" cx="141.74666" />
-    <radialGradient gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7609" id="radialGradient2544" fy="191.85428" fx="142.62215" r="78.728165" cy="191.85428" cx="142.62215" />
-    <radialGradient gradientTransform="matrix(-0.5034274,0,0,0.4878048,-14.525935,16.569844)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-5" id="radialGradient2540" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-111.35844,9.8999183)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-5" id="radialGradient2536" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,-65.911021,-6.22984)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-5" id="radialGradient2532" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <linearGradient gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="linearGradient2529" y2="35.28125" x2="24.6875" y1="35.28125" x1="7.0625" />
-    <linearGradient gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4236" id="linearGradient2526" y2="33.758667" x2="12.221823" y1="37.205811" x1="12.277412" />
-    <radialGradient gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4035" id="radialGradient2523" fy="143.82751" fx="127.31733" r="78.728165" cy="143.82751" cx="127.31733" />
-    <radialGradient gradientUnits="userSpaceOnUse" id="radialGradient4241-5" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654">
-      <stop offset="0" style="stop-color:#eeeeee;stop-opacity:1" id="stop4243-9" />
-      <stop offset="0.16" style="stop-color:#cecece;stop-opacity:1" id="stop4245-2" />
-      <stop offset="0.4675" style="stop-color:#888888;stop-opacity:1" id="stop4247-2" />
-      <stop offset="1" style="stop-color:#555555;stop-opacity:1" id="stop4249-8" />
+    <linearGradient
+       gradientTransform="matrix(0.1018087,0,0,0.02745099,-82.243162,61.941754)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient2566"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(0.05979662,0,0,0.02745099,-56.928085,61.941754)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient2563"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.05979662,0,0,0.02745099,-33.965085,61.941754)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient2560"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(1.3573591,0,0,1.0098512,-84.809999,25.225035)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2215"
+       id="linearGradient2557"
+       y2="49.999996"
+       x2="30"
+       y1="41"
+       x1="29.9375" />
+    <linearGradient
+       gradientTransform="matrix(1.3526366,0,0,1.3652569,-77.909869,15.838829)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3484"
+       id="linearGradient2553"
+       y2="10.000001"
+       x2="18.072828"
+       y1="29.796696"
+       x1="17.813944" />
+    <radialGradient
+       gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-77.97636,13.192304)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient7056"
+       id="radialGradient2551"
+       fy="8.4900017"
+       fx="11.734284"
+       r="23.047892"
+       cy="8.4900017"
+       cx="11.734284" />
+    <radialGradient
+       gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4035"
+       id="radialGradient2547"
+       fy="206.42612"
+       fx="141.74666"
+       r="78.728165"
+       cy="206.42612"
+       cx="141.74666" />
+    <radialGradient
+       gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient7609"
+       id="radialGradient2544"
+       fy="191.85428"
+       fx="142.62215"
+       r="78.728165"
+       cy="191.85428"
+       cx="142.62215" />
+    <radialGradient
+       gradientTransform="matrix(-0.5034274,0,0,0.4878048,-14.525935,16.569844)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#radialGradient4241-5"
+       id="radialGradient2540"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654" />
+    <radialGradient
+       gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-111.35844,9.8999183)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#radialGradient4241-5"
+       id="radialGradient2536"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654" />
+    <radialGradient
+       gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,-65.911021,-6.22984)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#radialGradient4241-5"
+       id="radialGradient2532"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654" />
+    <linearGradient
+       gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="linearGradient2529"
+       y2="35.28125"
+       x2="24.6875"
+       y1="35.28125"
+       x1="7.0625" />
+    <linearGradient
+       gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4236"
+       id="linearGradient2526"
+       y2="33.758667"
+       x2="12.221823"
+       y1="37.205811"
+       x1="12.277412" />
+    <radialGradient
+       gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4035"
+       id="radialGradient2523"
+       fy="143.82751"
+       fx="127.31733"
+       r="78.728165"
+       cy="143.82751"
+       cx="127.31733" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4241-5"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop4243-9" />
+      <stop
+         offset="0.16"
+         style="stop-color:#cecece;stop-opacity:1"
+         id="stop4245-2" />
+      <stop
+         offset="0.4675"
+         style="stop-color:#888888;stop-opacity:1"
+         id="stop4247-2" />
+      <stop
+         offset="1"
+         style="stop-color:#555555;stop-opacity:1"
+         id="stop4249-8" />
     </radialGradient>
-    <radialGradient gradientTransform="matrix(0.5034273,0,0,0.4878048,-76.367233,16.569844)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-5" id="radialGradient2519" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-78.589446,50.816919)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient6310-8" id="radialGradient2516" fy="42" fx="24" r="21" cy="42" cx="24" />
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(3.5489286,-0.00675717,-9.4880732e-4,-0.49834382,-43.10113,140.02951)" r="18.5" fy="75.09082" fx="25.960344" cy="75.09082" cx="25.960344" id="radialGradient925" xlink:href="#linearGradient1045" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,3.0000007,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="7" y1="53" x1="7" id="linearGradient1011" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.5000003,0,0,4.609689,4.4999971,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="10" y1="53" x1="10" id="linearGradient1013" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,6.0000014,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="13" y1="53" x1="13" id="linearGradient1015" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,7.5000003,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="16" y1="53" x1="16" id="linearGradient1017" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,9.000001,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="19" y1="53" x1="19" id="linearGradient1019" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,10.500001,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="22" y1="53" x1="22" id="linearGradient1021" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.5000003,0,0,4.609689,11.999993,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="25" y1="53" x1="25" id="linearGradient1023" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,13.500001,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="28" y1="53" x1="28" id="linearGradient1025" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,15.000002,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="31" y1="53" x1="31" id="linearGradient1027" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,16.500002,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="34" y1="53" x1="34" id="linearGradient1029" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.5000003,0,0,4.609689,17.999989,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="41" y1="53" x1="41" id="linearGradient1031" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,18.000002,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="37" y1="53" x1="37" id="linearGradient1033" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.0994935,0,0,1.7761342,-3.3755811,13.364888)" r="1.6890616" fy="53" fx="58.063545" cy="53" cx="58.063545" id="radialGradient1141-6" xlink:href="#linearGradient1139" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.5000003,0,0,4.609689,23.999989,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="41" y1="53" x1="41" id="linearGradient1031-3" xlink:href="#linearGradient1131" inkscape:collect="always" />
+    <radialGradient
+       gradientTransform="matrix(0.5034273,0,0,0.4878048,-76.367233,16.569844)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#radialGradient4241-5"
+       id="radialGradient2519"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654" />
+    <radialGradient
+       gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-78.589446,50.816919)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6310-8"
+       id="radialGradient2516"
+       fy="42"
+       fx="24"
+       r="21"
+       cy="42"
+       cx="24" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.5489286,-0.00675717,-9.4880732e-4,-0.49834382,-43.10113,140.02951)"
+       r="18.5"
+       fy="75.09082"
+       fx="25.960344"
+       cy="75.09082"
+       cx="25.960344"
+       id="radialGradient925"
+       xlink:href="#linearGradient1045"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.4999999,0,0,4.609689,3.0000007,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="7"
+       y1="53"
+       x1="7"
+       id="linearGradient1011"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.5000003,0,0,4.609689,4.4999971,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="10"
+       y1="53"
+       x1="10"
+       id="linearGradient1013"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.4999999,0,0,4.609689,6.0000014,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="13"
+       y1="53"
+       x1="13"
+       id="linearGradient1015"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.4999999,0,0,4.609689,7.5000003,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="16"
+       y1="53"
+       x1="16"
+       id="linearGradient1017"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.4999999,0,0,4.609689,9.000001,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="19"
+       y1="53"
+       x1="19"
+       id="linearGradient1019"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.4999999,0,0,4.609689,10.500001,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="22"
+       y1="53"
+       x1="22"
+       id="linearGradient1021"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.5000003,0,0,4.609689,11.999993,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="25"
+       y1="53"
+       x1="25"
+       id="linearGradient1023"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.4999999,0,0,4.609689,13.500001,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="28"
+       y1="53"
+       x1="28"
+       id="linearGradient1025"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.4999999,0,0,4.609689,15.000002,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="31"
+       y1="53"
+       x1="31"
+       id="linearGradient1027"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.4999999,0,0,4.609689,16.500002,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="34"
+       y1="53"
+       x1="34"
+       id="linearGradient1029"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.5000003,0,0,4.609689,17.999989,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="41"
+       y1="53"
+       x1="41"
+       id="linearGradient1031"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.4999999,0,0,4.609689,18.000002,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="37"
+       y1="53"
+       x1="37"
+       id="linearGradient1033"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0994935,0,0,1.7761342,-3.3755811,13.364888)"
+       r="1.6890616"
+       fy="53"
+       fx="58.063545"
+       cy="53"
+       cx="58.063545"
+       id="radialGradient1141-6"
+       xlink:href="#linearGradient1139"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.5000003,0,0,4.609689,23.999989,-136.31351)"
+       gradientUnits="userSpaceOnUse"
+       y2="52"
+       x2="41"
+       y1="53"
+       x1="41"
+       id="linearGradient1031-3"
+       xlink:href="#linearGradient1131"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1084"
+       id="linearGradient1077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8909727,0,0,2.0003492,3.4888865,-12.991269)"
+       x1="31.999998"
+       y1="48.487175"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       id="linearGradient1084">
+      <stop
+         id="stop1080"
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1082"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1047"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8909727,0,0,2.0003492,3.4888865,-11.991272)"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       id="linearGradient1018">
+      <stop
+         id="stop1013"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1015"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999996"
+       y2="48.973789"
+       gradientTransform="matrix(1.9567844,0,0,1.9963845,1.3823081,-1.784382)" />
+    <radialGradient
+       cx="24"
+       cy="42"
+       r="21"
+       fx="24"
+       fy="42"
+       id="radialGradient2516-3"
+       xlink:href="#linearGradient6310-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7619054,-2.9042351e-8,7.6815828e-8,0.97372818,-2.2857106,64.287329)" />
+    <linearGradient
+       x1="29.736721"
+       y1="42.14201"
+       x2="29.736721"
+       y2="45.020302"
+       id="linearGradient2557-5"
+       xlink:href="#linearGradient2215-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7223459,0,0,2.1359581,-14.948007,7.8385188)" />
+    <linearGradient
+       id="linearGradient2215-3">
+      <stop
+         id="stop2223-5"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219-6"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient959"
+       id="linearGradient961"
+       x1="32"
+       y1="57"
+       x2="32"
+       y2="48"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0056193,0,0,2.1151218,-0.17981211,-6.0192852)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient959">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop955" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.502"
+         offset="1"
+         id="stop957" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="8"
+       y2="31.555555"
+       gradientTransform="matrix(-2.0000002,0,0,2.0000004,128,-2.8927883e-6)" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.9375" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000002,0,0,2.0000004,0,-2.8927883e-6)" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.41666666" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.44444445" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560-2"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.11959324,0,0,0.054902,86.963035,86.537001)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563-2"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11959324,0,0,0.054902,41.037026,86.537001)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566-0"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20361742,0,0,0.054902,-9.593146,86.537001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1240"
+       id="linearGradient1233"
+       gradientUnits="userSpaceOnUse"
+       x1="55.999996"
+       y1="51.499992"
+       x2="55.999996"
+       y2="54.999989"
+       gradientTransform="matrix(2.1398002,0,0,2.1652042,-5.5613318,-8.4852063)" />
+    <linearGradient
+       id="linearGradient1240">
+      <stop
+         id="stop1236"
+         style="stop-color:#141414;stop-opacity:0.14901961"
+         offset="0" />
+      <stop
+         id="stop1238"
+         style="stop-color:#282828;stop-opacity:0.50196081"
+         offset="1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4521"
+       x="-0.39867864"
+       width="1.7973573"
+       y="-0.50740898"
+       height="2.014818">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.1628144"
+         id="feGaussianBlur4523" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1031-1"
+       x1="41"
+       y1="53"
+       x2="41"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,-3.05e-4,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1033-1"
+       x1="37"
+       y1="53"
+       x2="37"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1029-9"
+       x1="34"
+       y1="53"
+       x2="34"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1027-4"
+       x1="31"
+       y1="53"
+       x2="31"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1025-8"
+       x1="28"
+       y1="53"
+       x2="28"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1023-3"
+       x1="25"
+       y1="53"
+       x2="25"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1021-6"
+       x1="22"
+       y1="53"
+       x2="22"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1019-1"
+       x1="19"
+       y1="53"
+       x2="19"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1017-0"
+       x1="16"
+       y1="53"
+       x2="16"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1015-6"
+       x1="13"
+       y1="53"
+       x2="13"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1013-3"
+       x1="10"
+       y1="53"
+       x2="10"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011-2"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000125,0,0,3.9999846,1.999708,-104.99918)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925-0"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5"
+       gradientTransform="matrix(2.2647832,-3.6184741e-7,-5.4022921e-8,-0.43243072,-10.79455,134.4716)"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1079"
+       x="-1.1165345"
+       width="3.233069"
+       y="-1.3060608"
+       height="3.6121216">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.1449038"
+         id="feGaussianBlur1081" />
+    </filter>
   </defs>
-  <rect style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2624);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" id="rect2723" y="107.71581" x="13.632071" height="13.661199" width="100.73576" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2621);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" id="path2725" d="m 114.31876,107.71629 c 0,0 0,13.66044 0,13.66044 6.31019,0.0257 15.25499,-3.06061 15.25499,-6.8311 0,-3.77048 -7.04169,-6.82934 -15.25499,-6.82934 z" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2618);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" id="path2727" d="m 13.681244,107.71629 c 0,0 0,13.66044 0,13.66044 -6.310217,0.0257 -15.2549956,-3.06061 -15.2549956,-6.8311 0,-3.77048 7.0417191,-6.82934 15.2549956,-6.82934 z" />
-  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#linearGradient2714);fill-opacity:1;fill-rule:evenodd;stroke:#353537;stroke-width:0.9279989;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" id="rect6431" d="M 1.4640118,98.46396 H 126.53599 l -2.50078,16.072 H 4.2427776 Z" />
-  <rect style="display:inline;fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new" id="rect6381" y="96.278435" x="1.6722411" height="2.7934818" width="124.65551" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2708);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2710);stroke-width:0.99578357;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path6345" d="m 126.5021,98.502072 -18.87434,-72.27504 c -0.5337,-2.058171 -3.32939,-3.729178 -5.6797,-3.729178 H 25.401087 c -3.61082,0 -5.67995,0.55683 -6.441344,3.729178 L 1.4978917,98.431698" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path7046" d="M 125.49993,98.499962 H 2.5000713" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9007" d="m 14.993455,91.98533 c -0.126866,1.660488 -2.026799,3.014632 -4.241883,3.014632 -2.2140731,0 -3.8904862,-1.354144 -3.7424788,-3.014632 0.1470028,-1.65171 2.0459308,-2.985368 4.2388598,-2.985368 2.19394,7.83e-4 3.870352,1.333658 3.745502,2.985368 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2697);fill-opacity:1" id="path9009" d="m 13.560699,90.817522 c 0.202379,0.210719 0.433956,0.548297 0.433956,0.997072 0,0.03222 -0.002,0.06438 -0.004,0.09855 -0.0876,1.144388 -1.570694,2.111218 -3.238047,2.111218 -0.9494637,0 -1.8173717,-0.317072 -2.3208007,-0.849754 -0.2164704,-0.227316 -0.4631534,-0.603904 -0.418851,-1.105366 0.1016909,-1.134636 1.5827736,-2.093658 3.2360327,-2.093658 0.942416,7.8e-4 1.807303,0.315122 2.311736,0.841948 h 9e-6 l -10e-7,-1.4e-5 z" />
-  <path inkscape:connector-curvature="0" style="fill:#f0f0f0;fill-opacity:1" id="path9019" d="m 21.030997,25.61943 c 0.237579,1.052246 1.765539,1.627395 3.410643,1.278494 1.644356,-0.348742 2.77249,-1.487218 2.519216,-2.536133 -0.251792,-1.043405 -1.777218,-1.605485 -3.40587,-1.260071 -1.629338,0.346076 -2.759308,1.470812 -2.523989,2.51771 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2693);fill-opacity:1" id="path9021" d="m 21.994264,24.639666 c -0.132112,0.167962 -0.274955,0.422405 -0.236214,0.712195 0.0028,0.02071 0.007,0.04142 0.01151,0.06298 0.163859,0.725166 1.348799,1.11587 2.587114,0.853242 0.705149,-0.149536 1.322356,-0.491002 1.650254,-0.914267 0.141147,-0.180901 0.291825,-0.462913 0.215648,-0.779745 -0.173495,-0.716654 -1.356251,-1.102634 -2.5841,-0.842225 -0.699848,0.148949 -1.315048,0.488159 -1.644201,0.907803 l -4e-6,5e-6 -10e-6,1.7e-5 z" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9025" d="m 99.000772,24.430821 c -0.0373,1.06111 1.282028,2.178262 2.946298,2.488746 1.66353,0.31034 3.03124,-0.305538 3.05267,-1.369597 0.0213,-1.058417 -1.29873,-2.162557 -2.94637,-2.469933 -1.64846,-0.307015 -3.014472,0.295486 -3.052598,1.350784 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2689);fill-opacity:1" id="path9027" d="m 100.17053,23.897881 c -0.16888,0.104022 -0.369832,0.28367 -0.405681,0.565664 -0.0026,0.02011 -0.0037,0.04062 -0.0047,0.06249 -0.02574,0.731329 1.011481,1.546696 2.264241,1.780402 0.71337,0.133075 1.39078,0.05552 1.81158,-0.208618 0.18082,-0.112475 0.39622,-0.314526 0.40299,-0.635822 0.0142,-0.727174 -1.02197,-1.537352 -2.26413,-1.769086 -0.70814,-0.131596 -1.38308,-0.05531 -1.80415,0.20501 l -1e-5,-8e-6 -1e-4,-3.6e-5 z" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9091" d="m 113.00654,91.98533 c 0.12687,1.660488 2.0268,3.014632 4.24188,3.014632 2.21407,0 3.8905,-1.354144 3.74249,-3.014632 -0.14702,-1.65171 -2.04594,-2.985368 -4.23886,-2.985368 -2.19394,7.83e-4 -3.87035,1.333658 -3.74551,2.985368 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2676);fill-opacity:1" id="path9093" d="m 114.4393,90.817522 c -0.20238,0.210719 -0.43396,0.548297 -0.43396,0.997072 0,0.03222 0.002,0.06438 0.004,0.09855 0.0876,1.144388 1.57069,2.111218 3.23803,2.111218 0.94947,0 1.81738,-0.317072 2.32081,-0.849754 0.21646,-0.227316 0.46315,-0.603904 0.41885,-1.105366 -0.1017,-1.134636 -1.58277,-2.093658 -3.23603,-2.093658 -0.94243,7.8e-4 -1.8073,0.315122 -2.31174,0.841948 v 0 l 6e-5,-1.4e-5 z" />
-  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#radialGradient937);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.9279989;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new;opacity:0.323" id="rect6431-5" d="M 1.4640118,98.46396 H 126.53599 l -2.50078,16.072 H 4.2427776 Z" />
-  <path style="opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.59883722;paint-order:normal" d="m 10.424972,110.5 h 79.458714 l 0.644259,-6.91454 H 9.56596 Z" id="rect917" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 12,103.39031 V 108 h 3 v -4.60969 z" id="path928" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 18,103.39031 V 108 h 3 v -4.60969 z" id="path928-3" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 24,103.39031 V 108 h 3 v -4.60969 z" id="path928-6" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 30,103.39031 V 108 h 3 v -4.60969 z" id="path928-7" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 36,103.39031 V 108 h 3 v -4.60969 z" id="path928-5" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 42,103.39031 V 108 h 3 v -4.60969 z" id="path928-35" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 48,103.39031 V 108 h 3 v -4.60969 z" id="path928-62" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 54,103.39031 V 108 h 3 v -4.60969 z" id="path928-9" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 60,103.39031 V 108 h 3 v -4.60969 z" id="path928-1" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1029);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 66,103.39031 V 108 h 3 v -4.60969 z" id="path928-2" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 72,103.39031 V 108 h 3 v -4.60969 z" id="path928-70" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1031);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 78,103.39031 V 108 h 3 v -4.60969 z" id="path928-93" inkscape:connector-curvature="0" />
-  <path style="fill:url(#radialGradient1141-6);fill-opacity:1;stroke:#9bdb4d;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.54444442" d="m 120.91442,105.5 -0.62985,4 h -4.19898 l 0.62985,-4 z" id="path915-6" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="fill:url(#linearGradient1031-3);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 84,103.39031 V 108 h 3 v -4.60969 z" id="path928-93-1" inkscape:connector-curvature="0" />
+  <g
+     id="g1001"
+     style="display:none">
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2624);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+       id="rect2723"
+       y="107.71581"
+       x="13.632071"
+       height="13.661199"
+       width="100.73576" />
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2621);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+       id="path2725"
+       d="m 114.31876,107.71629 c 0,0 0,13.66044 0,13.66044 6.31019,0.0257 15.25499,-3.06061 15.25499,-6.8311 0,-3.77048 -7.04169,-6.82934 -15.25499,-6.82934 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2618);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+       id="path2727"
+       d="m 13.681244,107.71629 c 0,0 0,13.66044 0,13.66044 -6.310217,0.0257 -15.2549956,-3.06061 -15.2549956,-6.8311 0,-3.77048 7.0417191,-6.82934 15.2549956,-6.82934 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;fill:url(#linearGradient2714);fill-opacity:1;fill-rule:evenodd;stroke:#353537;stroke-width:0.927999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+       id="rect6431"
+       d="M 1.4640118,98.46396 H 126.53599 l -2.50078,16.072 H 4.2427776 Z" />
+    <rect
+       style="display:inline;fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+       id="rect6381"
+       y="96.278435"
+       x="1.6722411"
+       height="2.7934818"
+       width="124.65551" />
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2708);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2710);stroke-width:0.995784;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path6345"
+       d="m 126.5021,98.502072 -18.87434,-72.27504 c -0.5337,-2.058171 -3.32939,-3.729178 -5.6797,-3.729178 H 25.401087 c -3.61082,0 -5.67995,0.55683 -6.441344,3.729178 L 1.4978917,98.431698" />
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path7046"
+       d="M 125.49993,98.499962 H 2.5000713" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#e1e1e1;fill-opacity:1"
+       id="path9007"
+       d="m 14.993455,91.98533 c -0.126866,1.660488 -2.026799,3.014632 -4.241883,3.014632 -2.2140731,0 -3.8904862,-1.354144 -3.7424788,-3.014632 0.1470028,-1.65171 2.0459308,-2.985368 4.2388598,-2.985368 2.19394,7.83e-4 3.870352,1.333658 3.745502,2.985368 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#radialGradient2697);fill-opacity:1"
+       id="path9009"
+       d="m 13.560699,90.817522 c 0.202379,0.210719 0.433956,0.548297 0.433956,0.997072 0,0.03222 -0.002,0.06438 -0.004,0.09855 -0.0876,1.144388 -1.570694,2.111218 -3.238047,2.111218 -0.9494637,0 -1.8173717,-0.317072 -2.3208007,-0.849754 -0.2164704,-0.227316 -0.4631534,-0.603904 -0.418851,-1.105366 0.1016909,-1.134636 1.5827736,-2.093658 3.2360327,-2.093658 0.942416,7.8e-4 1.807303,0.315122 2.311736,0.841948 h 9e-6 l -10e-7,-1.4e-5 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#f0f0f0;fill-opacity:1"
+       id="path9019"
+       d="m 21.030997,25.61943 c 0.237579,1.052246 1.765539,1.627395 3.410643,1.278494 1.644356,-0.348742 2.77249,-1.487218 2.519216,-2.536133 -0.251792,-1.043405 -1.777218,-1.605485 -3.40587,-1.260071 -1.629338,0.346076 -2.759308,1.470812 -2.523989,2.51771 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#radialGradient2693);fill-opacity:1"
+       id="path9021"
+       d="m 21.994264,24.639666 c -0.132112,0.167962 -0.274955,0.422405 -0.236214,0.712195 0.0028,0.02071 0.007,0.04142 0.01151,0.06298 0.163859,0.725166 1.348799,1.11587 2.587114,0.853242 0.705149,-0.149536 1.322356,-0.491002 1.650254,-0.914267 0.141147,-0.180901 0.291825,-0.462913 0.215648,-0.779745 -0.173495,-0.716654 -1.356251,-1.102634 -2.5841,-0.842225 -0.699848,0.148949 -1.315048,0.488159 -1.644201,0.907803 l -4e-6,5e-6 -10e-6,1.7e-5 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#e1e1e1;fill-opacity:1"
+       id="path9025"
+       d="m 99.000772,24.430821 c -0.0373,1.06111 1.282028,2.178262 2.946298,2.488746 1.66353,0.31034 3.03124,-0.305538 3.05267,-1.369597 0.0213,-1.058417 -1.29873,-2.162557 -2.94637,-2.469933 -1.64846,-0.307015 -3.014472,0.295486 -3.052598,1.350784 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#radialGradient2689);fill-opacity:1"
+       id="path9027"
+       d="m 100.17053,23.897881 c -0.16888,0.104022 -0.369832,0.28367 -0.405681,0.565664 -0.0026,0.02011 -0.0037,0.04062 -0.0047,0.06249 -0.02574,0.731329 1.011481,1.546696 2.264241,1.780402 0.71337,0.133075 1.39078,0.05552 1.81158,-0.208618 0.18082,-0.112475 0.39622,-0.314526 0.40299,-0.635822 0.0142,-0.727174 -1.02197,-1.537352 -2.26413,-1.769086 -0.70814,-0.131596 -1.38308,-0.05531 -1.80415,0.20501 l -1e-5,-8e-6 -1e-4,-3.6e-5 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#e1e1e1;fill-opacity:1"
+       id="path9091"
+       d="m 113.00654,91.98533 c 0.12687,1.660488 2.0268,3.014632 4.24188,3.014632 2.21407,0 3.8905,-1.354144 3.74249,-3.014632 -0.14702,-1.65171 -2.04594,-2.985368 -4.23886,-2.985368 -2.19394,7.83e-4 -3.87035,1.333658 -3.74551,2.985368 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#radialGradient2676);fill-opacity:1"
+       id="path9093"
+       d="m 114.4393,90.817522 c -0.20238,0.210719 -0.43396,0.548297 -0.43396,0.997072 0,0.03222 0.002,0.06438 0.004,0.09855 0.0876,1.144388 1.57069,2.111218 3.23803,2.111218 0.94947,0 1.81738,-0.317072 2.32081,-0.849754 0.21646,-0.227316 0.46315,-0.603904 0.41885,-1.105366 -0.1017,-1.134636 -1.58277,-2.093658 -3.23603,-2.093658 -0.94243,7.8e-4 -1.8073,0.315122 -2.31174,0.841948 v 0 l 6e-5,-1.4e-5 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;opacity:0.323;fill:url(#radialGradient937);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.927999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+       id="rect6431-5"
+       d="M 1.4640118,98.46396 H 126.53599 l -2.50078,16.072 H 4.2427776 Z" />
+    <path
+       style="opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.598837;paint-order:normal"
+       d="m 10.424972,110.5 h 79.458714 l 0.644259,-6.91454 H 9.56596 Z"
+       id="rect917"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 18,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-3"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 24,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 30,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 36,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 42,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-35"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 48,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-62"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 54,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 60,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1029);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 66,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 72,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-70"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1031);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 78,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-93"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#radialGradient1141-6);fill-opacity:1;stroke:#9bdb4d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.544444"
+       d="m 120.91442,105.5 -0.62985,4 h -4.19898 l 0.62985,-4 z"
+       id="path915-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient1031-3);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 84,103.39031 V 108 h 3 v -4.60969 z"
+       id="path928-93-1"
+       inkscape:connector-curvature="0" />
+  </g>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect2723-0"
+     y="106.66667"
+     x="14.840887"
+     height="13.333335"
+     width="98.31813" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2725-6"
+     d="m 113.11112,106.66714 c 0,0 0,13.3326 0,13.3326 6.15874,0.0253 14.88888,-2.98717 14.88888,-6.66715 0,-3.68 -6.8727,-6.66545 -14.88888,-6.66545 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none"
+     id="path2727-2"
+     d="m 14.888884,106.66714 c 0,0 0,13.3326 0,13.3326 C 8.730107,120.02484 0,117.01257 0,113.33259 c 0,-3.68 6.872721,-6.66545 14.888884,-6.66545 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-61"
+     d="M 124,100.00001 108,27.000002 C 107.19616,24.000002 104,23 101.00002,23 H 27.000005 c -3,0 -6.308472,1.000002 -7,4.000002 L 4.0000007,100.00001"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 3.5,101 20.000005,27.000002 c 0.803848,-3 4,-4.000002 7,-4.000002 H 101.00002 C 104,23 107.30848,24.000002 108,27.000002 L 124.5,101"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:url(#linearGradient2557-5);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:1.02982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-8"
+     d="M 117.14892,113.48509 H 10.851095 c -4.0112393,0 -4.942398,-1.05756 -6.0172054,-5.28781 L 3.8314268,103.96705 C 1.8258071,95.506556 9.8482861,96.564117 13.859525,96.564117 H 114.14049 c 4.01124,0 12.0337,-1.057561 10.02809,7.402933 l -1.00281,4.23023 c -1.00281,4.23025 -2.00562,5.28781 -6.01685,5.28781 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <rect
+     style="display:inline;opacity:0.3;fill:url(#radialGradient2516-3);fill-opacity:1;stroke:none;stroke-width:2"
+     id="rect6300-3"
+     y="98.367813"
+     x="5.999999"
+     height="13.632197"
+     width="116.00001" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:1.97648;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="M 115.85419,111.01135 H 12.144623 c -3.91357,0 -4.822056,-0.99819 -5.8706921,-4.99096 l -0.978054,-3.99277 C 3.3390905,94.042081 11.16623,95.040271 15.0798,95.040271 h 97.8392 c 3.91357,0 11.7407,-0.99819 9.78392,6.987349 l -0.9784,3.99277 c -0.97838,3.99277 -1.95678,4.99096 -5.87033,4.99096 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1047);stroke-width:1.94489;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2"
+     d="M 114.11076,101.02846 H 13.889237 c -3.781945,0 -4.659876,-1.00017 -5.673246,-5.000869 l -0.945158,-4.0007 c -1.8909741,-8.0014 5.672917,-7.00122 9.454865,-7.00122 H 111.2743 c 3.78196,0 11.34584,-1.00018 9.45486,7.00122 l -0.94548,4.0007 c -0.94547,4.000699 -1.89095,5.000869 -5.67292,5.000869 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1077);stroke-width:1.94489;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2-2"
+     d="M 114.11076,100.02846 H 13.889237 c -3.781945,0 -4.659876,-1.000169 -5.673246,-5.000869 l -0.945158,-4.0007 c -1.8909741,-8.0014 5.672917,-7.00122 9.454865,-7.00122 H 111.2743 c 3.78196,0 11.34584,-1.00018 9.45486,7.00122 l -0.94548,4.0007 c -0.94547,4.0007 -1.89095,5.000869 -5.67292,5.000869 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     style="display:inline;opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1233);stroke-width:1.04567;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 117.47718,103.02284 -1.06991,5.95433 h -5.88445 l 1.0699,-5.95433 z"
+     id="path915-2"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="display:inline;opacity:0.5;fill:#fbffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4521)"
+     d="M 117.00001,103 116.2,108.48115 h -5.60002 L 111.5,103 Z"
+     id="path915-2-9"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc"
+     transform="matrix(0.71428326,0,0,0.71428326,32.500283,30.013729)" />
+  <path
+     style="display:inline;vector-effect:none;fill:url(#radialGradient925-0);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.598837;paint-order:normal"
+     d="M 11.945682,108.99999 H 86.50023 L 87.00024,103 H 11.000206 Z"
+     id="rect917-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="display:inline;fill:url(#linearGradient1011-2);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 13.999782,103 v 3.99999 h 4.000026 V 103 Z"
+     id="path928-54"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1013-3);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 19.999821,103 v 3.99999 h 4.000025 V 103 Z"
+     id="path928-3-7"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1015-6);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 25.999858,103 v 3.99999 h 4.000025 V 103 Z"
+     id="path928-6-6"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1017-0);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 31.999896,103 v 3.99999 H 35.99992 V 103 Z"
+     id="path928-7-5"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1019-1);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 37.999933,103 v 3.99999 h 4.000025 V 103 Z"
+     id="path928-5-6"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1021-6);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 43.999971,103 v 3.99999 h 4.000025 V 103 Z"
+     id="path928-35-9"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1023-3);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 50.000009,103 v 3.99999 h 4.000025 V 103 Z"
+     id="path928-62-3"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1025-8);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 56.000046,103 v 3.99999 h 4.000025 V 103 Z"
+     id="path928-9-7"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1027-4);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 62.000083,103 v 3.99999 h 4.000025 V 103 Z"
+     id="path928-1-4"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1029-9);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 68.000122,103 v 3.99999 H 72.00015 V 103 Z"
+     id="path928-2-5"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1033-1);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 74.00016,103 v 3.99999 h 4.00003 V 103 Z"
+     id="path928-70-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1031-1);fill-opacity:1;stroke:none;stroke-width:2.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 80.00019,103 v 3.99999 h 4.00003 V 103 Z"
+     id="path928-93-5"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;opacity:0.75;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:#d1ff82;stroke-width:0.990183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter1079)"
+     d="m 114.93053,104.79457 -0.35157,2.10386 h -2.10941 l 0.35157,-2.10386 z"
+     id="path915-1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc"
+     transform="matrix(2.8491254,0,0,2.661909,-209.69566,-176.17717)" />
 </svg>

--- a/devices/16/drive-harddisk-solidstate.svg
+++ b/devices/16/drive-harddisk-solidstate.svg
@@ -1,50 +1,577 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" id="svg3297" height="16" width="16" version="1.0" sodipodi:docname="drive-harddisk-solidstate-16.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview26" showgrid="false" inkscape:zoom="1" inkscape:cx="5.808669" inkscape:cy="8.5528004" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3297">
-    <inkscape:grid type="xygrid" id="grid833" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3297"
+   height="16"
+   width="16"
+   version="1.0"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1423"
+     inkscape:window-height="794"
+     id="namedview26"
+     showgrid="true"
+     inkscape:zoom="5.4049551"
+     inkscape:cx="-6.507702"
+     inkscape:cy="0.34054142"
+     inkscape:window-x="50"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3297"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
   </sodipodi:namedview>
-  <metadata id="metadata58">
+  <metadata
+     id="metadata58">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3299">
-    <linearGradient id="linearGradient4472">
-      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop4474" />
-      <stop offset="0.02116842" style="stop-color:#ffffff;stop-opacity:0.23529412" id="stop4476" />
-      <stop offset="0.99223143" style="stop-color:#ffffff;stop-opacity:0.15686275" id="stop4478" />
-      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0.39215687" id="stop4480" />
+  <defs
+     id="defs3299">
+    <linearGradient
+       id="linearGradient1117">
+      <stop
+         id="stop1113"
+         style="stop-color:#333330;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1115"
+         style="stop-color:#333333;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient2215-9">
-      <stop offset="0" style="stop-color:#7a7a7a;stop-opacity:1" id="stop2223-6" />
-      <stop offset="1" style="stop-color:#474747;stop-opacity:1" id="stop2219-1" />
+    <linearGradient
+       id="linearGradient4472">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4474" />
+      <stop
+         offset="0.02116842"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4476" />
+      <stop
+         offset="0.99223143"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4478" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4480" />
     </linearGradient>
-    <linearGradient id="linearGradient7056-0">
-      <stop offset="0" style="stop-color:#e6e6e6;stop-opacity:1" id="stop7064-4" />
-      <stop offset="1" style="stop-color:#c8c8c8;stop-opacity:1" id="stop7060-2" />
+    <linearGradient
+       id="linearGradient2215-9">
+      <stop
+         offset="0"
+         style="stop-color:#7a7a7a;stop-opacity:1"
+         id="stop2223-6" />
+      <stop
+         offset="1"
+         style="stop-color:#474747;stop-opacity:1"
+         id="stop2219-1" />
     </linearGradient>
-    <radialGradient gradientTransform="matrix(1.1767008,1.0376968,-0.76927742,0.87232541,1.0363585,-3.2771526)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7056-0" id="radialGradient8215" fy="2.3117516" fx="4.1993008" r="7.9999995" cy="2.3117516" cx="4.1993008" />
-    <linearGradient gradientTransform="matrix(0.1242128,0,0,0.1863981,0.233129,-3.9907482)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2215-9" id="linearGradient8226" y2="104.28131" x2="53.99139" y1="87.89592" x1="53.99139" />
-    <linearGradient x1="23.99999" y1="7.3399634" x2="23.99999" y2="41.03442" id="linearGradient4161" xlink:href="#linearGradient4472" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.26751495,0,0,0.26751495,4.7162587,-0.01354682)" />
-    <linearGradient y2="54.887066" x2="23.99999" y1="50.676285" x1="23.99999" gradientTransform="matrix(0.26751495,0,0,0.26751495,4.7162587,-0.01354682)" gradientUnits="userSpaceOnUse" id="linearGradient4525" xlink:href="#linearGradient4472" />
+    <linearGradient
+       id="linearGradient7056-0">
+      <stop
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064-4" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.1767008,1.0376968,-0.76927742,0.87232541,1.0363585,-3.2771526)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient7056-0"
+       id="radialGradient8215"
+       fy="2.3117516"
+       fx="4.1993008"
+       r="7.9999995"
+       cy="2.3117516"
+       cx="4.1993008" />
+    <linearGradient
+       gradientTransform="matrix(0.1242128,0,0,0.1863981,0.233129,-3.9907482)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2215-9"
+       id="linearGradient8226"
+       y2="104.28131"
+       x2="53.99139"
+       y1="87.89592"
+       x1="53.99139" />
+    <linearGradient
+       x1="23.99999"
+       y1="7.3399634"
+       x2="23.99999"
+       y2="41.03442"
+       id="linearGradient4161"
+       xlink:href="#linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26751495,0,0,0.26751495,4.7162587,-0.01354682)" />
+    <linearGradient
+       y2="54.887066"
+       x2="23.99999"
+       y1="50.676285"
+       x1="23.99999"
+       gradientTransform="matrix(0.26751495,0,0,0.26751495,4.7162587,-0.01354682)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4525"
+       xlink:href="#linearGradient4472" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000025,0,0,0.99999998,5.9999966,-38.499997)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1308"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000025,0,0,0.99999998,4.0000014,-38.499997)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000025,0,0,0.99999998,1.9999999,-38.499997)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000025,0,0,0.99999998,-1.3e-6,-38.499997)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5"
+       gradientTransform="matrix(0.25801163,-6.0308013e-8,0,-0.07207191,-0.39419448,18.735792)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#555761;stop-opacity:1"
+         id="stop1043" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1084"
+       id="linearGradient1092"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.472551,0,0,0.49816154,0.87836803,-1.6451052)"
+       x1="31.999998"
+       y1="48.487175"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       id="linearGradient1084">
+      <stop
+         id="stop1149"
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1095"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1018">
+      <stop
+         id="stop1013"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1015"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999996"
+       y2="48.973789"
+       gradientTransform="matrix(0.24456115,0,0,0.24903822,0.1740367,0.67961348)" />
+    <linearGradient
+       x1="29.000795"
+       y1="42.749775"
+       x2="29.000795"
+       y2="46.964066"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33583248,0,0,0.36693266,-1.7394092,-2.6862883)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="11.337756"
+       y2="31.566195"
+       gradientTransform="matrix(-0.2419978,0,0,0.25649829,15.743712,-0.45144559)" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.88746887" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25000003,0,0,0.2564103,0.09730899,-0.32780822)" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.48879358" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.53991425" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01494915,0,0,0.00686275,10.842686,11.810011)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01494915,0,0,0.00686275,5.101935,11.810011)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02545218,0,0,0.00686275,-1.2268337,11.810011)" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1117"
+       id="linearGradient1111"
+       x1="8"
+       y1="11"
+       x2="8"
+       y2="12"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.91425254,0,0,1.0127503,0.68598218,-1.904477)" />
   </defs>
-  <path style="fill:url(#radialGradient8215);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect2990" d="M 1.4897093,1.4657632 0.514749,12.488885 C 0.505,12.488885 0.5,12.491788 0.5,12.499999 l 14.999999,0 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478485 c 0,0 -0.187746,-0.74340135 -0.909635,-0.74340135 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576325 -0.8205124,0.96576325 z" />
-  <path style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;opacity:0.35" id="rect2990-0" d="M 1.4897093,1.465763 0.514749,12.488885 C 0.505,12.488885 0.5,12.491785 0.5,12.499995 l 14.999999,0 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478483 c 0,0 -0.187746,-0.74340136 -0.909635,-0.74340136 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576326 -0.8205124,0.96576326 z" />
-  <path style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="rect2992" d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
-  <path style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;opacity:0.5" id="rect2992-2" d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
-  <path d="m 2.4980469,1.5019531 c -0.00136,0.00636 -0.00781,0.027344 -0.00781,0.027344 a 1.0015087,1.0015087 0 0 1 -0.00195,0.023437 l -0.8789062,9.9453126 12.78125,0 -0.892578,-9.9921876 C 12.708012,1.5058107 3.4947245,1.5020781 2.4980469,1.5019531 Z" id="path4266" style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4161);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;color:#000000;clip-rule:nonzero;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
-  <path d="m 1.578125,13.476562 c 0.035324,0.3836 0.082771,0.870078 0.1015625,1.03125 2.352568,8.41e-4 5.411826,0.0094 8.015625,0.01367 1.3716895,0.0023 2.6003495,0.0036 3.4980465,0.002 0.448849,-8.46e-4 0.815103,-0.0034 1.072266,-0.0059 0.0025,-2.4e-5 0.0034,2.4e-5 0.0059,0 0.02745,-0.171355 0.08454,-0.677932 0.125,-1.041016 l -12.818359,0 z" id="path4497" style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;color:#000000;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect835" width="1" height="1" x="2" y="13.6" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect837" width="1" height="0.99999958" x="4" y="13.6" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect839" width="1" height="1" x="6" y="13.6" />
-  <rect style="opacity:1;vector-effect:none;fill:#eabb43;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect841" width="1" height="0.98437452" x="8" y="13.615625" />
-  <rect style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect843" width="1" height="1" x="13" y="13.6" />
-  <circle style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="path845" cx="3.5" cy="2.5" r="0.5" />
-  <circle style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="path845-3" cx="2.5" cy="10.5" r="0.5" />
-  <circle style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="path845-6" cx="12.5" cy="2.5" r="0.5" />
-  <circle style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="path845-7" cx="13.5" cy="10.5" r="0.5" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.125;marker:none"
+     id="rect2723-5"
+     y="14.326221"
+     x="1.8274198"
+     height="1.6666666"
+     width="12.289766" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.125;marker:none"
+     id="path2725-6"
+     d="m 14.111198,14.326278 c 0,0 0,1.666575 0,1.666575 0.769844,0.0032 1.86111,-0.373395 1.86111,-0.833394 0,-0.459999 -0.859086,-0.833181 -1.86111,-0.833181 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.25;marker:none"
+     id="path2727-2"
+     d="m 1.833419,14.326278 c 0,0 0,1.666575 0,1.666575 -0.7698467,0.0032 -1.86111,-0.373395 -1.86111,-0.833394 0,-0.459999 0.8590899,-0.833181 1.86111,-0.833181 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.253186;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-91"
+     d="M 15.5,13 13.375,3 C 13.274518,2.6153845 12.875001,2.5 12.5,2.5 h -9 C 3.1250002,2.5 2.7114411,2.6153845 2.6250001,3 L 0.5,13"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 0.5,13 2.625,3 C 2.722265,2.6152526 3.1370034,2.5 3.5,2.5 h 9 c 0.362998,0 0.791326,0.1152526 0.875,0.5 L 15.5,13"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;enable-background:new"
+     id="rect6431-2"
+     d="M 14.556256,15.462559 H 1.4432056 c -0.49483231,0 -0.60970133,-0.181684 -0.74229113,-0.908399 L 0.57724922,13.827478 C 0.32983295,12.374049 1.3194967,12.555733 1.8143306,12.555733 H 14.18514 c 0.494833,0 1.484492,-0.181684 1.237079,1.271745 L 15.29852,14.55416 c -0.123713,0.726715 -0.247424,0.908399 -0.742264,0.908399 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="M 14.480862,14.750274 H 1.5191228 c -0.4891222,0 -0.6026657,-0.124519 -0.7337256,-0.622596 L 0.663159,13.629602 C 0.4185977,12.633448 1.3968423,12.757968 1.8859646,12.757968 H 14.11402 c 0.489122,0 1.467367,-0.12452 1.222806,0.871634 l -0.122281,0.498076 c -0.12228,0.498077 -0.244561,0.622596 -0.733683,0.622596 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1111);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2-2"
+     d="M 13.724407,11.514992 H 2.2755919 c -0.4320306,0 -0.5323212,-0.126129 -0.6480837,-0.630646 l -0.10797,-0.504507 C 1.3035226,9.3708084 2.1675841,9.4969368 2.599615,9.4969368 h 10.800768 c 0.432031,0 1.296095,-0.1261284 1.080079,0.8829022 l -0.108007,0.504507 c -0.108008,0.504517 -0.216016,0.630646 -0.648048,0.630646 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <g
+     id="path915"
+     style="fill:#9bdb4d;fill-opacity:0.75;stroke:none;stroke-width:0.700198;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.504001"
+     transform="matrix(0.49971766,0,0,0.5,0.008082,4.8e-7)" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.74902;fill-rule:evenodd;stroke:#68b723;stroke-width:0.287211;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 13.481394,13.518606 v 0.96279 h -0.962789 l 0.0017,-0.96279 z"
+     id="path1472"
+     sodipodi:nodetypes="ccccc" />
+  <g
+     id="rect917"
+     transform="matrix(0.5185453,0,0,0.5,0.33300186,-0.25)"
+     style="stroke:#333333;stroke-width:0.99963;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.504001"
+     inkscape:groupmode="layer" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.99;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.550975;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 2.1139242,14.5 H 10.886077 L 11,13.5 H 2 Z"
+     id="path1478" />
+  <path
+     style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.499999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 3,13.5 v 1 h 1 v -1 z"
+     id="path928"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1259);fill-opacity:1;stroke:none;stroke-width:0.499999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 5,13.5 v 1 h 1 v -1 z"
+     id="path928-3"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1308);fill-opacity:1;stroke:none;stroke-width:0.499999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 7,13.5 v 1 h 1 v -1 z"
+     id="path928-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1394);fill-opacity:1;stroke:none;stroke-width:0.499999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 9,13.5 v 1 h 1 v -1 z"
+     id="path928-9"
+     inkscape:connector-curvature="0" />
+  <g
+     id="g875"
+     style="display:none">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient8215);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect2990"
+       d="M 1.4897093,1.4657632 0.514749,12.488885 C 0.505,12.488885 0.5,12.491788 0.5,12.499999 h 14.999999 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478485 c 0,0 -0.187746,-0.74340135 -0.909635,-0.74340135 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576325 -0.8205124,0.96576305 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect2990-0"
+       d="M 1.4897093,1.465763 0.514749,12.488885 C 0.505,12.488885 0.5,12.491785 0.5,12.499995 h 14.999999 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478483 c 0,0 -0.187746,-0.74340136 -0.909635,-0.74340136 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576326 -0.8205124,0.96576306 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect2992"
+       d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect2992-2"
+       d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
+    <path
+       d="m 2.4980469,1.5019531 c -0.00136,0.00636 -0.00781,0.027344 -0.00781,0.027344 a 1.0015087,1.0015087 0 0 1 -0.00195,0.023437 L 1.6093807,11.498047 H 14.390631 L 13.498053,1.5058591 C 12.708012,1.5058107 3.4947245,1.5020781 2.4980469,1.5019531 Z"
+       id="path4266"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4161);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       d="m 1.578125,13.476562 c 0.035324,0.3836 0.082771,0.870078 0.1015625,1.03125 2.352568,8.41e-4 5.411826,0.0094 8.015625,0.01367 1.3716895,0.0023 2.6003495,0.0036 3.4980465,0.002 0.448849,-8.46e-4 0.815103,-0.0034 1.072266,-0.0059 0.0025,-2.4e-5 0.0034,2.4e-5 0.0059,0 0.02745,-0.171355 0.08454,-0.677932 0.125,-1.041016 H 1.578166 Z"
+       id="path4497"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
+       id="rect835"
+       width="1"
+       height="1"
+       x="2"
+       y="13.6" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
+       id="rect837"
+       width="1"
+       height="0.99999958"
+       x="4"
+       y="13.6" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
+       id="rect839"
+       width="1"
+       height="1"
+       x="6"
+       y="13.6" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#eabb43;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
+       id="rect841"
+       width="1"
+       height="0.98437452"
+       x="8"
+       y="13.615625" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
+       id="rect843"
+       width="1"
+       height="1"
+       x="13"
+       y="13.6" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="path845"
+       cx="3.5"
+       cy="2.5"
+       r="0.5" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="path845-3"
+       cx="2.5"
+       cy="10.5"
+       r="0.5" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="path845-6"
+       cx="12.5"
+       cy="2.5"
+       r="0.5" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="path845-7"
+       cx="13.5"
+       cy="10.5"
+       r="0.5" />
+  </g>
 </svg>

--- a/devices/16/drive-harddisk-solidstate.svg
+++ b/devices/16/drive-harddisk-solidstate.svg
@@ -27,9 +27,9 @@
      inkscape:window-height="794"
      id="namedview26"
      showgrid="true"
-     inkscape:zoom="5.4049551"
-     inkscape:cx="-6.507702"
-     inkscape:cy="0.34054142"
+     inkscape:zoom="18.398279"
+     inkscape:cx="-0.24288232"
+     inkscape:cy="10.109085"
      inkscape:window-x="50"
      inkscape:window-y="30"
      inkscape:window-maximized="0"
@@ -261,7 +261,7 @@
        y1="47.999744"
        x2="31.999996"
        y2="48.973789"
-       gradientTransform="matrix(0.24456115,0,0,0.24903822,0.1740367,0.67961348)" />
+       gradientTransform="matrix(0.24455231,0,0,0.24897057,0.17405298,0.68289304)" />
     <linearGradient
        x1="29.000795"
        y1="42.749775"
@@ -270,7 +270,7 @@
        id="linearGradient2557"
        xlink:href="#linearGradient2215"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.33583248,0,0,0.36693266,-1.7394092,-2.6862883)" />
+       gradientTransform="matrix(0.33752081,0,0,0.37646575,-1.7881039,-3.1203192)" />
     <linearGradient
        id="linearGradient2215">
       <stop
@@ -400,7 +400,7 @@
        x2="8"
        y2="12"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.91425254,0,0,1.0127503,0.68598218,-1.904477)" />
+       gradientTransform="matrix(0.9121425,0,0,0.99715677,0.70286251,-1.7128706)" />
   </defs>
   <rect
      style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.125;marker:none"
@@ -423,31 +423,31 @@
      inkscape:connector-curvature="0"
      style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.253186;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
      id="path6345-91"
-     d="M 15.5,13 13.375,3 C 13.274518,2.6153845 12.875001,2.5 12.5,2.5 h -9 C 3.1250002,2.5 2.7114411,2.6153845 2.6250001,3 L 0.5,13"
+     d="M 15.5,13 13.375,2 C 13.274518,1.6153845 12.875001,1.5 12.5,1.5 h -9 C 3.1250002,1.5 2.7114411,1.6153845 2.6250001,2 L 0.5,13"
      sodipodi:nodetypes="ccsscc" />
   <path
      inkscape:connector-curvature="0"
      style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
      id="path6345-6"
-     d="M 0.5,13 2.625,3 C 2.722265,2.6152526 3.1370034,2.5 3.5,2.5 h 9 c 0.362998,0 0.791326,0.1152526 0.875,0.5 L 15.5,13"
+     d="M 0.5,13 2.625,2 C 2.722265,1.6152526 3.1370034,1.5 3.5,1.5 h 9 c 0.362998,0 0.791326,0.1152526 0.875,0.5 L 15.5,13"
      sodipodi:nodetypes="ccsscc" />
   <path
      inkscape:connector-curvature="0"
-     style="display:inline;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;enable-background:new"
+     style="display:inline;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:#333333;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;enable-background:new"
      id="rect6431-2"
-     d="M 14.556256,15.462559 H 1.4432056 c -0.49483231,0 -0.60970133,-0.181684 -0.74229113,-0.908399 L 0.57724922,13.827478 C 0.32983295,12.374049 1.3194967,12.555733 1.8143306,12.555733 H 14.18514 c 0.494833,0 1.484492,-0.181684 1.237079,1.271745 L 15.29852,14.55416 c -0.123713,0.726715 -0.247424,0.908399 -0.742264,0.908399 z"
+     d="M 14.589484,15.500044 H 1.4105109 c -0.49732002,0 -0.61276652,-0.186404 -0.74602289,-0.932 L 0.54020106,13.822483 C 0.29154095,12.331293 1.2861801,12.517697 1.7835017,12.517697 H 14.216502 c 0.497321,0 1.491955,-0.186404 1.243298,1.304786 l -0.12432,0.745561 c -0.124335,0.745596 -0.248668,0.932 -0.745996,0.932 z"
      sodipodi:nodetypes="ccccscccc" />
   <path
      inkscape:connector-curvature="0"
      style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
      id="rect6431-3"
-     d="M 14.480862,14.750274 H 1.5191228 c -0.4891222,0 -0.6026657,-0.124519 -0.7337256,-0.622596 L 0.663159,13.629602 C 0.4185977,12.633448 1.3968423,12.757968 1.8859646,12.757968 H 14.11402 c 0.489122,0 1.467367,-0.12452 1.222806,0.871634 l -0.122281,0.498076 c -0.12228,0.498077 -0.244561,0.622596 -0.733683,0.622596 z"
+     d="M 14.480361,14.749732 H 1.5190905 c -0.4891046,0 -0.60264395,-0.124486 -0.73369912,-0.622427 L 0.6631576,13.629364 C 0.41860514,12.633481 1.3968144,12.757967 1.885919,12.757967 h 12.227613 c 0.489105,0 1.467314,-0.124486 1.222762,0.871397 l -0.122276,0.497941 c -0.122276,0.497941 -0.244552,0.622427 -0.733657,0.622427 z"
      sodipodi:nodetypes="ccccscccc" />
   <path
      inkscape:connector-curvature="0"
      style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1111);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
      id="rect6431-3-2-2"
-     d="M 13.724407,11.514992 H 2.2755919 c -0.4320306,0 -0.5323212,-0.126129 -0.6480837,-0.630646 l -0.10797,-0.504507 C 1.3035226,9.3708084 2.1675841,9.4969368 2.599615,9.4969368 h 10.800768 c 0.432031,0 1.296095,-0.1261284 1.080079,0.8829022 l -0.108007,0.504507 c -0.108008,0.504517 -0.216016,0.630646 -0.648048,0.630646 z"
+     d="M 13.711195,11.499976 H 2.2888035 c -0.4310335,0 -0.5310927,-0.124187 -0.646588,-0.620936 L 1.5344947,10.382301 C 1.3189777,9.3888069 2.181045,9.5129932 2.6120788,9.5129932 H 13.387919 c 0.431034,0 1.293104,-0.1241863 1.077586,0.8693078 l -0.107757,0.496739 c -0.107759,0.496749 -0.215518,0.620936 -0.646553,0.620936 z"
      sodipodi:nodetypes="ccccscccc" />
   <g
      id="path915"
@@ -487,91 +487,4 @@
      d="m 9,13.5 v 1 h 1 v -1 z"
      id="path928-9"
      inkscape:connector-curvature="0" />
-  <g
-     id="g875"
-     style="display:none">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient8215);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="rect2990"
-       d="M 1.4897093,1.4657632 0.514749,12.488885 C 0.505,12.488885 0.5,12.491788 0.5,12.499999 h 14.999999 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478485 c 0,0 -0.187746,-0.74340135 -0.909635,-0.74340135 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576325 -0.8205124,0.96576305 z" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="rect2990-0"
-       d="M 1.4897093,1.465763 0.514749,12.488885 C 0.505,12.488885 0.5,12.491785 0.5,12.499995 h 14.999999 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478483 c 0,0 -0.187746,-0.74340136 -0.909635,-0.74340136 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576326 -0.8205124,0.96576306 z" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="rect2992"
-       d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="rect2992-2"
-       d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
-    <path
-       d="m 2.4980469,1.5019531 c -0.00136,0.00636 -0.00781,0.027344 -0.00781,0.027344 a 1.0015087,1.0015087 0 0 1 -0.00195,0.023437 L 1.6093807,11.498047 H 14.390631 L 13.498053,1.5058591 C 12.708012,1.5058107 3.4947245,1.5020781 2.4980469,1.5019531 Z"
-       id="path4266"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4161);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <path
-       d="m 1.578125,13.476562 c 0.035324,0.3836 0.082771,0.870078 0.1015625,1.03125 2.352568,8.41e-4 5.411826,0.0094 8.015625,0.01367 1.3716895,0.0023 2.6003495,0.0036 3.4980465,0.002 0.448849,-8.46e-4 0.815103,-0.0034 1.072266,-0.0059 0.0025,-2.4e-5 0.0034,2.4e-5 0.0059,0 0.02745,-0.171355 0.08454,-0.677932 0.125,-1.041016 H 1.578166 Z"
-       id="path4497"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <rect
-       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
-       id="rect835"
-       width="1"
-       height="1"
-       x="2"
-       y="13.6" />
-    <rect
-       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
-       id="rect837"
-       width="1"
-       height="0.99999958"
-       x="4"
-       y="13.6" />
-    <rect
-       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
-       id="rect839"
-       width="1"
-       height="1"
-       x="6"
-       y="13.6" />
-    <rect
-       style="opacity:1;vector-effect:none;fill:#eabb43;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
-       id="rect841"
-       width="1"
-       height="0.98437452"
-       x="8"
-       y="13.615625" />
-    <rect
-       style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
-       id="rect843"
-       width="1"
-       height="1"
-       x="13"
-       y="13.6" />
-    <circle
-       style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
-       id="path845"
-       cx="3.5"
-       cy="2.5"
-       r="0.5" />
-    <circle
-       style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
-       id="path845-3"
-       cx="2.5"
-       cy="10.5"
-       r="0.5" />
-    <circle
-       style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
-       id="path845-6"
-       cx="12.5"
-       cy="2.5"
-       r="0.5" />
-    <circle
-       style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
-       id="path845-7"
-       cx="13.5"
-       cy="10.5"
-       r="0.5" />
-  </g>
 </svg>

--- a/devices/24/drive-harddisk-solidstate.svg
+++ b/devices/24/drive-harddisk-solidstate.svg
@@ -1,122 +1,813 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="24" height="24" id="svg2" sodipodi:docname="drive-harddisk-solidstate-24.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview93" showgrid="true" inkscape:zoom="27.812867" inkscape:cx="18.934484" inkscape:cy="9.3374569" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg2">
-    <inkscape:grid type="xygrid" id="grid900" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="24"
+   height="24"
+   id="svg2"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1293"
+     inkscape:window-height="755"
+     id="namedview93"
+     showgrid="true"
+     inkscape:zoom="21.938365"
+     inkscape:cx="12.418543"
+     inkscape:cy="12.69734"
+     inkscape:window-x="16"
+     inkscape:window-y="39"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid900" />
   </sodipodi:namedview>
-  <metadata id="metadata88">
+  <metadata
+     id="metadata88">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs4">
-    <linearGradient id="linearGradient4075">
-      <stop id="stop4077" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4079" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.03367912" />
-      <stop id="stop4081" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4083" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4075">
+      <stop
+         id="stop4077"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4079"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03367912" />
+      <stop
+         id="stop4081"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4083"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="53.99139" y1="87.89592" x2="53.99139" y2="104.28131" id="linearGradient2872" xlink:href="#linearGradient2215-9" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.1904597,0,0,0.2485308,0.090799,-3.484712)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2877" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.02218262,0,0,0.01085997,16.259269,17.380799)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2880" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.02218262,0,0,0.01085997,7.7407365,17.380799)" />
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2883" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.03776775,0,0,0.01085997,-1.650341,17.380799)" />
-    <linearGradient id="linearGradient7056-0">
-      <stop id="stop7064-4" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060-2" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="53.99139"
+       y1="87.89592"
+       x2="53.99139"
+       y2="104.28131"
+       id="linearGradient2872"
+       xlink:href="#linearGradient2215-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1904597,0,0,0.2485308,0.090799,-3.484712)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2877"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02218262,0,0,0.01085997,16.259269,17.380799)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2880"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02218262,0,0,0.01085997,7.7407365,17.380799)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2883"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03776775,0,0,0.01085997,-1.650341,17.380799)" />
+    <linearGradient
+       id="linearGradient7056-0">
+      <stop
+         id="stop7064-4"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060-2"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient2215-9">
-      <stop id="stop2223-6" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219-1" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient2215-9">
+      <stop
+         id="stop2223-6"
+         style="stop-color:#7a7a7a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219-1"
+         style="stop-color:#474747;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="7.2203388" cy="4.2332726" r="12" fx="7.2203388" fy="4.2332726" id="radialGradient4072" xlink:href="#linearGradient7056-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.5193809,0.00371571,-0.00302474,1.2368318,-3.737301,0.06783288)" />
-    <linearGradient x1="23.99999" y1="51.346149" x2="23.99999" y2="53.354122" id="linearGradient4525" xlink:href="#linearGradient4472" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.42777307,0,0,0.51069006,6.7368356,-6.2528082)" />
-    <linearGradient id="linearGradient4472">
-      <stop id="stop4474" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4476" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.02116842" />
-      <stop id="stop4478" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4480" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    <radialGradient
+       cx="7.2203388"
+       cy="4.2332726"
+       r="12"
+       fx="7.2203388"
+       fy="4.2332726"
+       id="radialGradient4072"
+       xlink:href="#linearGradient7056-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5193809,0.00371571,-0.00302474,1.2368318,-3.737301,0.06783288)" />
+    <linearGradient
+       x1="23.99999"
+       y1="51.346149"
+       x2="23.99999"
+       y2="53.354122"
+       id="linearGradient4525"
+       xlink:href="#linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42777307,0,0,0.51069006,6.7368356,-6.2528082)" />
+    <linearGradient
+       id="linearGradient4472">
+      <stop
+         id="stop4474"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4476"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02116842" />
+      <stop
+         id="stop4478"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4480"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="23.99999" y1="6.5391083" x2="23.99999" y2="42.102226" id="linearGradient4161-4" xlink:href="#linearGradient4075" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.26232885,0,0,0.42474288,8.0835877,-0.81629626)" />
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient8490" xlink:href="#linearGradient6309" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.2092209,1.4719088)" />
-    <linearGradient id="linearGradient6309">
-      <stop id="stop6311" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop6313" style="stop-color:#bbbbbb;stop-opacity:0" offset="1" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.5391083"
+       x2="23.99999"
+       y2="42.102226"
+       id="linearGradient4161-4"
+       xlink:href="#linearGradient4075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26232885,0,0,0.42474288,8.0835877,-0.81629626)" />
+    <linearGradient
+       x1="7.0625"
+       y1="35.28125"
+       x2="24.6875"
+       y2="35.28125"
+       id="linearGradient8490"
+       xlink:href="#linearGradient6309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.2092209,1.4719088)" />
+    <linearGradient
+       id="linearGradient6309">
+      <stop
+         id="stop6311"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6313"
+         style="stop-color:#bbbbbb;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient8487" xlink:href="#linearGradient4236-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.7959675,2.1869583)" />
-    <linearGradient id="linearGradient4236-0">
-      <stop id="stop4238-4" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240-3" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient8487"
+       xlink:href="#linearGradient4236-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.7959675,2.1869583)" />
+    <linearGradient
+       id="linearGradient4236-0">
+      <stop
+         id="stop4238-4"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240-3"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient8447" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient4241" gradientUnits="userSpaceOnUse">
-      <stop id="stop4243" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4245" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop4247" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop4249" style="stop-color:#555555;stop-opacity:1" offset="1" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8447"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient4241"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop4243"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4245"
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="0.16" />
+      <stop
+         id="stop4247"
+         style="stop-color:#888888;stop-opacity:1"
+         offset="0.4675" />
+      <stop
+         id="stop4249"
+         style="stop-color:#555555;stop-opacity:1"
+         offset="1" />
     </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient8443" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient8471" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.18614571,-0.00314024,0.00137767,0.18068297,-15.012876,-20.635958)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8443"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="141.74666"
+       cy="206.42612"
+       r="78.728165"
+       fx="141.74666"
+       fy="206.42612"
+       id="radialGradient8471"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18614571,-0.00314024,0.00137767,0.18068297,-15.012876,-20.635958)" />
+    <linearGradient
+       id="linearGradient4035">
+      <stop
+         id="stop4037"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4039"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop4041"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.69348532" />
+      <stop
+         id="stop4043"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop4045"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient8464" xlink:href="#linearGradient7609-6" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.09247618,0,0,-0.08716215,-1.5555849,24.365579)" />
-    <linearGradient id="linearGradient7609-6">
-      <stop id="stop7611-3" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop7677-2" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop7613-4" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop7617-3" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop7615-6" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <radialGradient
+       cx="142.62215"
+       cy="191.85428"
+       r="78.728165"
+       fx="142.62215"
+       fy="191.85428"
+       id="radialGradient8464"
+       xlink:href="#linearGradient7609-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09247618,0,0,-0.08716215,-1.5555849,24.365579)" />
+    <linearGradient
+       id="linearGradient7609-6">
+      <stop
+         id="stop7611-3"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7677-2"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop7613-4"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.67183787" />
+      <stop
+         id="stop7617-3"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop7615-6"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient8475" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.10005865,-0.02337636,0.00821684,0.05971738,-5.2741109,-0.9113469)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient8498" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient8494" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="127.31733"
+       cy="143.82751"
+       r="78.728165"
+       fx="127.31733"
+       fy="143.82751"
+       id="radialGradient8475"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10005865,-0.02337636,0.00821684,0.05971738,-5.2741109,-0.9113469)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8498"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8494"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04163856,0,0,0.01122713,-3.0867404,16.048711)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0244561,0,0,0.01122713,7.2668246,16.048711)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0244561,0,0,0.01122713,16.658421,16.048711)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40898817,0,0,0.41947507,-0.9205058,-3.8081848)" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.48879358" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.53991425" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="11.337756"
+       y2="31.566195"
+       gradientTransform="matrix(-0.39589691,0,0,0.41961902,24.676267,-4.0104497)" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.88746887" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="29.000795"
+       y1="42.749775"
+       x2="29.000795"
+       y2="46.964066"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5175541,0,0,0.62816384,-3.0090837,-7.5696044)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1018">
+      <stop
+         id="stop1013"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1015"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1117"
+       id="linearGradient1111"
+       x1="8"
+       y1="11"
+       x2="8"
+       y2="12"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4734942,0,0,1.6568114,0.21205032,-5.1358477)" />
+    <linearGradient
+       id="linearGradient1117">
+      <stop
+         id="stop1113"
+         style="stop-color:#333330;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1115"
+         style="stop-color:#333333;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5"
+       gradientTransform="matrix(0.45868731,-1.2061608e-7,0,-0.14414387,-2.2563447,30.471591)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#555761;stop-opacity:1"
+         id="stop1043" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000006,0,0,2.0000008,-3.0000031,-84.000035)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000004,0,0,2.0000008,1.0000007,-84.000035)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1308"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999694,0,0,2.0000008,5.0000279,-84.000035)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9999997,0,0,2.0000008,8.9999955,-84.000035)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
   </defs>
-  <rect width="18.236429" height="2.6374204" x="2.8817775" y="21.362579" id="rect2723" style="opacity:0.40206185;fill:url(#linearGradient2883);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="m 21.109321,21.362672 c 0,0 0,2.637274 0,2.637274 1.142348,0.005 2.761647,-0.59088 2.761647,-1.318806 0,-0.727927 -1.274774,-1.318468 -2.761647,-1.318468 z" id="path2725" style="opacity:0.40206185;fill:url(#radialGradient2880);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="m 2.890679,21.362672 c 0,0 0,2.637274 0,2.637274 -1.142353,0.005 -2.761647,-0.59088 -2.761647,-1.318806 0,-0.727927 1.274779,-1.318468 2.761647,-1.318468 z" id="path2727" style="opacity:0.40206185;fill:url(#radialGradient2877);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 l 23,0 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.50000001 19.5,0.50000001 l -15,0 C 3.6666667,0.50000001 2.5992572,1.172599 2.5,2 z" id="rect2990" style="fill:url(#radialGradient4072);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 l 23,0 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.49999997 19.5,0.49999997 l -15,0 C 3.6666667,0.49999997 2.5992572,1.172599 2.5,2 z" id="rect2990-5" style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 0,-4.9e-5 z" id="rect2992" style="fill:url(#linearGradient2872);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 0,-4.9e-5 z" id="rect2992-0" style="opacity:0.5;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 1.8811692,21.468685 20.1351998,0.01866 c 0.0552,-0.198713 0.332357,-1.987316 0.332357,-1.987316 l -20.7291868,0 c 0,0 0.1806404,1.463168 0.26163,1.968656 z" id="path4497" style="opacity:0.2;color:#000000;fill:none;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="M 4.5,1.46875 C 4.3477124,1.46875 4.0083027,1.5891821 3.78125,1.75 3.5541973,1.9108179 3.4725109,2.0936491 3.46875,2.125 L 1.625,17.53125 l 20.75,0 L 20.53125,2.125 C 20.527489,2.0936468 20.445803,1.910818 20.21875,1.75 19.991697,1.589182 19.652287,1.46875 19.5,1.46875 l -15,0 z" id="path4034" style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <g transform="matrix(0.06610079,-0.01141585,0.00791914,0.04585394,-0.89214226,-6.4254019)" id="g9164">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9166" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9168" style="fill:url(#radialGradient8447);fill-opacity:1" />
+  <g
+     id="g1094"
+     style="display:none">
+    <rect
+       width="18.236429"
+       height="2.6374204"
+       x="2.8817775"
+       y="21.362579"
+       id="rect2723"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient2883);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="m 21.109321,21.362672 c 0,0 0,2.637274 0,2.637274 1.142348,0.005 2.761647,-0.59088 2.761647,-1.318806 0,-0.727927 -1.274774,-1.318468 -2.761647,-1.318468 z"
+       id="path2725"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient2880);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="m 2.890679,21.362672 c 0,0 0,2.637274 0,2.637274 -1.142353,0.005 -2.761647,-0.59088 -2.761647,-1.318806 0,-0.727927 1.274779,-1.318468 2.761647,-1.318468 z"
+       id="path2727"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient2877);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 h 23 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.50000001 19.5,0.50000001 H 4.5 C 3.6666667,0.50000001 2.5992572,1.172599 2.5,2 Z"
+       id="rect2990"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4072);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+    <path
+       d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 h 23 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.49999997 19.5,0.49999997 H 4.5 C 3.6666667,0.49999997 2.5992572,1.172599 2.5,2 Z"
+       id="rect2990-5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 z"
+       id="rect2992"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2872);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 z"
+       id="rect2992-0"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 1.8811692,21.468685 20.1351998,0.01866 c 0.0552,-0.198713 0.332357,-1.987316 0.332357,-1.987316 H 1.6195392 c 0,0 0.1806404,1.463168 0.26163,1.968656 z"
+       id="path4497"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="M 4.5,1.46875 C 4.3477124,1.46875 4.0083027,1.5891821 3.78125,1.75 3.5541973,1.9108179 3.4725109,2.0936491 3.46875,2.125 L 1.625,17.53125 h 20.75 L 20.53125,2.125 C 20.527489,2.0936468 20.445803,1.910818 20.21875,1.75 19.991697,1.589182 19.652287,1.46875 19.5,1.46875 Z"
+       id="path4034"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="matrix(0.06610079,-0.01141585,0.00791914,0.04585394,-0.89214226,-6.4254019)"
+       id="g9164">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9166"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9168"
+         style="fill:url(#radialGradient8447);fill-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.06707933,0,0,0.04653275,15.651438,-7.213077)"
+       id="g9170">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9172"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9174"
+         style="fill:url(#radialGradient8443);fill-opacity:1" />
+    </g>
+    <g
+       transform="matrix(-0.09781119,0,0,0.1076727,8.1622105,-3.8182515)"
+       id="g9158">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9160"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9162"
+         style="fill:url(#radialGradient8498);fill-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.09781119,0,0,0.1076727,15.777316,-3.8182515)"
+       id="g9190">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9192"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9194"
+         style="fill:url(#radialGradient8494);fill-opacity:1" />
+    </g>
+    <rect
+       style="opacity:1;vector-effect:none;fill:#0e141f;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
+       id="rect902"
+       width="11"
+       height="1"
+       x="2"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect904"
+       width="1"
+       height="1"
+       x="20"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect906"
+       width="1"
+       height="1"
+       x="3"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect908"
+       width="1"
+       height="1"
+       x="5"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect910"
+       width="1"
+       height="1"
+       x="7"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect912"
+       width="1"
+       height="1"
+       x="9"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect914"
+       width="1"
+       height="1"
+       x="11"
+       y="20" />
   </g>
-  <g transform="matrix(0.06707933,0,0,0.04653275,15.651438,-7.213077)" id="g9170">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9172" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9174" style="fill:url(#radialGradient8443);fill-opacity:1" />
-  </g>
-  <g transform="matrix(-0.09781119,0,0,0.1076727,8.1622105,-3.8182515)" id="g9158">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9160" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9162" style="fill:url(#radialGradient8498);fill-opacity:1" />
-  </g>
-  <g transform="matrix(0.09781119,0,0,0.1076727,15.777316,-3.8182515)" id="g9190">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9192" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9194" style="fill:url(#radialGradient8494);fill-opacity:1" />
-  </g>
-  <rect style="opacity:1;vector-effect:none;fill:#0e141f;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect902" width="11" height="1" x="2" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect904" width="1" height="1" x="20" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect906" width="1" height="1" x="3" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect908" width="1" height="1" x="5" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect910" width="1" height="1" x="7" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect912" width="1" height="1" x="9" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect914" width="1" height="1" x="11" y="20" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.204494;marker:none"
+     id="rect2723-5"
+     y="20.16511"
+     x="1.9098734"
+     height="2.7265873"
+     width="20.105473" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.204494;marker:none"
+     id="path2725-6"
+     d="m 22.005551,20.165204 c 0,0 0,2.726438 0,2.726438 1.259428,0.0052 3.044687,-0.610857 3.044687,-1.363393 0,-0.752537 -1.405424,-1.363045 -3.044687,-1.363045 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.408988;marker:none"
+     id="path2727-2"
+     d="m 1.9196875,20.165204 c 0,0 0,2.726438 0,2.726438 C 0.6602549,22.896842 -1.125,22.280785 -1.125,21.528249 c 0,-0.752537 1.40543025,-1.363045 3.0446875,-1.363045 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.4142;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-91"
+     d="M 23.5,20 20.75,1.5 C 20.585616,0.8707873 20.113484,0.5 19.5,0.5 H 4.5000674 c -0.6134819,0 -1.108654,0.3707873 -1.2500673,1 L 0.5,20"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 0.5,20 3.2499999,1.5 c 0.1591209,-0.6294285 0.6560875,-1 1.2499327,-1 H 19.5 c 0.593848,0 1.113113,0.3705688 1.25,1 L 23.5,20"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:#333333;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;enable-background:new"
+     id="rect6431-2"
+     d="M 22.104296,23.499992 H 1.8956689 c -0.7625898,0 -0.93961503,-0.311033 -1.14395027,-1.555119 L 0.56113679,20.700843 C 0.17984187,18.212673 1.7050204,18.523703 2.4676124,18.523703 H 21.532366 c 0.76259,0 2.28776,-0.31103 1.906472,2.17714 l -0.190634,1.24403 c -0.190658,1.244086 -0.381307,1.555119 -1.143908,1.555119 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1111);stroke-width:0.999991;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2-2"
+     d="M 21.225986,16.817769 H 2.7740124 c -0.6963005,0 -0.8579382,-0.206341 -1.0445118,-1.031707 L 1.5554862,14.960712 C 1.2073354,13.309986 2.599937,13.516327 3.2962382,13.516327 H 20.703759 c 0.6963,0 2.088907,-0.206341 1.740754,1.444385 l -0.174072,0.82535 c -0.174076,0.825366 -0.348153,1.031707 -1.044455,1.031707 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.74902;fill-rule:evenodd;stroke:#68b723;stroke-width:0.469863;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 22,20 v 2 h -2.0028 l 0.0036,-2 z"
+     id="path1472"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.99;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.901369;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="M 2.2025324,22.000001 H 17.797469 l 0.202532,-2 H 2.0000006 Z"
+     id="path1478" />
+  <path
+     style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.817979px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 3,20 v 2 h 2 v -2 z"
+     id="path928"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1259);fill-opacity:1;stroke:none;stroke-width:0.817979px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 7,20 v 2 h 2 v -2 z"
+     id="path928-3"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1308);fill-opacity:1;stroke:none;stroke-width:0.817979px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 11,20 v 2 h 2 v -2 z"
+     id="path928-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1394);fill-opacity:1;stroke:none;stroke-width:0.817979px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 15,20 v 2 h 2 v -2 z"
+     id="path928-9"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/devices/32/drive-harddisk-solidstate.svg
+++ b/devices/32/drive-harddisk-solidstate.svg
@@ -23,16 +23,16 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1600"
-     inkscape:window-height="839"
+     inkscape:window-width="1141"
+     inkscape:window-height="706"
      id="namedview95"
      showgrid="true"
-     inkscape:zoom="17.907789"
-     inkscape:cx="29.276569"
-     inkscape:cy="26.575979"
+     inkscape:zoom="8.3860962"
+     inkscape:cx="-19.689935"
+     inkscape:cy="15.975544"
      inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
+     inkscape:window-y="122"
+     inkscape:window-maximized="0"
      inkscape:current-layer="svg3786"
      inkscape:document-rotation="0">
     <inkscape:grid
@@ -453,7 +453,7 @@
        y1="28"
        x2="8"
        y2="31.555555"
-       gradientTransform="matrix(-0.5,0,0,0.5,32,1.7500002)" />
+       gradientTransform="matrix(-0.5000145,0,0,0.5,32.000014,1.7500002)" />
     <linearGradient
        id="linearGradient1151">
       <stop
@@ -563,7 +563,7 @@
        x2="7"
        y2="52"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,1,1,-23.999999)" />
+       gradientTransform="matrix(0.5,0,0,1,1,-24.249999)" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient1131">
@@ -606,7 +606,7 @@
        xlink:href="#linearGradient1018"
        id="linearGradient1047"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.47274311,0,0,0.5000872,0.81683965,-1.0120425)"
+       gradientTransform="matrix(0.46422283,0,0,0.49789433,1.1448712,-2.1308903)"
        x1="31.999645"
        y1="47.999744"
        x2="31.999645"
@@ -616,7 +616,7 @@
        xlink:href="#linearGradient1084"
        id="linearGradient1077"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.472551,0,0,0.49816154,0.87836803,-1.6451052)"
+       gradientTransform="matrix(0.46425814,0,0,0.49816154,1.1437392,-2.6451102)"
        x1="31.999998"
        y1="48.487175"
        x2="31.999645"
@@ -648,7 +648,7 @@
        xlink:href="#linearGradient1131"
        id="linearGradient1259"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,1,3,-23.999999)"
+       gradientTransform="matrix(0.5,0,0,1,3,-24.249999)"
        x1="7"
        y1="53"
        x2="7"
@@ -658,7 +658,7 @@
        xlink:href="#linearGradient1131"
        id="linearGradient1308"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,1,5,-23.999999)"
+       gradientTransform="matrix(0.5,0,0,1,5,-24.249999)"
        x1="7"
        y1="53"
        x2="7"
@@ -668,7 +668,7 @@
        xlink:href="#linearGradient1131"
        id="linearGradient1394"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,1,7,-23.999999)"
+       gradientTransform="matrix(0.5,0,0,1,7,-24.249999)"
        x1="7"
        y1="53"
        x2="7"
@@ -678,7 +678,7 @@
        xlink:href="#linearGradient1131"
        id="linearGradient1396"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,1,9,-23.999999)"
+       gradientTransform="matrix(0.5,0,0,1,9,-24.249999)"
        x1="7"
        y1="53"
        x2="7"
@@ -688,7 +688,7 @@
        xlink:href="#linearGradient1131"
        id="linearGradient1398"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,1,11,-23.999999)"
+       gradientTransform="matrix(0.5,0,0,1,11,-24.249999)"
        x1="7"
        y1="53"
        x2="7"
@@ -698,7 +698,7 @@
        xlink:href="#linearGradient1131"
        id="linearGradient1400"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,1,13,-23.999999)"
+       gradientTransform="matrix(0.5,0,0,1,13,-24.249999)"
        x1="7"
        y1="53"
        x2="7"
@@ -708,7 +708,7 @@
        xlink:href="#linearGradient1131"
        id="linearGradient1435"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,1,15,-23.999999)"
+       gradientTransform="matrix(0.5,0,0,1,15,-24.249999)"
        x1="7"
        y1="53"
        x2="7"
@@ -718,7 +718,7 @@
        xlink:href="#linearGradient1131"
        id="linearGradient1451"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,1,17,-23.999999)"
+       gradientTransform="matrix(0.5,0,0,1,17,-24.249999)"
        x1="7"
        y1="53"
        x2="7"
@@ -745,13 +745,13 @@
      inkscape:connector-curvature="0"
      style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
      id="path6345-91"
-     d="M 31.5,27 27,8.5 c -0.200962,-0.75 -1,-1 -1.75,-1 H 6.75 C 6,7.5 5.172882,7.75 5,8.5 L 0.5,27"
+     d="M 31.5,27 27.000384,8.5 c -0.200962,-0.75 -1,-1 -1.75,-1 H 6.7503841 c -0.75,0 -1.577118,0.25 -1.75,1 L 0.5,27"
      sodipodi:nodetypes="ccsscc" />
   <path
      inkscape:connector-curvature="0"
      style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
      id="path6345-6"
-     d="M 0.50089866,27 5,8.5 c 0.200962,-0.75 1,-1 1.75,-1 h 18.5 c 0.75,0 1.577118,0.25 1.75,1 L 31.5,27"
+     d="M 0.5,27 4.9996159,8.5 c 0.2009678,-0.75 1.000029,-1 1.7500507,-1 H 25.250203 c 0.750021,0 1.577163,0.25 1.75005,1 L 31.5,27"
      sodipodi:nodetypes="ccsscc" />
   <path
      inkscape:connector-curvature="0"
@@ -767,40 +767,40 @@
      sodipodi:nodetypes="ccccscccc" />
   <path
      inkscape:connector-curvature="0"
-     style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1047);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     style="display:inline;opacity:0.75;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1047);stroke-width:1.00001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
      id="rect6431-3-2"
-     d="M 28.472309,27.242887 H 3.4169267 c -0.9454862,0 -1.1649689,-0.250044 -1.418311,-1.250219 L 1.7623259,24.992494 C 1.2895827,22.992144 3.1805552,23.242189 4.1260415,23.242189 H 27.763195 c 0.945486,0 2.836458,-0.250045 2.363715,1.750305 l -0.236372,1.000174 c -0.236371,1.000175 -0.472742,1.250219 -1.418229,1.250219 z"
+     d="M 28.301905,26.000139 H 3.6980965 c -0.9284456,0 -1.1439724,-0.248947 -1.3927485,-1.244737 L 2.0733168,23.759614 C 1.609094,21.768036 3.4659852,22.016984 4.3944309,22.016984 H 27.60557 c 0.928445,0 2.785336,-0.248948 2.321113,1.74263 l -0.232112,0.995788 c -0.23211,0.99579 -0.464221,1.244737 -1.392666,1.244737 z"
      sodipodi:nodetypes="ccccscccc" />
   <path
      inkscape:connector-curvature="0"
      style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1077);stroke-width:0.997871;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
      id="rect6431-3-2-2"
-     d="M 28.522601,26.501026 H 3.4773986 c -0.9451018,0 -1.1644952,-0.249081 -1.4177347,-1.245404 L 1.8234704,24.259299 C 1.3509191,22.266652 3.2411231,22.515734 4.1862255,22.515734 H 27.813776 c 0.945101,0 2.835304,-0.249082 2.362754,1.743565 l -0.236276,0.996323 c -0.236275,0.996323 -0.47255,1.245404 -1.417653,1.245404 z"
+     d="M 28.302838,25.501026 H 3.697159 c -0.9285161,0 -1.1440591,-0.249081 -1.3928545,-1.245404 L 2.0722559,23.259299 C 1.6079974,21.266652 3.4650299,21.515734 4.3935465,21.515734 H 27.606452 c 0.928518,0 2.785549,-0.249082 2.321293,1.743565 l -0.232132,0.996323 c -0.232128,0.996323 -0.464255,1.245404 -1.392775,1.245404 z"
      sodipodi:nodetypes="ccccscccc" />
   <g
      id="path915"
      style="opacity:1;fill:#9bdb4d;fill-opacity:0.75;stroke:none;stroke-width:0.700198;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.504001"
      transform="matrix(0.99943532,0,0,1,0.01616396,0)" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.74901962;fill-rule:evenodd;stroke:#68b723;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
-     d="M 29.250847,27.75 28.950746,29 H 27.75 l 0.300101,-1.25 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.74902;fill-rule:evenodd;stroke:#68b723;stroke-width:0.499999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 29.250009,27.749999 28.900086,29.25 h -1.400093 l 0.349924,-1.500001 z"
      id="path1472"
      sodipodi:nodetypes="ccccc" />
   <g
      id="rect917"
-     style="opacity:1">
+     style="opacity:1;stroke-width:0.999997">
     <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.500002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
        d="M 2.75,29.25 H 22 l 0.25,-1.5 H 2.5 Z"
        id="path1478" />
     <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#474747;fill-opacity:0.598837;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#474747;fill-opacity:0.598837;fill-rule:nonzero;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
        d="m 2.5,27.5 a 0.250025,0.250025 0 0 0 -0.2460938,0.291016 l 0.25,1.5 A 0.250025,0.250025 0 0 0 2.75,29.5 H 22 a 0.250025,0.250025 0 0 0 0.246094,-0.208984 l 0.25,-1.5 A 0.250025,0.250025 0 0 0 22.25,27.5 Z M 2.7949219,28 H 21.955078 l -0.166016,1 H 2.9609375 Z"
        id="path1480" />
   </g>
   <path
      style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 4,28 v 1 h 1 v -1 z"
+     d="m 4,27.75 v 1 h 1 v -1 z"
      id="path928"
      inkscape:connector-curvature="0" />
   <g
@@ -974,42 +974,42 @@
   </g>
   <path
      style="display:inline;fill:url(#linearGradient1259);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 6,28 v 1 h 1 v -1 z"
+     d="m 6,27.75 v 1 h 1 v -1 z"
      id="path928-3"
      inkscape:connector-curvature="0" />
   <path
      style="display:inline;fill:url(#linearGradient1308);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 8,28 v 1 h 1 v -1 z"
+     d="m 8,27.75 v 1 h 1 v -1 z"
      id="path928-2"
      inkscape:connector-curvature="0" />
   <path
      style="display:inline;fill:url(#linearGradient1394);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 10,28 v 1 h 1 v -1 z"
+     d="m 10,27.75 v 1 h 1 v -1 z"
      id="path928-9"
      inkscape:connector-curvature="0" />
   <path
      style="display:inline;fill:url(#linearGradient1396);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 12,28 v 1 h 1 v -1 z"
+     d="m 12,27.75 v 1 h 1 v -1 z"
      id="path928-3-2"
      inkscape:connector-curvature="0" />
   <path
      style="display:inline;fill:url(#linearGradient1398);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 14,28 v 1 h 1 v -1 z"
+     d="m 14,27.75 v 1 h 1 v -1 z"
      id="path928-2-0"
      inkscape:connector-curvature="0" />
   <path
      style="display:inline;fill:url(#linearGradient1400);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 16,28 v 1 h 1 v -1 z"
+     d="m 16,27.75 v 1 h 1 v -1 z"
      id="path928-3-6-2"
      inkscape:connector-curvature="0" />
   <path
      style="display:inline;fill:url(#linearGradient1435);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 18,28 v 1 h 1 v -1 z"
+     d="m 18,27.75 v 1 h 1 v -1 z"
      id="path928-3-6-2-9"
      inkscape:connector-curvature="0" />
   <path
      style="display:inline;fill:url(#linearGradient1451);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 20,28 v 1 h 1 v -1 z"
+     d="m 20,27.75 v 1 h 1 v -1 z"
      id="path928-3-6-2-97"
      inkscape:connector-curvature="0" />
 </svg>

--- a/devices/32/drive-harddisk-solidstate.svg
+++ b/devices/32/drive-harddisk-solidstate.svg
@@ -1,127 +1,1015 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="32" height="32" id="svg3786" sodipodi:docname="drive-harddisk-solidstate-32.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview95" showgrid="true" inkscape:zoom="41.7193" inkscape:cx="14.678206" inkscape:cy="2.5671693" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3786">
-    <inkscape:grid type="xygrid" id="grid902" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="32"
+   height="32"
+   id="svg3786"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1600"
+     inkscape:window-height="839"
+     id="namedview95"
+     showgrid="true"
+     inkscape:zoom="17.907789"
+     inkscape:cx="29.276569"
+     inkscape:cy="26.575979"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3786"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid902" />
   </sodipodi:namedview>
-  <metadata id="metadata90">
+  <metadata
+     id="metadata90">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3788">
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+  <defs
+     id="defs3788">
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2465" xlink:href="#linearGradient2215-9" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.6886478,0,0,0.5067185,-3.9708843,4.4552574)" />
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2471" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.07635654,0,0,0.02184879,1.4025717,30.138555)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2473" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.04484747,0,0,0.02184879,20.38888,30.138555)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2475" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.04484747,0,0,0.02184879,37.61113,30.138555)" />
-    <linearGradient id="linearGradient2215-9">
-      <stop id="stop2223-6" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219-1" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="29.9375"
+       y1="41"
+       x2="30"
+       y2="49.999996"
+       id="linearGradient2465"
+       xlink:href="#linearGradient2215-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6886478,0,0,0.5067185,-3.9708843,4.4552574)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2471"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07635654,0,0,0.02184879,1.4025717,30.138555)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2473"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04484747,0,0,0.02184879,20.38888,30.138555)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2475"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04484747,0,0,0.02184879,37.61113,30.138555)" />
+    <linearGradient
+       id="linearGradient2215-9">
+      <stop
+         id="stop2223-6"
+         style="stop-color:#7a7a7a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219-1"
+         style="stop-color:#474747;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient7056-0">
-      <stop id="stop7064-4" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060-2" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient7056-0">
+      <stop
+         id="stop7064-4"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060-2"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="10" cy="7.2368369" r="16" fx="10" fy="7.2368369" id="radialGradient5024" xlink:href="#linearGradient7056-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.4045128,0,0,0.9375,-4.0451283,4.2154656)" />
-    <linearGradient id="linearGradient4472">
-      <stop id="stop4474" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4476" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.02116842" />
-      <stop id="stop4478" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4480" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    <radialGradient
+       cx="10"
+       cy="7.2368369"
+       r="16"
+       fx="10"
+       fy="7.2368369"
+       id="radialGradient5024"
+       xlink:href="#linearGradient7056-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4045128,0,0,0.9375,-4.0451283,4.2154656)" />
+    <linearGradient
+       id="linearGradient4472">
+      <stop
+         id="stop4474"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4476"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02116842" />
+      <stop
+         id="stop4478"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4480"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="23.99999" y1="51.346149" x2="23.99999" y2="53.354122" id="linearGradient3171" xlink:href="#linearGradient4472" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.58810697,0,0,0.51394954,8.8319415,0.58279532)" />
-    <linearGradient x1="23.99999" y1="6.5391083" x2="23.99999" y2="42.102226" id="linearGradient3168-6" xlink:href="#linearGradient4075-8" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.26232885,0,0,0.42474288,5.0669059,6.097143)" />
-    <linearGradient id="linearGradient4075-8">
-      <stop id="stop4077-4" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4079-5" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.03367912" />
-      <stop id="stop4081-2" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4083-4" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    <linearGradient
+       x1="23.99999"
+       y1="51.346149"
+       x2="23.99999"
+       y2="53.354122"
+       id="linearGradient3171"
+       xlink:href="#linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.58810697,0,0,0.51394954,8.8319415,0.58279532)" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.5391083"
+       x2="23.99999"
+       y2="42.102226"
+       id="linearGradient3168-6"
+       xlink:href="#linearGradient4075-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26232885,0,0,0.42474288,5.0669059,6.097143)" />
+    <linearGradient
+       id="linearGradient4075-8">
+      <stop
+         id="stop4077-4"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4079-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03367912" />
+      <stop
+         id="stop4081-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4083-4"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3789" xlink:href="#radialGradient3437" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3437" gradientUnits="userSpaceOnUse">
-      <stop id="stop3439" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop3441" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop3443" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop3445" style="stop-color:#555555;stop-opacity:1" offset="1" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient3789"
+       xlink:href="#radialGradient3437"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient3437"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3439"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3441"
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="0.16" />
+      <stop
+         id="stop3443"
+         style="stop-color:#888888;stop-opacity:1"
+         offset="0.4675" />
+      <stop
+         id="stop3445"
+         style="stop-color:#555555;stop-opacity:1"
+         offset="1" />
     </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3793" xlink:href="#radialGradient3437" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient3831" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.24573995,-0.00308859,0.00181873,0.17771138,-19.666102,-13.139935)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient3793"
+       xlink:href="#radialGradient3437"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="141.74666"
+       cy="206.42612"
+       r="78.728165"
+       fx="141.74666"
+       fy="206.42612"
+       id="radialGradient3831"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24573995,-0.00308859,0.00181873,0.17771138,-19.666102,-13.139935)" />
+    <linearGradient
+       id="linearGradient4035">
+      <stop
+         id="stop4037"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4039"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop4041"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.69348532" />
+      <stop
+         id="stop4043"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop4045"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient3820" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.12330157,0,0,-0.08625852,-2.074113,31.247748)" />
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient3827" xlink:href="#linearGradient5026" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.12092245,-0.01546848,0.00546562,0.04607914,-4.4169742,6.9719925)" />
-    <linearGradient id="linearGradient5026">
-      <stop id="stop5028" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop5030" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.27751356" />
-      <stop id="stop5032" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.52359134" />
-      <stop id="stop5034" style="stop-color:#dddddd;stop-opacity:1" offset="1" />
-      <stop id="stop5036" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <radialGradient
+       cx="142.62215"
+       cy="191.85428"
+       r="78.728165"
+       fx="142.62215"
+       fy="191.85428"
+       id="radialGradient3820"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12330157,0,0,-0.08625852,-2.074113,31.247748)" />
+    <radialGradient
+       cx="127.31733"
+       cy="143.82751"
+       r="78.728165"
+       fx="127.31733"
+       fy="143.82751"
+       id="radialGradient3827"
+       xlink:href="#linearGradient5026"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12092245,-0.01546848,0.00546562,0.04607914,-4.4169742,6.9719925)" />
+    <linearGradient
+       id="linearGradient5026">
+      <stop
+         id="stop5028"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5030"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.27751356" />
+      <stop
+         id="stop5032"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.52359134" />
+      <stop
+         id="stop5034"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="1" />
+      <stop
+         id="stop5036"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3797" xlink:href="#radialGradient3437" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3801" xlink:href="#radialGradient3437" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient4238" xlink:href="#linearGradient6309" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.79304646,0,0,0.53932582,-0.57833673,8.4719087)" />
-    <linearGradient id="linearGradient6309">
-      <stop id="stop6311" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop6313" style="stop-color:#bbbbbb;stop-opacity:0" offset="1" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient3797"
+       xlink:href="#radialGradient3437"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient3801"
+       xlink:href="#radialGradient3437"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <linearGradient
+       x1="7.0625"
+       y1="35.28125"
+       x2="24.6875"
+       y2="35.28125"
+       id="linearGradient4238"
+       xlink:href="#linearGradient6309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.79304646,0,0,0.53932582,-0.57833673,8.4719087)" />
+    <linearGradient
+       id="linearGradient6309">
+      <stop
+         id="stop6311"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6313"
+         style="stop-color:#bbbbbb;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient4235" xlink:href="#linearGradient4236-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.79304646,0,0,0.53932582,-1.209199,9.1869582)" />
-    <linearGradient id="linearGradient4236-0">
-      <stop id="stop4238-4" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240-3" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient4235"
+       xlink:href="#linearGradient4236-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.79304646,0,0,0.53932582,-1.209199,9.1869582)" />
+    <linearGradient
+       id="linearGradient4236-0">
+      <stop
+         id="stop4238-4"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240-3"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
     </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05090435,0,0,0.0137255,-2.4536674,23.620022)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02989831,0,0,0.0137255,10.203871,23.620022)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02989831,0,0,0.0137255,21.685371,23.620022)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,0.5,-0.055382,1.9857745)" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.41666666" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.44444445" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="8"
+       y2="31.555555"
+       gradientTransform="matrix(-0.5,0,0,0.5,32,1.7500002)" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.9375" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="29.736721"
+       y1="43.024384"
+       x2="29.736721"
+       y2="49.956097"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69617843,0,0,0.55756763,-4.1894392,2.8900042)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient959"
+       id="linearGradient961"
+       x1="32"
+       y1="57"
+       x2="32"
+       y2="48"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.51289186,0,0,0.55212851,-0.41280714,-0.72741775)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient959">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop955" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.502"
+         offset="1"
+         id="stop957" />
+    </linearGradient>
+    <radialGradient
+       cx="24"
+       cy="42"
+       r="21"
+       fx="24"
+       fy="42"
+       id="radialGradient2516"
+       xlink:href="#linearGradient6310-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6904762,0,1.9203954e-8,0.243432,-0.62680935,18.057604)" />
+    <linearGradient
+       id="linearGradient6310-8">
+      <stop
+         id="stop6312-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6314-6"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5"
+       gradientTransform="matrix(0.56619225,-9.04622e-8,-1.3505646e-8,-0.1081081,-2.7539267,35.603703)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#555761;stop-opacity:1"
+         id="stop1043" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,1,1,-23.999999)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999996"
+       y2="48.973789"
+       gradientTransform="matrix(0.4891223,0,0,0.49807644,0.34807334,1.3592257)" />
+    <linearGradient
+       id="linearGradient1018">
+      <stop
+         id="stop1013"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1015"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1047"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.47274311,0,0,0.5000872,0.81683965,-1.0120425)"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1084"
+       id="linearGradient1077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.472551,0,0,0.49816154,0.87836803,-1.6451052)"
+       x1="31.999998"
+       y1="48.487175"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       id="linearGradient1084">
+      <stop
+         id="stop1149"
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1082"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1240">
+      <stop
+         id="stop1236"
+         style="stop-color:#fafafa;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop1238"
+         style="stop-color:#1a1a1a;stop-opacity:0.502"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,1,3,-23.999999)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1308"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,1,5,-23.999999)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,1,7,-23.999999)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1396"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,1,9,-23.999999)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1398"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,1,11,-23.999999)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1400"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,1,13,-23.999999)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,1,15,-23.999999)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1451"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,1,17,-23.999999)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
   </defs>
-  <path d="M 31.502339,25.502101 26.821023,8.3812814 C 26.688651,7.8937324 25.995252,7.4978971 25.412312,7.4978971 l -18.9855897,0 c -0.8955749,0 -1.4087718,0.1319037 -1.597617,0.8833843 L 0.49812296,25.485432" id="path6345" style="fill:url(#radialGradient5024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99578333;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="M 31.502339,25.502101 26.821023,8.381281 C 26.688651,7.893732 25.995252,7.4978967 25.412312,7.4978967 l -18.9855897,0 c -0.8955749,0 -1.4087718,0.1319037 -1.597617,0.8833843 L 0.49812296,25.485432 z" id="path6345-9" style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <g transform="matrix(0.6666596,0,0,0.6259973,-3.3331284,3.7969778)" id="g6029" style="display:inline;enable-background:new">
-    <rect width="36.869301" height="5.3061337" x="10.565332" y="38.149361" id="rect2723" style="opacity:0.40206185;fill:url(#linearGradient2471);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path d="m 47.41667,38.149545 c 0,0 0,5.30584 0,5.30584 2.30953,0.01 5.58333,-1.18877 5.58333,-2.65326 0,-1.46449 -2.57726,-2.65258 -5.58333,-2.65258 z" id="path2725" style="opacity:0.40206185;fill:url(#radialGradient2473);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path d="m 10.58333,38.149545 c 0,0 0,5.30584 0,5.30584 C 8.2737899,43.465375 5,42.266615 5,40.802125 c 0,-1.46449 2.5772699,-2.65258 5.58333,-2.65258 z" id="path2727" style="opacity:0.40206185;fill:url(#radialGradient2475);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.25;marker:none"
+     id="rect2723-5"
+     y="28.652441"
+     x="3.6548395"
+     height="3.3333333"
+     width="24.579533" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.25;marker:none"
+     id="path2725-6"
+     d="m 28.222397,28.652556 c 0,0 0,3.333149 0,3.333149 1.539687,0.0063 3.72222,-0.74679 3.72222,-1.666788 0,-0.919998 -1.718173,-1.666361 -3.72222,-1.666361 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="path2727-2"
+     d="m 3.666838,28.652556 c 0,0 0,3.333149 0,3.333149 -1.5396934,0.0063 -3.72222,-0.74679 -3.72222,-1.666788 0,-0.919998 1.7181799,-1.666361 3.72222,-1.666361 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-91"
+     d="M 31.5,27 27,8.5 c -0.200962,-0.75 -1,-1 -1.75,-1 H 6.75 C 6,7.5 5.172882,7.75 5,8.5 L 0.5,27"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 0.50089866,27 5,8.5 c 0.200962,-0.75 1,-1 1.75,-1 h 18.5 c 0.75,0 1.577118,0.25 1.75,1 L 31.5,27"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:1.06432;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-2"
+     d="M 29.591363,30.467838 H 2.4080978 c -1.0257838,0 -1.2639063,-0.276063 -1.53876419,-1.38032 L 0.61297654,27.983263 C 0.10008469,25.774749 2.1516519,26.050814 3.1774357,26.050814 H 28.822024 c 1.025786,0 3.077353,-0.276065 2.564461,1.932449 l -0.256447,1.104255 c -0.256445,1.104257 -0.512889,1.38032 -1.538675,1.38032 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:0.998903;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="M 28.961724,29.500547 H 3.0382457 c -0.9782444,0 -1.2053315,-0.249038 -1.4674512,-1.245191 L 1.326318,27.259204 C 0.83719551,25.266896 2.7936846,25.515935 3.7719292,25.515935 H 28.22804 c 0.978245,0 2.934734,-0.249039 2.445612,1.743269 l -0.244562,0.996152 c -0.24456,0.996153 -0.489122,1.245191 -1.467366,1.245191 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1047);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2"
+     d="M 28.472309,27.242887 H 3.4169267 c -0.9454862,0 -1.1649689,-0.250044 -1.418311,-1.250219 L 1.7623259,24.992494 C 1.2895827,22.992144 3.1805552,23.242189 4.1260415,23.242189 H 27.763195 c 0.945486,0 2.836458,-0.250045 2.363715,1.750305 l -0.236372,1.000174 c -0.236371,1.000175 -0.472742,1.250219 -1.418229,1.250219 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1077);stroke-width:0.997871;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2-2"
+     d="M 28.522601,26.501026 H 3.4773986 c -0.9451018,0 -1.1644952,-0.249081 -1.4177347,-1.245404 L 1.8234704,24.259299 C 1.3509191,22.266652 3.2411231,22.515734 4.1862255,22.515734 H 27.813776 c 0.945101,0 2.835304,-0.249082 2.362754,1.743565 l -0.236276,0.996323 c -0.236275,0.996323 -0.47255,1.245404 -1.417653,1.245404 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <g
+     id="path915"
+     style="opacity:1;fill:#9bdb4d;fill-opacity:0.75;stroke:none;stroke-width:0.700198;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.504001"
+     transform="matrix(0.99943532,0,0,1,0.01616396,0)" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.74901962;fill-rule:evenodd;stroke:#68b723;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 29.250847,27.75 28.950746,29 H 27.75 l 0.300101,-1.25 z"
+     id="path1472"
+     sodipodi:nodetypes="ccccc" />
+  <g
+     id="rect917"
+     style="opacity:1">
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       d="M 2.75,29.25 H 22 l 0.25,-1.5 H 2.5 Z"
+       id="path1478" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#474747;fill-opacity:0.598837;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       d="m 2.5,27.5 a 0.250025,0.250025 0 0 0 -0.2460938,0.291016 l 0.25,1.5 A 0.250025,0.250025 0 0 0 2.75,29.5 H 22 a 0.250025,0.250025 0 0 0 0.246094,-0.208984 l 0.25,-1.5 A 0.250025,0.250025 0 0 0 22.25,27.5 Z M 2.7949219,28 H 21.955078 l -0.166016,1 H 2.9609375 Z"
+       id="path1480" />
   </g>
-  <rect width="31" height="1" x="0.5" y="25" id="rect6381" style="fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
-  <path d="m 0.50764664,25.485779 30.98450536,0 -0.619526,4.050331 -29.6765863,0 -0.68839306,-4.050331 z" id="rect6431" style="fill:url(#linearGradient2465);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
-  <path d="m 0.50764664,25.5 30.98450536,0 -0.619526,4 -29.6765863,0 -0.68839306,-4 z" id="rect6431-1" style="opacity:0.5;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 6.4375,8.5 c -0.4014515,0 -0.6181328,0.05924 -0.625,0.0625 -0.00687,0.00326 0.045405,-0.1181812 0,0.0625 L 1.78125,24.5 30.1875,24.5 25.84375,8.65625 a 1.0079748,1.0079748 0 0 1 0,-0.03125 c 0.03231,0.119003 0.01552,0.065777 -0.09375,0 C 25.640731,8.559223 25.474426,8.5 25.40625,8.5 L 6.4375,8.5 z" id="path4094" style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient3168-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 2.0163276,28.5 27.9776234,2e-6 c 0.07589,-0.199983 0.332492,-2 0.332492,-2 l -28.6075888,0 c 0,0 0.1861288,1.491284 0.2974734,1.999998 z" id="path4497" style="opacity:0.2;color:#000000;fill:none;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <g transform="matrix(0.06707933,0,0,0.04653275,2.4611632,-0.2130773)" id="g9164" style="display:inline;enable-background:new">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9166" style="fill:#f0f0f0;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9168" style="fill:url(#radialGradient3789);fill-opacity:1" />
+  <path
+     style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 4,28 v 1 h 1 v -1 z"
+     id="path928"
+     inkscape:connector-curvature="0" />
+  <g
+     id="g956"
+     style="display:none">
+    <path
+       d="M 31.502339,25.502101 26.821023,8.3812814 C 26.688651,7.8937324 25.995252,7.4978971 25.412312,7.4978971 H 6.4267223 c -0.8955749,0 -1.4087718,0.1319037 -1.597617,0.8833843 L 0.49812296,25.485432"
+       id="path6345"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient5024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.995783;marker:none;enable-background:accumulate" />
+    <path
+       d="M 31.502339,25.502101 26.821023,8.381281 C 26.688651,7.893732 25.995252,7.4978967 25.412312,7.4978967 H 6.4267223 c -0.8955749,0 -1.4087718,0.1319037 -1.597617,0.8833843 L 0.49812296,25.485432 Z"
+       id="path6345-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="matrix(0.6666596,0,0,0.6259973,-3.3331284,3.7969778)"
+       id="g6029"
+       style="display:inline;enable-background:new">
+      <rect
+         width="36.869301"
+         height="5.3061337"
+         x="10.565332"
+         y="38.149361"
+         id="rect2723"
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient2471);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <path
+         d="m 47.41667,38.149545 c 0,0 0,5.30584 0,5.30584 2.30953,0.01 5.58333,-1.18877 5.58333,-2.65326 0,-1.46449 -2.57726,-2.65258 -5.58333,-2.65258 z"
+         id="path2725"
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient2473);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <path
+         d="m 10.58333,38.149545 c 0,0 0,5.30584 0,5.30584 C 8.2737899,43.465375 5,42.266615 5,40.802125 c 0,-1.46449 2.5772699,-2.65258 5.58333,-2.65258 z"
+         id="path2727"
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient2475);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    </g>
+    <rect
+       width="31"
+       height="1"
+       x="0.5"
+       y="25"
+       id="rect6381"
+       style="display:inline;fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new" />
+    <path
+       d="M 0.50764664,25.485779 H 31.492152 L 30.872626,29.53611 H 1.1960397 Z"
+       id="rect6431"
+       style="display:inline;fill:url(#linearGradient2465);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new" />
+    <path
+       d="M 0.50764664,25.5 H 31.492152 l -0.619526,4 H 1.1960397 Z"
+       id="rect6431-1"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 6.4375,8.5 c -0.4014515,0 -0.6181328,0.05924 -0.625,0.0625 -0.00687,0.00326 0.045405,-0.1181812 0,0.0625 L 1.78125,24.5 H 30.1875 L 25.84375,8.65625 a 1.0079748,1.0079748 0 0 1 0,-0.03125 c 0.03231,0.119003 0.01552,0.065777 -0.09375,0 C 25.640731,8.559223 25.474426,8.5 25.40625,8.5 Z"
+       id="path4094"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3168-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 2.0163276,28.5 27.9776234,2e-6 c 0.07589,-0.199983 0.332492,-2 0.332492,-2 H 1.7188542 c 0,0 0.1861288,1.491284 0.2974734,1.999998 z"
+       id="path4497"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="matrix(0.06707933,0,0,0.04653275,2.4611632,-0.2130773)"
+       id="g9164"
+       style="display:inline;enable-background:new">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9166"
+         style="fill:#f0f0f0;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9168"
+         style="fill:url(#radialGradient3789);fill-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.06707933,0,0,0.04653275,21.361163,-0.2130773)"
+       id="g9170"
+       style="display:inline;enable-background:new">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9172"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9174"
+         style="fill:url(#radialGradient3793);fill-opacity:1" />
+    </g>
+    <g
+       transform="matrix(-0.09781119,0,0,0.1076727,9.1622105,3.1817482)"
+       id="g9158"
+       style="display:inline;enable-background:new">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9160"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9162"
+         style="fill:url(#radialGradient3797);fill-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.09781119,0,0,0.1076727,22.777316,3.1817482)"
+       id="g9190"
+       style="display:inline;enable-background:new">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9192"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9194"
+         style="fill:url(#radialGradient3801);fill-opacity:1" />
+    </g>
+    <rect
+       style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:1;fill-rule:nonzero;stroke:#9bdb4d;stroke-opacity:0.6;paint-order:normal"
+       id="rect904"
+       width="1"
+       height="1"
+       x="28"
+       y="27" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#95a3ab;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
+       d="M 2.7,27 H 17.1 L 17,28 H 2.8 Z"
+       id="rect904-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect922"
+       width="1"
+       height="1"
+       x="3"
+       y="27" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect924"
+       width="1"
+       height="1"
+       x="5"
+       y="27" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect926"
+       width="1"
+       height="1"
+       x="7"
+       y="27" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect928"
+       width="1"
+       height="1"
+       x="9"
+       y="27" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect930"
+       width="1"
+       height="1"
+       x="11"
+       y="27" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect932"
+       width="1"
+       height="1"
+       x="13"
+       y="27" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect932-6"
+       width="1"
+       height="1"
+       x="15"
+       y="27" />
   </g>
-  <g transform="matrix(0.06707933,0,0,0.04653275,21.361163,-0.2130773)" id="g9170" style="display:inline;enable-background:new">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9172" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9174" style="fill:url(#radialGradient3793);fill-opacity:1" />
-  </g>
-  <g transform="matrix(-0.09781119,0,0,0.1076727,9.1622105,3.1817482)" id="g9158" style="display:inline;enable-background:new">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9160" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9162" style="fill:url(#radialGradient3797);fill-opacity:1" />
-  </g>
-  <g transform="matrix(0.09781119,0,0,0.1076727,22.777316,3.1817482)" id="g9190" style="display:inline;enable-background:new">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9192" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9194" style="fill:url(#radialGradient3801);fill-opacity:1" />
-  </g>
-  <rect style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:1;fill-rule:nonzero;stroke:#9bdb4d;stroke-opacity:0.60000002;paint-order:normal" id="rect904" width="1" height="1" x="28" y="27" />
-  <path style="opacity:1;vector-effect:none;fill:#95a3ab;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:0.6;paint-order:normal" d="M 2.7,27 H 17.1 L 17,28 H 2.8 Z" id="rect904-3" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect922" width="1" height="1" x="3" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect924" width="1" height="1" x="5" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect926" width="1" height="1" x="7" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect928" width="1" height="1" x="9" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect930" width="1" height="1" x="11" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect932" width="1" height="1" x="13" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect932-6" width="1" height="1" x="15" y="27" />
+  <path
+     style="display:inline;fill:url(#linearGradient1259);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 6,28 v 1 h 1 v -1 z"
+     id="path928-3"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1308);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 8,28 v 1 h 1 v -1 z"
+     id="path928-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1394);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 10,28 v 1 h 1 v -1 z"
+     id="path928-9"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1396);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 12,28 v 1 h 1 v -1 z"
+     id="path928-3-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1398);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 14,28 v 1 h 1 v -1 z"
+     id="path928-2-0"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1400);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 16,28 v 1 h 1 v -1 z"
+     id="path928-3-6-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1435);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 18,28 v 1 h 1 v -1 z"
+     id="path928-3-6-2-9"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1451);fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 20,28 v 1 h 1 v -1 z"
+     id="path928-3-6-2-97"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/devices/48/drive-harddisk-solidstate.svg
+++ b/devices/48/drive-harddisk-solidstate.svg
@@ -1,173 +1,1030 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="48" height="48" id="svg3786" sodipodi:docname="drive-harddisk-solidstate-48.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview87" showgrid="true" inkscape:zoom="1" inkscape:cx="17.862146" inkscape:cy="6.4289738" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3786">
-    <inkscape:grid type="xygrid" id="grid1385" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="48"
+   height="48"
+   id="svg3786"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1312"
+     inkscape:window-height="773"
+     id="namedview87"
+     showgrid="true"
+     inkscape:zoom="8.1819432"
+     inkscape:cx="6.4940295"
+     inkscape:cy="26.539916"
+     inkscape:window-x="10"
+     inkscape:window-y="53"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3786"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1385" />
   </sodipodi:namedview>
-  <metadata id="metadata82">
+  <metadata
+     id="metadata82">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3788">
-    <linearGradient id="linearGradient4231">
-      <stop id="stop4233" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4235" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.00818416" />
-      <stop id="stop4237" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4239" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+  <defs
+     id="defs3788">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1260">
+      <stop
+         style="stop-color:#333333;stop-opacity:0"
+         offset="0"
+         id="stop1256" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.75"
+         offset="1"
+         id="stop1258" />
     </linearGradient>
-    <linearGradient id="linearGradient4170">
-      <stop id="stop4172" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4174" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.02783963" />
-      <stop id="stop4176" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99811679" />
-      <stop id="stop4178" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    <linearGradient
+       id="linearGradient1244">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.00364053"
+         id="stop1240" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop1242" />
     </linearGradient>
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient4231">
+      <stop
+         id="stop4233"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4235"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00818416" />
+      <stop
+         id="stop4237"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4239"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient4170">
+      <stop
+         id="stop4172"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4174"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02783963" />
+      <stop
+         id="stop4176"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99811679" />
+      <stop
+         id="stop4178"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient2215">
-      <stop id="stop2223" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient7056">
-      <stop id="stop7064" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="11.734284" cy="8.4900017" r="23.047892" fx="11.734284" fy="8.4900017" id="radialGradient2927" xlink:href="#linearGradient7056" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3767077,0.69719425,-0.46810846,0.92434578,-0.04915651,-2.9386274)" />
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2933" xlink:href="#linearGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0017502,0,0,0.7596403,-5.0508975,4.9363745)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2936" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.04484747,0,0,0.02058824,32.61113,32.451372)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2939" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.04484747,0,0,0.02058824,15.38888,32.451372)" />
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2942" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.07635654,0,0,0.02058824,-3.5974283,32.451372)" />
-    <linearGradient x1="34.947395" y1="50.909214" x2="34.947395" y2="53.83601" id="linearGradient3308" xlink:href="#linearGradient4231" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.84051728,0,0,1.0278991,14.415778,-14.334416)" />
-    <linearGradient x1="23.99999" y1="6.2531767" x2="23.99999" y2="42.941334" id="linearGradient3311-4" xlink:href="#linearGradient4170" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.26232885,0,0,0.65751536,6.9297476,6.8105801)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient2923" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.35160878,-0.0050244,0.00260227,0.28909275,-27.02434,-25.217538)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#7a7a7a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#474747;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient2920" xlink:href="#linearGradient7609" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.18495239,0,0,-0.13074306,-3.1111723,45.048436)" />
-    <linearGradient id="linearGradient7609">
-      <stop id="stop7611" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop7677" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop7613" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop7617" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop7615" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         id="stop7064"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2965" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.32948872,0,0,0.34974643,41.963041,0.4938254)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient4241" gradientUnits="userSpaceOnUse">
-      <stop id="stop4243" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4245" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop4247" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop4249" style="stop-color:#555555;stop-opacity:1" offset="1" />
+    <radialGradient
+       cx="11.734284"
+       cy="8.4900017"
+       r="23.047892"
+       fx="11.734284"
+       fy="8.4900017"
+       id="radialGradient2927"
+       xlink:href="#linearGradient7056"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3767077,0.69719425,-0.46810846,0.92434578,-0.04915651,-2.9386274)" />
+    <linearGradient
+       x1="29.9375"
+       y1="41"
+       x2="30"
+       y2="49.999996"
+       id="linearGradient2933"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0017502,0,0,0.7596403,-5.0508975,4.9363745)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2936"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04484747,0,0,0.02058824,32.61113,32.451372)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2939"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04484747,0,0,0.02058824,15.38888,32.451372)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2942"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07635654,0,0,0.02058824,-3.5974283,32.451372)" />
+    <linearGradient
+       x1="34.947395"
+       y1="50.909214"
+       x2="34.947395"
+       y2="53.83601"
+       id="linearGradient3308"
+       xlink:href="#linearGradient4231"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.84051728,0,0,1.0278991,14.415778,-14.334416)" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.2531767"
+       x2="23.99999"
+       y2="42.941334"
+       id="linearGradient3311-4"
+       xlink:href="#linearGradient4170"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26232885,0,0,0.65751536,6.9297476,6.8105801)" />
+    <radialGradient
+       cx="141.74666"
+       cy="206.42612"
+       r="78.728165"
+       fx="141.74666"
+       fy="206.42612"
+       id="radialGradient2923"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35160878,-0.0050244,0.00260227,0.28909275,-27.02434,-25.217538)" />
+    <linearGradient
+       id="linearGradient4035">
+      <stop
+         id="stop4037"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4039"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop4041"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.69348532" />
+      <stop
+         id="stop4043"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop4045"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="142.62215"
+       cy="191.85428"
+       r="78.728165"
+       fx="142.62215"
+       fy="191.85428"
+       id="radialGradient2920"
+       xlink:href="#linearGradient7609"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18495239,0,0,-0.13074306,-3.1111723,45.048436)" />
+    <linearGradient
+       id="linearGradient7609">
+      <stop
+         id="stop7611"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7677"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop7613"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.67183787" />
+      <stop
+         id="stop7617"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop7615"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2965"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.32948872,0,0,0.34974643,41.963041,0.4938254)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient4241"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop4243"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4245"
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="0.16" />
+      <stop
+         id="stop4247"
+         style="stop-color:#888888;stop-opacity:1"
+         offset="0.4675" />
+      <stop
+         id="stop4249"
+         style="stop-color:#555555;stop-opacity:1"
+         offset="1" />
     </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2959" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.22282769,-0.03752228,0.02509892,0.149051,-18.145918,0.5322802)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2953" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.22333209,0.03439303,-0.02300572,0.14938839,14.791441,-7.631841)" />
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient2908" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0212766,0,0,0.89887639,2.1092738,20.498378)" />
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient2905" xlink:href="#linearGradient4236" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0212766,0,0,0.89887639,0.3816013,20.266398)" />
-    <linearGradient id="linearGradient4236">
-      <stop id="stop4238" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2959"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22282769,-0.03752228,0.02509892,0.149051,-18.145918,0.5322802)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2953"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22333209,0.03439303,-0.02300572,0.14938839,14.791441,-7.631841)" />
+    <linearGradient
+       x1="7.0625"
+       y1="35.28125"
+       x2="24.6875"
+       y2="35.28125"
+       id="linearGradient2908"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0212766,0,0,0.89887639,2.1092738,20.498378)" />
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient2905"
+       xlink:href="#linearGradient4236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0212766,0,0,0.89887639,0.3816013,20.266398)" />
+    <linearGradient
+       id="linearGradient4236">
+      <stop
+         id="stop4238"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient2902" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.19054222,-0.02505584,0.00619351,0.10073457,-7.4371744,4.4286863)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2947" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.32948872,0,0,0.34974643,6.0549235,0.4938254)" />
-    <linearGradient id="linearGradient1139" inkscape:collect="always">
-      <stop id="stop1135" offset="0" style="stop-color:#d1ff82;stop-opacity:1;" />
-      <stop id="stop1137" offset="1" style="stop-color:#9bdb4d;stop-opacity:1" />
+    <radialGradient
+       cx="127.31733"
+       cy="143.82751"
+       r="78.728165"
+       fx="127.31733"
+       fy="143.82751"
+       id="radialGradient2902"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.19054222,-0.02505584,0.00619351,0.10073457,-7.4371744,4.4286863)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2947"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32948872,0,0,0.34974643,6.0549235,0.4938254)" />
+    <linearGradient
+       id="linearGradient1131"
+       inkscape:collect="always">
+      <stop
+         id="stop1127"
+         offset="0"
+         style="stop-color:#ffe16b;stop-opacity:1" />
+      <stop
+         style="stop-color:#d39220;stop-opacity:1;"
+         offset="0.51300955"
+         id="stop1133" />
+      <stop
+         id="stop1129"
+         offset="1"
+         style="stop-color:#f9c440;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient1131" inkscape:collect="always">
-      <stop id="stop1127" offset="0" style="stop-color:#ffe16b;stop-opacity:1" />
-      <stop style="stop-color:#d39220;stop-opacity:1;" offset="0.51300955" id="stop1133" />
-      <stop id="stop1129" offset="1" style="stop-color:#f9c440;stop-opacity:1" />
+    <linearGradient
+       id="linearGradient1101">
+      <stop
+         id="stop1091"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1093"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.25" />
+      <stop
+         id="stop1095"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.67183787" />
+      <stop
+         id="stop1097"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop1099"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1101">
-      <stop id="stop1091" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop1093" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.25" />
-      <stop id="stop1095" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop1097" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop1099" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         id="stop1041"
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1043"
+         style="stop-color:#555761;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1045">
-      <stop id="stop1041" style="stop-color:#333333;stop-opacity:1" offset="0" />
-      <stop id="stop1043" style="stop-color:#555761;stop-opacity:1" offset="1" />
+    <linearGradient
+       gradientTransform="matrix(0.1018087,0,0,0.02745099,-69.338943,29.531208)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient2566"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(0.05979662,0,0,0.02745099,-44.023866,29.531208)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient2563"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.05979662,0,0,0.02745099,-21.060866,29.531208)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient2560"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(1.3573591,0,0,1.0098512,-71.90578,-7.1855111)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2215"
+       id="linearGradient2557"
+       y2="49.999996"
+       x2="30"
+       y1="41"
+       x1="29.9375" />
+    <linearGradient
+       id="linearGradient3484">
+      <stop
+         offset="0"
+         style="stop-color:#969696;stop-opacity:1"
+         id="stop3486" />
+      <stop
+         offset="1"
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         id="stop3488" />
     </linearGradient>
-    <linearGradient gradientTransform="matrix(0.1018087,0,0,0.02745099,-69.338943,29.531208)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5048" id="linearGradient2566" y2="609.50507" x2="302.85715" y1="366.64789" x1="302.85715" />
-    <radialGradient gradientTransform="matrix(0.05979662,0,0,0.02745099,-44.023866,29.531208)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="radialGradient2563" fy="486.64789" fx="605.71429" r="117.14286" cy="486.64789" cx="605.71429" />
-    <radialGradient gradientTransform="matrix(-0.05979662,0,0,0.02745099,-21.060866,29.531208)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="radialGradient2560" fy="486.64789" fx="605.71429" r="117.14286" cy="486.64789" cx="605.71429" />
-    <linearGradient gradientTransform="matrix(1.3573591,0,0,1.0098512,-71.90578,-7.1855111)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2215" id="linearGradient2557" y2="49.999996" x2="30" y1="41" x1="29.9375" />
-    <linearGradient id="linearGradient3484">
-      <stop offset="0" style="stop-color:#969696;stop-opacity:1" id="stop3486" />
-      <stop offset="1" style="stop-color:#b4b4b4;stop-opacity:1" id="stop3488" />
-    </linearGradient>
-    <linearGradient gradientTransform="matrix(1.3526366,0,0,1.3652569,-65.00565,-16.571717)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3484" id="linearGradient2553" y2="10.000001" x2="18.072828" y1="29.796696" x1="17.813944" />
-    <radialGradient gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-65.072141,-19.218242)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7056" id="radialGradient2551" fy="8.4900017" fx="11.734284" r="23.047892" cy="8.4900017" cx="11.734284" />
-    <radialGradient gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4035" id="radialGradient2547" fy="206.42612" fx="141.74666" r="78.728165" cy="206.42612" cx="141.74666" />
-    <radialGradient gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7609" id="radialGradient2544" fy="191.85428" fx="142.62215" r="78.728165" cy="191.85428" cx="142.62215" />
-    <radialGradient gradientTransform="matrix(-0.5034274,0,0,0.4878048,-1.621716,-15.840702)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-8" id="radialGradient2540" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-98.454216,-22.510628)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-8" id="radialGradient2536" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,-53.006802,-38.640386)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-8" id="radialGradient2532" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <linearGradient gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="linearGradient2529" y2="35.28125" x2="24.6875" y1="35.28125" x1="7.0625" />
-    <linearGradient gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4236" id="linearGradient2526" y2="33.758667" x2="12.221823" y1="37.205811" x1="12.277412" />
-    <radialGradient gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4035" id="radialGradient2523" fy="143.82751" fx="127.31733" r="78.728165" cy="143.82751" cx="127.31733" />
-    <radialGradient gradientUnits="userSpaceOnUse" id="radialGradient4241-8" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654">
-      <stop offset="0" style="stop-color:#eeeeee;stop-opacity:1" id="stop4243-7" />
-      <stop offset="0.16" style="stop-color:#cecece;stop-opacity:1" id="stop4245-9" />
-      <stop offset="0.4675" style="stop-color:#888888;stop-opacity:1" id="stop4247-2" />
-      <stop offset="1" style="stop-color:#555555;stop-opacity:1" id="stop4249-0" />
+    <linearGradient
+       gradientTransform="matrix(1.3526366,0,0,1.3652569,-65.00565,-16.571717)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3484"
+       id="linearGradient2553"
+       y2="10.000001"
+       x2="18.072828"
+       y1="29.796696"
+       x1="17.813944" />
+    <radialGradient
+       gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-65.072141,-19.218242)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient7056"
+       id="radialGradient2551"
+       fy="8.4900017"
+       fx="11.734284"
+       r="23.047892"
+       cy="8.4900017"
+       cx="11.734284" />
+    <radialGradient
+       gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4035"
+       id="radialGradient2547"
+       fy="206.42612"
+       fx="141.74666"
+       r="78.728165"
+       cy="206.42612"
+       cx="141.74666" />
+    <radialGradient
+       gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient7609"
+       id="radialGradient2544"
+       fy="191.85428"
+       fx="142.62215"
+       r="78.728165"
+       cy="191.85428"
+       cx="142.62215" />
+    <radialGradient
+       gradientTransform="matrix(-0.5034274,0,0,0.4878048,-1.621716,-15.840702)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#radialGradient4241-8"
+       id="radialGradient2540"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654" />
+    <radialGradient
+       gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-98.454216,-22.510628)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#radialGradient4241-8"
+       id="radialGradient2536"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654" />
+    <radialGradient
+       gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,-53.006802,-38.640386)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#radialGradient4241-8"
+       id="radialGradient2532"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654" />
+    <linearGradient
+       gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="linearGradient2529"
+       y2="35.28125"
+       x2="24.6875"
+       y1="35.28125"
+       x1="7.0625" />
+    <linearGradient
+       gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4236"
+       id="linearGradient2526"
+       y2="33.758667"
+       x2="12.221823"
+       y1="37.205811"
+       x1="12.277412" />
+    <radialGradient
+       gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4035"
+       id="radialGradient2523"
+       fy="143.82751"
+       fx="127.31733"
+       r="78.728165"
+       cy="143.82751"
+       cx="127.31733" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4241-8"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop4243-7" />
+      <stop
+         offset="0.16"
+         style="stop-color:#cecece;stop-opacity:1"
+         id="stop4245-9" />
+      <stop
+         offset="0.4675"
+         style="stop-color:#888888;stop-opacity:1"
+         id="stop4247-2" />
+      <stop
+         offset="1"
+         style="stop-color:#555555;stop-opacity:1"
+         id="stop4249-0" />
     </radialGradient>
-    <radialGradient gradientTransform="matrix(0.5034273,0,0,0.4878048,-63.463014,-15.840702)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-8" id="radialGradient2519" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <linearGradient id="linearGradient6310-8">
-      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop6312-6" />
-      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0" id="stop6314-6" />
+    <radialGradient
+       gradientTransform="matrix(0.5034273,0,0,0.4878048,-63.463014,-15.840702)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#radialGradient4241-8"
+       id="radialGradient2519"
+       fy="98"
+       fx="113.667"
+       r="2.5631001"
+       cy="97.587898"
+       cx="113.0654" />
+    <linearGradient
+       id="linearGradient6310-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6312-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6314-6" />
     </linearGradient>
-    <radialGradient gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-65.685227,18.406373)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient6310-8" id="radialGradient2516" fy="42" fx="24" r="21" cy="42" cx="24" />
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.77483523,-1.809244e-7,-1.8482502e-8,-0.2162162,-2.9570507,53.735858)" r="18.5" fy="75.09082" fx="25.960344" cy="75.09082" cx="25.960344" id="radialGradient925" xlink:href="#linearGradient1045" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.99999995,0,0,2,-0.9999998,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="7" y1="53" x1="7" id="linearGradient1011" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.0000002,0,0,2,-1.0000022,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="10" y1="53" x1="10" id="linearGradient1013" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.99999924,0,0,2,-3.9999894,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="16" y1="53" x1="16" id="linearGradient1017" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.0000007,0,0,2,-4.0000134,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="19" y1="53" x1="19" id="linearGradient1019" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.0000007,0,0,2,-7.0000178,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="25" y1="53" x1="25" id="linearGradient1023" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.97384771,0,0,2,-6.2938899,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="28" y1="53" x1="28" id="linearGradient1025" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.99999999,0,0,2,-7.0000001,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="31" y1="53" x1="31" id="linearGradient1027" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.99999999,0,0,2,-10,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="37" y1="53" x1="37" id="linearGradient1033" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.88806701,-14.819406,-7.5675518)" r="1.6890617" fy="53" fx="58.063544" cy="53" cx="58.063544" id="radialGradient1141" xlink:href="#linearGradient1139" inkscape:collect="always" />
+    <radialGradient
+       gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-65.685227,18.406373)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6310-8"
+       id="radialGradient2516"
+       fy="42"
+       fx="24"
+       r="21"
+       cy="42"
+       cx="24" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1400"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000003,0,0,1.9999993,24.000013,-64.499951)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1398"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000003,0,0,1.9999993,20.000003,-64.499951)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1396"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000003,0,0,1.9999993,16,-64.499951)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000003,0,0,1.9999993,12.000008,-64.499951)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1308"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000003,0,0,1.9999993,8.0000046,-64.499951)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000003,0,0,1.9999993,4.0000027,-64.499951)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011-3"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000003,0,0,1.9999993,9.7e-7,-64.499951)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925-5"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5"
+       gradientTransform="matrix(0.83853791,-1.3397567e-7,-2.0002033e-8,-0.16010947,-4.0116534,51.001689)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient1084">
+      <stop
+         id="stop1149"
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1095-9"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1047"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69644678,0,0,0.65444704,1.7138262,-0.72400582)"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       id="linearGradient1018">
+      <stop
+         id="stop1013"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1015"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999996"
+       y2="48.973789"
+       gradientTransform="matrix(0.72919486,0,0,0.74491129,0.66576864,-0.59712616)" />
+    <linearGradient
+       x1="29.736721"
+       y1="43.024384"
+       x2="29.736721"
+       y2="49.956097"
+       id="linearGradient2557-1"
+       xlink:href="#linearGradient2215-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0231039,0,0,0.87577779,-5.4200062,0.16429235)" />
+    <linearGradient
+       id="linearGradient2215-2">
+      <stop
+         id="stop2223-7"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219-0"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient959"
+       id="linearGradient961"
+       x1="32"
+       y1="57"
+       x2="32"
+       y2="48"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.753746,0,0,0.8672345,0.13013321,-5.5176332)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient959">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop955" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.502"
+         offset="1"
+         id="stop957" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="8"
+       y2="31.555555"
+       gradientTransform="matrix(-0.73255818,0,0,0.73255818,47.485679,1.0755815)" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.9375" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73255818,0,0,0.73255818,0.52081462,1.4210182)" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.41666666" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.44444445" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560-9"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0438045,0,0,0.02010946,32.373547,33.117708)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563-0"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0438045,0,0,0.02010946,15.551814,33.117708)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566-6"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0745808,0,0,0.02010946,-2.9929519,33.117708)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1260"
+       id="linearGradient1246"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.5799362,0,0,0.59252384,0.41869358,-1.8879234)"
+       x1="6.5747628"
+       y1="55.4814"
+       x2="6.5747628"
+       y2="53.827366"
+       spreadMethod="pad" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient1264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83795815,-2.0145405e-7,-1.9988204e-8,-0.24075045,-3.8956566,57.061847)"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5" />
   </defs>
-  <path d="M 46.55,36.601962 39.740367,10.827625 c -0.192553,-0.733973 -1.2012,-1.329879 -2.049166,-1.329879 l -27.617218,0 c -1.30274,0 -2.049257,0.198573 -2.323959,1.329879 L 1.45,36.576866 z" id="path6345" style="fill:url(#radialGradient2927);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99578345;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <rect width="36.869301" height="5" x="5.5653324" y="40" id="rect2723" style="opacity:0.3;fill:url(#linearGradient2942);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="m 42.41667,40.000174 c 0,0 0,4.999723 0,4.999723 C 44.7262,45.009311 48,43.879712 48,42.499715 48,41.119718 45.42274,40.000174 42.41667,40.000174 z" id="path2725" style="opacity:0.3;fill:url(#radialGradient2939);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="m 5.58333,40.000174 c 0,0 0,4.999723 0,4.999723 C 3.2737899,45.009311 0,43.879712 0,42.499715 0,41.119718 2.5772699,40.000174 5.58333,40.000174 z" id="path2727" style="opacity:0.3;fill:url(#radialGradient2936);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="M 46.55,36.5 39.740367,10.824766 c -0.192553,-0.731151 -1.2012,-1.3247661 -2.049166,-1.3247661 l -27.617218,0 c -1.30274,0 -2.049257,0.1978095 -2.323959,1.3247661 L 1.45,36.475001 z" id="path6345-1" style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 10.0625,10.46875 c -0.6058109,0 -0.9673014,0.09427 -1.09375,0.15625 -0.1264486,0.06198 -0.1572339,0.02421 -0.25,0.40625 l -6.03125,24.5625 42.625,0.03125 -6.5,-24.5625 c -0.0041,-0.01553 -0.138916,-0.199012 -0.375,-0.34375 -0.236084,-0.144738 -0.549495,-0.25 -0.75,-0.25 l -27.625,0 z" id="path4129" style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient3311-4);stroke-width:1.00312006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" transform="matrix(1,0,0,0.99378882,0,0.09627324)" />
-  <path d="m 1.4638537,36.464001 45.0720003,0 -0.901202,6.072 -43.1694186,0 -1.0013797,-6.072 z" id="rect6431" style="fill:url(#linearGradient2933);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
-  <path d="m 1.4638537,36.5 45.0720003,0 -0.901202,6 -43.1694185,0 -1.0013798,-6 z" id="rect6431-3" style="opacity:0.5;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 3.3117397,41.499995 41.4657843,3e-6 c 0.108461,-0.399966 0.576759,-4 0.576759,-4 H 2.654475 c 0,0 0.4981314,2.982569 0.6572647,3.999997 z" id="path4497" style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;stroke:url(#linearGradient3308);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-  <path d="M 6.0158229,34.619284 C 5.9743059,35.214553 5.3525618,35.7 4.6276859,35.7 c -0.7245458,0 -1.2731445,-0.485447 -1.2247097,-1.080716 0.048106,-0.592121 0.6695217,-1.070225 1.3871481,-1.070225 0.7179564,2.81e-4 1.2665551,0.478104 1.2256986,1.070225 z" id="path9007" style="fill:#e1e1e1;fill-opacity:1" />
-  <path d="m 5.5469595,34.200637 c 0.066228,0.07554 0.1420102,0.196558 0.1420102,0.357441 0,0.01155 -6.602e-4,0.02308 -0.00132,0.03533 -0.028667,0.410252 -0.5140028,0.756851 -1.0596361,0.756851 -0.3107079,0 -0.5947269,-0.113668 -0.7594717,-0.304629 -0.070839,-0.08149 -0.1515649,-0.216493 -0.1370672,-0.396263 0.033278,-0.406755 0.5179556,-0.750556 1.0589773,-0.750556 0.3084014,2.8e-4 0.5914315,0.112968 0.7565052,0.301831 h 2.6e-6 z" id="path9009" style="fill:url(#radialGradient2965);fill-opacity:1" />
-  <path d="m 8.6135352,10.981804 c 0.070795,0.248957 0.526108,0.385035 1.0163294,0.302486 0.4899984,-0.08251 0.8261694,-0.351869 0.7506954,-0.600038 -0.07503,-0.246865 -0.5295895,-0.379851 -1.0149081,-0.298127 -0.4855218,0.08188 -0.8222397,0.347988 -0.7521167,0.595679 z" id="path9019" style="fill:#f0f0f0;fill-opacity:1" />
-  <path d="m 8.9005762,10.749996 c -0.039367,0.03974 -0.081933,0.09994 -0.070388,0.168502 8.287e-4,0.0049 0.0021,0.0098 0.00343,0.0149 0.048828,0.171572 0.4019255,0.264011 0.7709282,0.201874 0.2101265,-0.03538 0.3940466,-0.116169 0.4917566,-0.216312 0.04206,-0.0428 0.08696,-0.109523 0.06426,-0.184484 -0.0517,-0.169557 -0.4041467,-0.260879 -0.7700306,-0.199267 -0.2085465,0.03524 -0.3918682,0.115496 -0.4899513,0.214782 l -1.8e-6,1e-6 z" id="path9021" style="fill:url(#radialGradient2959);fill-opacity:1" />
-  <path d="m 36.912257,10.696563 c -0.01101,0.258593 0.37848,0.530843 0.869811,0.606508 0.491108,0.07563 0.894887,-0.07446 0.901213,-0.333771 0.0063,-0.257936 -0.383413,-0.527015 -0.869831,-0.601923 -0.486659,-0.07482 -0.889937,0.07201 -0.901193,0.329186 z" id="path9025" style="fill:#e1e1e1;fill-opacity:1" />
-  <path d="m 37.257597,10.566686 c -0.04986,0.02535 -0.109185,0.06913 -0.119768,0.137852 -7.6e-4,0.0049 -0.0011,0.0099 -0.0014,0.01523 -0.0076,0.178225 0.298614,0.37693 0.668452,0.433884 0.210602,0.03243 0.410591,0.01353 0.534819,-0.05084 0.05338,-0.02741 0.116973,-0.07665 0.118971,-0.15495 0.0042,-0.177212 -0.301707,-0.374653 -0.668419,-0.431126 -0.209057,-0.03207 -0.408312,-0.01348 -0.532624,0.04996 l -2e-6,-1e-6 z" id="path9027" style="fill:url(#radialGradient2953);fill-opacity:1" />
-  <path d="M 42.002142,34.619284 C 42.043662,35.214553 42.665403,35.7 43.390279,35.7 c 0.724546,0 1.273145,-0.485447 1.22471,-1.080716 -0.04811,-0.592121 -0.669522,-1.070225 -1.387148,-1.070225 -0.717957,2.81e-4 -1.266555,0.478104 -1.225699,1.070225 z" id="path9091" style="fill:#e1e1e1;fill-opacity:1" />
-  <path d="m 42.471006,34.200637 c -0.06623,0.07554 -0.142011,0.196558 -0.142011,0.357441 0,0.01155 6.6e-4,0.02308 0.0013,0.03533 0.02867,0.410252 0.514002,0.756851 1.059636,0.756851 0.310708,0 0.594727,-0.113668 0.759471,-0.304629 0.07084,-0.08149 0.151565,-0.216493 0.137068,-0.396263 -0.03328,-0.406755 -0.517956,-0.750556 -1.058978,-0.750556 -0.308401,2.8e-4 -0.591431,0.112968 -0.756505,0.301831 h -2e-6 z" id="path9093" style="fill:url(#radialGradient2947);fill-opacity:1" />
-  <path style="fill:url(#radialGradient1141);fill-opacity:1;stroke:#9bdb4d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.54444442" d="m 44.380594,38.5 -0.3,2 h -2 l 0.3,-2 z" id="path915" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.59883722;paint-order:normal" d="M 4.2,40.5 H 30.258207 L 30.5,38.5 H 3.9 Z" id="rect917" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 5.0000001,38 v 2 H 7 v -2 z" id="path928" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 8,38 v 2 h 2 v -2 z" id="path928-3" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 11,38 v 2 h 1.999999 v -2 z" id="path928-7" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 14,38 v 2 h 2 v -2 z" id="path928-5" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 17,38 v 2 h 2 v -2 z" id="path928-62" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 20,38 v 2 h 1.947694 v -2 z" id="path928-9" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 23,38 v 2 h 2 v -2 z" id="path928-1" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 26,38 v 2 h 2 v -2 z" id="path928-70" inkscape:connector-curvature="0" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.366279;marker:none"
+     id="rect2723-5"
+     y="40.490784"
+     x="5.9567194"
+     height="4.8837209"
+     width="36.011875" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.366279;marker:none"
+     id="path2725-6"
+     d="m 41.951049,40.490954 c 0,0 0,4.883451 0,4.883451 2.25582,0.0092 5.453484,-1.094134 5.453484,-2.442038 0,-1.347905 -2.517323,-2.441413 -5.453484,-2.441413 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.732558;marker:none"
+     id="path2727-2"
+     d="m 5.9742991,40.490954 c 0,0 0,4.883451 0,4.883451 -2.2558293,0.0092 -5.45348512,-1.094134 -5.45348512,-2.442038 0,-1.347905 2.51733342,-2.441413 5.45348512,-2.441413 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.732558;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-91"
+     d="M 46.753117,38.069768 40.160095,10.965117 C 39.865662,9.8662791 38.694978,9.5 37.59614,9.5 H 10.491489 C 9.3926528,9.5 8.1808287,9.8662791 7.9275364,10.965117 L 1.3345132,38.069768"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 1.5,38 7.9275364,10.965117 C 8.2219691,9.8662791 9.3926528,9.5 10.491489,9.5 H 37.59614 c 1.098838,0 2.310662,0.3662791 2.563955,1.465117 L 46.5,38"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:url(#linearGradient2557-1);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:1.03699;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-2"
+     d="M 44.224263,43.481108 H 4.2757348 c -1.5074922,0 -1.8574364,-0.433614 -2.2613678,-2.168081 L 1.6376248,39.578559 C 0.88387868,36.109619 3.8988617,36.54324 5.406354,36.54324 h 37.687288 c 1.507497,0 4.522479,-0.433621 3.768733,3.035319 l -0.376873,1.734468 c -0.376874,1.734467 -0.753745,2.168081 -2.261239,2.168081 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:1.01917;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-8"
+     d="M 43.323661,41.490364 H 4.6763402 c -1.4583903,0 -1.796937,-0.372456 -2.1877101,-1.862278 L 2.1241581,38.138267 C 1.3949638,35.158616 4.3117428,35.531073 5.7701316,35.531073 H 42.229867 c 1.45839,0 4.375169,-0.372457 3.645975,2.607194 l -0.364599,1.489819 c -0.364595,1.489822 -0.729194,1.862278 -2.187582,1.862278 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.75;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1047);stroke-width:0.995521;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2"
+     d="M 42.455948,36.252239 H 5.5442815 c -1.3928947,0 -1.7162362,-0.327221 -2.0894605,-1.636118 L 3.1067179,33.307227 C 2.4102715,30.68944 5.1960573,31.016665 6.5889501,31.016665 H 41.411278 c 1.392891,0 4.178677,-0.327225 3.482232,2.290562 l -0.348226,1.308894 c -0.348221,1.308897 -0.696444,1.636118 -2.089336,1.636118 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1246);stroke-width:0.993034;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2-2"
+     d="M 42.456206,36.253421 H 5.5437936 c -1.3929213,0 -1.7162708,-0.358489 -2.0895025,-1.792437 L 3.1061807,33.027037 C 2.4097201,30.15914 5.1955626,30.517628 6.5884838,30.517628 H 41.41152 c 1.392918,0 4.178757,-0.358488 3.4823,2.509409 l -0.34823,1.433947 c -0.34823,1.433948 -0.69646,1.792437 -2.089384,1.792437 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <g
+     id="path915-7"
+     style="fill:#9bdb4d;fill-opacity:0.75;stroke:none;stroke-width:0.700198;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.504001"
+     transform="matrix(1.464289,0,0,1.4651163,0.6256372,-1.4883725)" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.74902;fill-rule:evenodd;stroke:#68b723;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 44.499991,39 -0.5,3 h -2.5 l 0.5,-3 z"
+     id="path1472"
+     sodipodi:nodetypes="ccccc" />
+  <g
+     id="rect917-9"
+     transform="matrix(1.4568654,0,0,1.5,0.72129095,-3.05)"
+     style="display:inline;stroke-width:0.676464;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#radialGradient1264);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:1.03073;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.6;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 4.6097075,41.984623 H 32.779839 l 0.299683,-2.969258 H 4.110237 Z"
+     id="path1478"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="display:inline;fill:url(#linearGradient1011-3);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 6,39.5 v 2 h 2.0000042 v -2 z"
+     id="path928-20"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1259);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 9.9999995,39.5 v 2 h 1.9999955 v -2 z"
+     id="path928-3-23"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1308);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 13.999963,39.5 v 2 h 2.000059 v -2 z"
+     id="path928-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1394);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 17.999989,39.5 v 2 h 1.999969 v -2 z"
+     id="path928-9-7"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1396);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 22.000016,39.5 v 2 h 1.999968 v -2 z"
+     id="path928-3-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1398);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 26.000043,39.5 v 2 h 1.999967 v -2 z"
+     id="path928-2-0"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1400);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 29.999978,39.5 v 2 h 2.000059 v -2 z"
+     id="path928-3-6-2"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/devices/64/drive-harddisk-solidstate.svg
+++ b/devices/64/drive-harddisk-solidstate.svg
@@ -23,14 +23,14 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1288"
+     inkscape:window-width="1317"
      inkscape:window-height="796"
      id="namedview82"
      showgrid="true"
      showguides="false"
-     inkscape:zoom="6.2303374"
-     inkscape:cx="12.61062"
-     inkscape:cy="34.740723"
+     inkscape:zoom="7.5560237"
+     inkscape:cx="18.972312"
+     inkscape:cy="34.342282"
      inkscape:window-x="16"
      inkscape:window-y="30"
      inkscape:window-maximized="0"
@@ -62,7 +62,7 @@
          offset="0" />
       <stop
          id="stop1238"
-         style="stop-color:#1a1a1a;stop-opacity:0.502"
+         style="stop-color:#555761;stop-opacity:0.50196081"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -685,9 +685,9 @@
        id="linearGradient1233"
        gradientUnits="userSpaceOnUse"
        x1="56"
-       y1="52"
+       y1="49"
        x2="56"
-       y2="55"
+       y2="53"
        gradientTransform="translate(1.0000005)" />
     <filter
        inkscape:collect="always"
@@ -705,19 +705,6 @@
     <filter
        inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
-       id="filter1411"
-       x="-0.6075"
-       width="2.215"
-       y="-0.759375"
-       height="2.51875">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.6328125"
-         id="feGaussianBlur1413" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
        id="filter1539"
        x="-0.30000065"
        width="1.6000013"
@@ -727,6 +714,19 @@
          inkscape:collect="always"
          stdDeviation="0.12416061"
          id="feGaussianBlur1541" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1278"
+       x="-0.40114286"
+       width="1.8022857"
+       y="-0.468"
+       height="1.936">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.585"
+         id="feGaussianBlur1280" />
     </filter>
   </defs>
   <rect
@@ -851,15 +851,16 @@
     <g
        id="path915-6"
        transform="matrix(1.0028589,0,0,0.9815644,-1.1629934,0.97735801)"
-       style="opacity:1;filter:url(#filter1350)" />
+       style="opacity:1;filter:url(#filter1350)"
+       inkscape:groupmode="layer" />
     <path
-       style="display:inline;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:#d1ff82;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter1411)"
-       d="m 57,52 -0.5,2 h -2 L 55,52 Z"
+       style="display:inline;opacity:0.75;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:#d1ff82;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter1278)"
+       d="m 57.5,51.5 -0.5,3 h -3 l 0.5,-3 z"
        id="path915-1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
     <ellipse
-       style="opacity:0.75;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00672;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter1539)"
+       style="display:none;opacity:0.75;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00672;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter1539)"
        id="path1417"
        cx="55.850002"
        cy="53.000004"
@@ -887,7 +888,7 @@
      sodipodi:nodetypes="ccccscccc" />
   <path
      style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 58.5,51.5 -0.75,2.75 h -2.5 l 0.5,-2.75 z"
+     d="m 58.5,51.5 -0.5,3 -3,0 0.5,-3 z"
      id="path915-2"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccc" />

--- a/devices/64/drive-harddisk-solidstate.svg
+++ b/devices/64/drive-harddisk-solidstate.svg
@@ -1,146 +1,894 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="64" height="64" id="svg3338" sodipodi:docname="drive-harddisk-solidstate.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview82" showgrid="false" showguides="false" inkscape:zoom="22.627417" inkscape:cx="16.321056" inkscape:cy="10.875431" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3338">
-    <inkscape:grid type="xygrid" id="grid892" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="64"
+   height="64"
+   id="svg3338"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1288"
+     inkscape:window-height="796"
+     id="namedview82"
+     showgrid="true"
+     showguides="false"
+     inkscape:zoom="6.2303374"
+     inkscape:cx="12.61062"
+     inkscape:cy="34.740723"
+     inkscape:window-x="16"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3338"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid892" />
   </sodipodi:namedview>
-  <metadata id="metadata83">
+  <metadata
+     id="metadata83">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3340">
-    <linearGradient inkscape:collect="always" id="linearGradient1139">
-      <stop style="stop-color:#d1ff82;stop-opacity:1;" offset="0" id="stop1135" />
-      <stop style="stop-color:#9bdb4d;stop-opacity:1" offset="1" id="stop1137" />
+  <defs
+     id="defs3340">
+    <linearGradient
+       id="linearGradient1240">
+      <stop
+         id="stop1236"
+         style="stop-color:#fafafa;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop1238"
+         style="stop-color:#1a1a1a;stop-opacity:0.502"
+         offset="1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient1131">
-      <stop style="stop-color:#ffe16b;stop-opacity:1" offset="0" id="stop1127" />
-      <stop id="stop1133" offset="0.51300955" style="stop-color:#d39220;stop-opacity:1;" />
-      <stop style="stop-color:#f9c440;stop-opacity:1" offset="1" id="stop1129" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.9375" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1101">
-      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop1091" />
-      <stop offset="0.25" style="stop-color:#e7e7e7;stop-opacity:1" id="stop1093" />
-      <stop offset="0.67183787" style="stop-color:#8c8c8c;stop-opacity:1" id="stop1095" />
-      <stop offset="0.83542866" style="stop-color:#dddddd;stop-opacity:1" id="stop1097" />
-      <stop offset="1" style="stop-color:#a8a8a8;stop-opacity:1" id="stop1099" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.41666666" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.44444445" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1045">
-      <stop offset="0" style="stop-color:#333333;stop-opacity:1" id="stop1041" />
-      <stop offset="1" style="stop-color:#555761;stop-opacity:1" id="stop1043" />
+    <linearGradient
+       id="linearGradient1084">
+      <stop
+         id="stop1080"
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1082"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient1018">
+      <stop
+         id="stop1013"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1015"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2566" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.1018087,0,0,0.02745099,-4.7965709,43.268495)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2563" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.05979662,0,0,0.02745099,20.518506,43.268495)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2560" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.05979662,0,0,0.02745099,43.481506,43.268495)" />
-    <linearGradient id="linearGradient2215">
-      <stop id="stop2223" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient959">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop955" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.502"
+         offset="1"
+         id="stop957" />
     </linearGradient>
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2557" xlink:href="#linearGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3573591,0,0,1.0098512,-7.3634079,6.5517759)" />
-    <linearGradient id="linearGradient3484">
-      <stop id="stop3486" style="stop-color:#969696;stop-opacity:1" offset="0" />
-      <stop id="stop3488" style="stop-color:#b4b4b4;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
     </linearGradient>
-    <linearGradient x1="17.813944" y1="29.796696" x2="18.072828" y2="10.000001" id="linearGradient2553" xlink:href="#linearGradient3484" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3526366,0,0,1.3652569,-0.463278,-2.8344302)" />
-    <linearGradient id="linearGradient7056">
-      <stop id="stop7064" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1101">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1091" />
+      <stop
+         offset="0.25"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         id="stop1093" />
+      <stop
+         offset="0.67183787"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         id="stop1095" />
+      <stop
+         offset="0.83542866"
+         style="stop-color:#dddddd;stop-opacity:1"
+         id="stop1097" />
+      <stop
+         offset="1"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         id="stop1099" />
     </linearGradient>
-    <radialGradient cx="11.734284" cy="8.4900017" r="23.047892" fx="11.734284" fy="8.4900017" id="radialGradient2551" xlink:href="#linearGradient7056" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-0.5297689,-5.4809546)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient2547" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)" />
-    <linearGradient id="linearGradient7609">
-      <stop id="stop7611" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop7677" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop7613" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop7617" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop7615" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#555761;stop-opacity:1"
+         id="stop1043" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient2544" xlink:href="#linearGradient7609" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2540" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.5034274,0,0,0.4878048,62.920656,-2.103415)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2536" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-33.911844,-8.7733407)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2532" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,11.53557,-24.903099)" />
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient2529" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)" />
-    <linearGradient id="linearGradient4236">
-      <stop id="stop4238" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1018087,0,0,0.02745099,-4.7965709,43.268495)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05979662,0,0,0.02745099,20.518506,43.268495)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.05979662,0,0,0.02745099,43.481506,43.268495)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient2526" xlink:href="#linearGradient4236" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="29.736721"
+       y1="43.024384"
+       x2="29.736721"
+       y2="49.956097"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3573591,0,0,1.0098512,-7.3634079,6.5517759)" />
+    <linearGradient
+       id="linearGradient3484">
+      <stop
+         id="stop3486"
+         style="stop-color:#969696;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3488"
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient2523" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient4241" gradientUnits="userSpaceOnUse">
-      <stop id="stop4243" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4245" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop4247" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop4249" style="stop-color:#555555;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="17.813944"
+       y1="29.796696"
+       x2="18.072828"
+       y2="10.000001"
+       id="linearGradient2553"
+       xlink:href="#linearGradient3484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3526366,0,0,1.3652569,-0.463278,-2.8344302)" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         id="stop7064"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="11.734284"
+       cy="8.4900017"
+       r="23.047892"
+       fx="11.734284"
+       fy="8.4900017"
+       id="radialGradient2551"
+       xlink:href="#linearGradient7056"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-0.5297689,-5.4809546)" />
+    <radialGradient
+       cx="141.74666"
+       cy="206.42612"
+       r="78.728165"
+       fx="141.74666"
+       fy="206.42612"
+       id="radialGradient2547"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)" />
+    <linearGradient
+       id="linearGradient7609">
+      <stop
+         id="stop7611"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7677"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop7613"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.67183787" />
+      <stop
+         id="stop7617"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop7615"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="142.62215"
+       cy="191.85428"
+       r="78.728165"
+       fx="142.62215"
+       fy="191.85428"
+       id="radialGradient2544"
+       xlink:href="#linearGradient7609"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2540"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.5034274,0,0,0.4878048,62.920656,-2.103415)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2536"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-33.911844,-8.7733407)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2532"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,11.53557,-24.903099)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="7.0625"
+       y1="35.28125"
+       x2="24.6875"
+       y2="35.28125"
+       id="linearGradient2529"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)" />
+    <linearGradient
+       id="linearGradient4236">
+      <stop
+         id="stop4238"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient2526"
+       xlink:href="#linearGradient4236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)" />
+    <linearGradient
+       id="linearGradient4035">
+      <stop
+         id="stop4037"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4039"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop4041"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.69348532" />
+      <stop
+         id="stop4043"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop4045"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="127.31733"
+       cy="143.82751"
+       r="78.728165"
+       fx="127.31733"
+       fy="143.82751"
+       id="radialGradient2523"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient4241"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop4243"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4245"
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="0.16" />
+      <stop
+         id="stop4247"
+         style="stop-color:#888888;stop-opacity:1"
+         offset="0.4675" />
+      <stop
+         id="stop4249"
+         style="stop-color:#555555;stop-opacity:1"
+         offset="1" />
     </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2519" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.5034273,0,0,0.4878048,1.0793577,-2.103415)" />
-    <linearGradient id="linearGradient6310-8">
-      <stop id="stop6312-6" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop6314-6" style="stop-color:#ffffff;stop-opacity:0" offset="1" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2519"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5034273,0,0,0.4878048,1.0793577,-2.103415)" />
+    <linearGradient
+       id="linearGradient6310-8">
+      <stop
+         id="stop6312-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6314-6"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="24" cy="42" r="21" fx="24" fy="42" id="radialGradient2516" xlink:href="#linearGradient6310-8" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-1.1428547,32.14366)" />
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient1045" id="radialGradient925" cx="25.960344" cy="75.09082" fx="25.960344" fy="75.09082" r="18.5" gradientTransform="matrix(1.1323845,-1.809244e-7,-2.7011291e-8,-0.2162162,-6.3970894,67.235857)" gradientUnits="userSpaceOnUse" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1011" x1="7" y1="53" x2="7" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1013" x1="10" y1="53" x2="10" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1015" x1="13" y1="53" x2="13" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1017" x1="16" y1="53" x2="16" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1019" x1="19" y1="53" x2="19" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1021" x1="22" y1="53" x2="22" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1023" x1="25" y1="53" x2="25" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1025" x1="28" y1="53" x2="28" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1027" x1="31" y1="53" x2="31" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1029" x1="34" y1="53" x2="34" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1031" x1="41" y1="53" x2="41" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,-1,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1033" x1="37" y1="53" x2="37" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient1139" id="radialGradient1141" cx="58.063544" cy="53" fx="58.063544" fy="53" r="1.6890617" gradientTransform="matrix(1,0,0,0.88806701,0,5.9324482)" gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="24"
+       cy="42"
+       r="21"
+       fx="24"
+       fy="42"
+       id="radialGradient2516"
+       xlink:href="#linearGradient6310-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-1.1428547,32.14366)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5"
+       gradientTransform="matrix(1.1323845,-1.809244e-7,-2.7011291e-8,-0.2162162,-6.3970894,67.235857)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1013"
+       x1="10"
+       y1="53"
+       x2="10"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1015"
+       x1="13"
+       y1="53"
+       x2="13"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1017"
+       x1="16"
+       y1="53"
+       x2="16"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1019"
+       x1="19"
+       y1="53"
+       x2="19"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1021"
+       x1="22"
+       y1="53"
+       x2="22"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1023"
+       x1="25"
+       y1="53"
+       x2="25"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1025"
+       x1="28"
+       y1="53"
+       x2="28"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1027"
+       x1="31"
+       y1="53"
+       x2="31"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1029"
+       x1="34"
+       y1="53"
+       x2="34"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1031"
+       x1="41"
+       y1="53"
+       x2="41"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-1,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1033"
+       x1="37"
+       y1="53"
+       x2="37"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient959"
+       id="linearGradient961"
+       x1="32"
+       y1="57"
+       x2="32"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999996"
+       y2="48.973789"
+       gradientTransform="matrix(0.97839212,0,0,0.99819206,0.69115353,-0.89218999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1047"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94548623,0,0,1.0001744,1.7444433,-5.995634)"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1084"
+       id="linearGradient1077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94548623,0,0,1.0001744,1.744443,-6.4956322)"
+       x1="31.999998"
+       y1="48.487175"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="8"
+       y2="31.555555"
+       gradientTransform="matrix(-1,0,0,1,64,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1240"
+       id="linearGradient1233"
+       gradientUnits="userSpaceOnUse"
+       x1="56"
+       y1="52"
+       x2="56"
+       y2="55"
+       gradientTransform="translate(1.0000005)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1350"
+       x="-0.28333337"
+       width="1.5666667"
+       y="-0.31874995"
+       height="1.6374999">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.20659725"
+         id="feGaussianBlur1352" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1411"
+       x="-0.6075"
+       width="2.215"
+       y="-0.759375"
+       height="2.51875">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.6328125"
+         id="feGaussianBlur1413" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1539"
+       x="-0.30000065"
+       width="1.6000013"
+       y="-0.29999935"
+       height="1.5999987">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.12416061"
+         id="feGaussianBlur1541" />
+    </filter>
   </defs>
-  <rect style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" id="rect2723" y="53.333332" x="7.4204431" height="6.6666665" width="49.159065" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" id="path2725" d="m 56.555559,53.333564 c 0,0 0,6.666297 0,6.666297 3.079373,0.01255 7.444439,-1.49358 7.444439,-3.333576 0,-1.839996 -3.436346,-3.332721 -7.444439,-3.332721 z" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" id="path2727" d="m 7.4444398,53.333564 c 0,0 0,6.666297 0,6.666297 C 4.3650531,60.012413 0,58.506281 0,56.666285 0,54.826289 3.4363598,53.333564 7.4444398,53.333564 Z" />
-  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:#353537;stroke-width:0.9279989;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" id="rect6431" d="M 1.4639996,48.463998 H 62.536003 l -1.221119,8.072 H 2.8208566 Z" />
-  <rect style="display:inline;fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new" id="rect6381" y="47.626324" x="1.5656769" height="1.3632195" width="60.868649" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2551);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2553);stroke-width:0.99578357;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path6345" d="M 62.501957,48.502108 53.290998,13.313517 C 53.030543,12.311454 51.666211,11.49789 50.51922,11.49789 H 13.16316 c -1.762134,0 -2.7719,0.271104 -3.143472,1.815627 L 1.4980451,48.467845" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path7046" d="M 61.499999,48.515874 2.5,48.484128" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9007" d="M 7.9967277,45.492684 C 7.9332943,46.322928 6.9833279,47 5.8757865,47 4.7687495,47 3.9305429,46.322928 4.0045466,45.492684 4.078048,44.666829 5.027512,44 6.1239769,44 c 1.096969,3.91e-4 1.9351757,0.666829 1.8727508,1.492684 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2540);fill-opacity:1" id="path9009" d="m 7.280349,44.90878 c 0.1011901,0.105359 0.2169781,0.274148 0.2169781,0.498536 0,0.01611 -0.00101,0.03219 -0.00202,0.04928 -0.0438,0.572194 -0.7853474,1.055609 -1.6190232,1.055609 -0.474732,0 -0.908686,-0.158536 -1.1604005,-0.424877 -0.1082352,-0.113658 -0.2315767,-0.301952 -0.2094255,-0.552683 0.050846,-0.567318 0.7913868,-1.046829 1.6180165,-1.046829 0.471208,3.9e-4 0.9036511,0.157561 1.1558678,0.420974 h 4.1e-6 l -5e-7,-7e-6 z" />
-  <path inkscape:connector-curvature="0" style="fill:#f0f0f0;fill-opacity:1" id="path9019" d="m 11.015508,13.309735 c 0.118861,0.526123 0.883302,0.813697 1.706351,0.639247 0.822674,-0.174371 1.387082,-0.743609 1.260368,-1.268067 -0.125972,-0.521702 -0.889146,-0.802742 -1.703963,-0.630035 -0.815161,0.173038 -1.380487,0.735406 -1.262756,1.258855 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2536);fill-opacity:1" id="path9021" d="m 11.497432,12.819853 c -0.0661,0.08398 -0.137561,0.211202 -0.118178,0.356097 0.0014,0.01035 0.0035,0.02071 0.0058,0.03149 0.08198,0.362583 0.674806,0.557935 1.294338,0.426621 0.352787,-0.07477 0.661577,-0.245501 0.825625,-0.457134 0.07062,-0.09045 0.146001,-0.231456 0.107889,-0.389872 -0.0868,-0.358327 -0.678535,-0.551317 -1.29283,-0.421113 -0.350136,0.07447 -0.657921,0.24408 -0.822597,0.453902 l -2e-6,2e-6 -5e-6,9e-6 z" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9025" d="m 49.000386,12.701322 c -0.01865,0.530555 0.641011,1.089131 1.473151,1.244373 0.831763,0.15517 1.515621,-0.152769 1.526335,-0.684798 0.01067,-0.529209 -0.649366,-1.081279 -1.473185,-1.234967 -0.824228,-0.153508 -1.507238,0.147743 -1.526301,0.675392 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2532);fill-opacity:1" id="path9027" d="m 49.58527,12.434852 c -0.08445,0.05201 -0.184921,0.141835 -0.202845,0.282832 -0.0013,0.01005 -0.0019,0.02031 -0.0024,0.03125 -0.01287,0.365665 0.505746,0.773348 1.132121,0.890201 0.356685,0.06654 0.695395,0.02776 0.905794,-0.104309 0.09041,-0.05624 0.198111,-0.157263 0.201496,-0.317911 0.0071,-0.363587 -0.510985,-0.768676 -1.132066,-0.884543 -0.354069,-0.0658 -0.691536,-0.02765 -0.902077,0.102505 l -4e-6,-4e-6 -4.7e-5,-1.8e-5 z" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9091" d="M 56.003272,45.492684 C 56.066707,46.322928 57.016672,47 58.124213,47 59.23125,47 60.069458,46.322928 59.995454,45.492684 59.921945,44.666829 58.972488,44 57.876023,44 c -1.09697,3.91e-4 -1.935174,0.666829 -1.872751,1.492684 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2519);fill-opacity:1" id="path9093" d="m 56.719652,44.90878 c -0.101194,0.105359 -0.216979,0.274148 -0.216979,0.498536 0,0.01611 10e-4,0.03219 0.002,0.04928 0.04381,0.572194 0.785346,1.055609 1.619022,1.055609 0.474732,0 0.908686,-0.158536 1.160399,-0.424877 0.108237,-0.113658 0.231578,-0.301952 0.209427,-0.552683 -0.05085,-0.567318 -0.791387,-1.046829 -1.618016,-1.046829 -0.471209,3.9e-4 -0.903651,0.157561 -1.155869,0.420974 h -3e-6 l 3.3e-5,-7e-6 z" />
-  <rect style="opacity:0.3;fill:url(#radialGradient2516);fill-opacity:1;stroke:none;stroke-width:1" id="rect6300-3" y="49.183899" x="3.0000002" height="6.8160973" width="58.000004" />
-  <path style="fill:url(#radialGradient1141);fill-opacity:1;stroke:#9bdb4d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.54444442" d="m 59.2,52 -0.3,2 h -2 l 0.3,-2 z" id="path915" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5988372;paint-order:normal" d="m 4.972956,54.5 h 37.17246 l 0.301398,-3 H 4.5710916 Z" id="rect917" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 6,51.499999 v 2 h 2 v -2 z" id="path928" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 9,51.499999 v 2 h 2 v -2 z" id="path928-3" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 12,51.499999 v 2 h 2 v -2 z" id="path928-6" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 15,51.499999 v 2 h 2 v -2 z" id="path928-7" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 18,51.499999 v 2 h 2 v -2 z" id="path928-5" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 21,51.499999 v 2 h 2 v -2 z" id="path928-35" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 24,51.499999 v 2 h 2 v -2 z" id="path928-62" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 27,51.499999 v 2 h 2 v -2 z" id="path928-9" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 30,51.499999 v 2 h 2 v -2 z" id="path928-1" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1029);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 33,51.499999 v 2 h 2 v -2 z" id="path928-2" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 36,51.499999 v 2 h 2 v -2 z" id="path928-70" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1031);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 39,51.499999 v 2 h 2 v -2 z" id="path928-93" inkscape:connector-curvature="0" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="rect2723"
+     y="53.333332"
+     x="7.4204431"
+     height="6.6666665"
+     width="49.159065" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="path2725"
+     d="m 56.555559,53.333564 c 0,0 0,6.666297 0,6.666297 3.079373,0.01255 7.444439,-1.49358 7.444439,-3.333576 0,-1.839996 -3.436346,-3.332721 -7.444439,-3.332721 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2727"
+     d="m 7.4444398,53.333564 c 0,0 0,6.666297 0,6.666297 C 4.3650531,60.012413 0,58.506281 0,56.666285 0,54.826289 3.4363598,53.333564 7.4444398,53.333564 Z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345"
+     d="M 62,50 54,13.5 c -0.401924,-1.5 -2,-2 -3.5,-2 h -37 c -1.5,0 -3.154236,0.5 -3.5,2 L 2,50"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50400102;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="m 2,50 8,-36.5 c 0.401924,-1.5 2,-2 3.5,-2 h 37 c 1.5,0 3.154236,0.5 3.5,2 L 62,50"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:1;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431"
+     d="M 58.5,56.5 H 5.5 C 3.5,56.5 3.0357254,56 2.499827,54 L 2,52 C 1,48 5,48.5 7,48.5 h 50 c 2,0 6,-0.5 5,3.5 l -0.5,2 c -0.5,2 -1,2.5 -3,2.5 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <rect
+     style="display:inline;opacity:0.3;fill:url(#radialGradient2516);fill-opacity:1;stroke:none;stroke-width:1"
+     id="rect6300-3"
+     y="49.183899"
+     x="3.0000002"
+     height="6.8160973"
+     width="58.000004" />
+  <g
+     id="g136"
+     style="display:inline"
+     transform="translate(1)"
+     inkscape:groupmode="layer">
+    <path
+       style="display:inline;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:#9bdb4d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 57,52 -0.5,2 h -2 L 55,52 Z"
+       id="path915"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.598837;paint-order:normal"
+       d="M 4.972956,54.5 H 42.25 l 0.25,-3 H 4.5002209 Z"
+       id="rect917"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6,51.499999 v 2 h 2 v -2 z"
+       id="path928"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,51.499999 v 2 h 2 v -2 z"
+       id="path928-3"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12,51.499999 v 2 h 2 v -2 z"
+       id="path928-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 15,51.499999 v 2 h 2 v -2 z"
+       id="path928-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 18,51.499999 v 2 h 2 v -2 z"
+       id="path928-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 21,51.499999 v 2 h 2 v -2 z"
+       id="path928-35"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 24,51.499999 v 2 h 2 v -2 z"
+       id="path928-62"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 27,51.499999 v 2 h 2 v -2 z"
+       id="path928-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 30,51.499999 v 2 h 2 v -2 z"
+       id="path928-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1029);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 33,51.499999 v 2 h 2 v -2 z"
+       id="path928-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 36,51.499999 v 2 h 2 v -2 z"
+       id="path928-70"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1031);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 39,51.499999 v 2 h 2 v -2 z"
+       id="path928-93"
+       inkscape:connector-curvature="0" />
+    <g
+       id="path915-6"
+       transform="matrix(1.0028589,0,0,0.9815644,-1.1629934,0.97735801)"
+       style="opacity:1;filter:url(#filter1350)" />
+    <path
+       style="display:inline;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:#d1ff82;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter1411)"
+       d="m 57,52 -0.5,2 h -2 L 55,52 Z"
+       id="path915-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <ellipse
+       style="opacity:0.75;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00672;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter1539)"
+       id="path1417"
+       cx="55.850002"
+       cy="53.000004"
+       rx="0.49664137"
+       ry="0.49664351"
+       transform="matrix(1.5730654,0,0,1.5730994,-31.955706,-30.574244)" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:0.988243;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="M 57.927086,55.505668 H 6.0723098 c -1.9567841,0 -2.4110269,-0.499097 -2.9353453,-2.495481 L 2.6479377,51.013803 C 1.6695454,47.021033 5.5831137,47.52013 7.5398978,47.52013 H 56.459498 c 1.956785,0 5.870352,-0.499097 4.89196,3.493673 l -0.489196,1.996384 c -0.489196,1.996384 -0.978391,2.495481 -2.935176,2.495481 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1047);stroke-width:0.972447;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2"
+     d="M 57.055382,50.514225 H 6.9446174 c -1.8909724,0 -2.3299378,-0.500088 -2.8366221,-2.500437 L 3.6354158,46.01344 c -0.9454864,-4.0007 2.8364585,-3.500611 4.727431,-3.500611 H 55.637154 c 1.890973,0 5.672916,-0.500089 4.72743,3.50061 l -0.472743,2.000349 c -0.472743,2.000349 -0.945485,2.500437 -2.836459,2.500437 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1077);stroke-width:0.972447;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2-2"
+     d="M 57.055382,50.014225 H 6.944617 c -1.890972,0 -2.329937,-0.500088 -2.836622,-2.500437 L 3.635416,45.51344 c -0.945487,-4.0007 2.836458,-3.500611 4.727431,-3.500611 h 47.274307 c 1.890973,0 5.672916,-0.500089 4.72743,3.50061 l -0.472743,2.000349 c -0.472743,2.000349 -0.945485,2.500437 -2.836459,2.500437 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 58.5,51.5 -0.75,2.75 h -2.5 l 0.5,-2.75 z"
+     id="path915-2"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
 </svg>

--- a/devices/64/drive-removable-media-usb.svg
+++ b/devices/64/drive-removable-media-usb.svg
@@ -6,13 +6,42 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg11300"
-   height="64"
-   width="64"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
-   viewBox="0 0 64 64">
+   width="64"
+   height="64"
+   id="svg3338"
+   sodipodi:docname="drive-removable-media-usb.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1288"
+     inkscape:window-height="796"
+     id="namedview82"
+     showgrid="true"
+     showguides="false"
+     inkscape:zoom="8.0704339"
+     inkscape:cx="17.1568"
+     inkscape:cy="32.262388"
+     inkscape:window-x="16"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3338"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid892" />
+  </sodipodi:namedview>
   <metadata
-     id="metadata49">
+     id="metadata83">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,182 +53,869 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3">
+     id="defs3340">
     <linearGradient
-       id="linearGradient4614">
+       inkscape:collect="always"
+       id="linearGradient987">
       <stop
-         id="stop4606"
-         style="stop-color:#ffffff;stop-opacity:1"
+         style="stop-color:#1a1a1a;stop-opacity:1;"
+         offset="0"
+         id="stop983" />
+      <stop
+         style="stop-color:#1a1a1a;stop-opacity:0.60000002"
+         offset="1"
+         id="stop985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1240">
+      <stop
+         id="stop1236"
+         style="stop-color:#fafafa;stop-opacity:0"
          offset="0" />
       <stop
-         id="stop4608"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
-      <stop
-         id="stop4610"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.9812181" />
-      <stop
-         id="stop4612"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1238"
+         style="stop-color:#1a1a1a;stop-opacity:0.502"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3742">
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.9375" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.41666666" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.44444445" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1084">
+      <stop
+         id="stop1080"
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1082"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1018">
+      <stop
+         id="stop1013"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1015"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient959">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop955" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.502"
+         offset="1"
+         id="stop957" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1101">
       <stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3734" />
+         id="stop1091" />
       <stop
-         offset="0.01900466"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3736" />
+         offset="0.25"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         id="stop1093" />
       <stop
-         offset="0.9812181"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3738" />
+         offset="0.67183787"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         id="stop1095" />
+      <stop
+         offset="0.83542866"
+         style="stop-color:#dddddd;stop-opacity:1"
+         id="stop1097" />
       <stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3740" />
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         id="stop1099" />
     </linearGradient>
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#555761;stop-opacity:1"
+         id="stop1043" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1018087,0,0,0.02745099,-4.7965709,43.268495)" />
     <radialGradient
-       id="radialGradient7374"
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
-       cy="41.636002"
-       cx="23.334999"
-       gradientTransform="matrix(0.61871386,0,0,0.14061988,17.56277,53.961714)"
-       r="22.627001">
+       gradientTransform="matrix(0.05979662,0,0,0.02745099,20.518506,43.268495)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.05979662,0,0,0.02745099,43.481506,43.268495)" />
+    <linearGradient
+       id="linearGradient2215">
       <stop
-         id="stop23421"
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop23423"
-         style="stop-opacity:0"
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
          offset="1" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient3600-8">
-      <stop
-         offset="0"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-2" />
-      <stop
-         offset="1"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-5" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.2289726,0,0,1.0632918,22.850217,-0.1995066)"
+       x1="29.736721"
+       y1="43.024384"
+       x2="29.736721"
+       y2="49.956097"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-8"
-       id="linearGradient5466-8-3"
-       y2="45.68882"
-       x2="11.098394"
-       y1="5.9702148"
-       x1="11.098394" />
+       gradientTransform="matrix(1.3573591,0,0,1.0098512,-7.3634079,6.5517759)" />
     <linearGradient
-       xlink:href="#linearGradient3742"
-       id="linearGradient3730"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.81791996,0,0,1.4890166,-55.31544,0.6569973)"
-       x1="118.57409"
-       y1="3.7037382"
-       x2="118.57409"
-       y2="31.67935" />
+       id="linearGradient3484">
+      <stop
+         id="stop3486"
+         style="stop-color:#969696;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3488"
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4614"
-       id="linearGradient4604"
+       x1="17.813944"
+       y1="29.796696"
+       x2="18.072828"
+       y2="10.000001"
+       id="linearGradient2553"
+       xlink:href="#linearGradient3484"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.81288992,0,0,1.4490643,-54.78462,-4.0592618)"
-       x1="116.7913"
-       y1="-37.80846"
-       x2="116.7913"
-       y2="-26.979191" />
+       gradientTransform="matrix(1.3526366,0,0,1.3652569,-0.463278,-2.8344302)" />
     <linearGradient
        id="linearGradient7056">
       <stop
-         offset="0"
+         id="stop7064"
          style="stop-color:#e6e6e6;stop-opacity:1"
-         id="stop7064" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop7060"
          style="stop-color:#c8c8c8;stop-opacity:1"
-         id="stop7060" />
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="11.734284"
+       cy="8.4900017"
+       r="23.047892"
+       fx="11.734284"
+       fy="8.4900017"
+       id="radialGradient2551"
+       xlink:href="#linearGradient7056"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-0.5297689,-5.4809546)" />
+    <radialGradient
+       cx="141.74666"
+       cy="206.42612"
+       r="78.728165"
+       fx="141.74666"
+       fy="206.42612"
+       id="radialGradient2547"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)" />
+    <linearGradient
+       id="linearGradient7609">
+      <stop
+         id="stop7611"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7677"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop7613"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.67183787" />
+      <stop
+         id="stop7617"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop7615"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="142.62215"
+       cy="191.85428"
+       r="78.728165"
+       fx="142.62215"
+       fy="191.85428"
+       id="radialGradient2544"
+       xlink:href="#linearGradient7609"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2540"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.5034274,0,0,0.4878048,62.920656,-2.103415)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2536"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-33.911844,-8.7733407)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2532"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,11.53557,-24.903099)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.2666667,0,0,1.2666667,0.6,-4.1333342)"
-       xlink:href="#linearGradient7056"
-       id="linearGradient4763"
-       x1="25"
-       y1="-35"
-       x2="25"
-       y2="-44.395805"
+       x1="7.0625"
+       y1="35.28125"
+       x2="24.6875"
+       y2="35.28125"
+       id="linearGradient2529"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)" />
+    <linearGradient
+       id="linearGradient4236">
+      <stop
+         id="stop4238"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4240"
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.277412"
+       y1="37.205811"
+       x2="12.221823"
+       y2="33.758667"
+       id="linearGradient2526"
+       xlink:href="#linearGradient4236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)" />
+    <linearGradient
+       id="linearGradient4035">
+      <stop
+         id="stop4037"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4039"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="0.47025558" />
+      <stop
+         id="stop4041"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="0.69348532" />
+      <stop
+         id="stop4043"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.83542866" />
+      <stop
+         id="stop4045"
+         style="stop-color:#a8a8a8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="127.31733"
+       cy="143.82751"
+       r="78.728165"
+       fx="127.31733"
+       fy="143.82751"
+       id="radialGradient2523"
+       xlink:href="#linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient4241"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop4243"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4245"
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="0.16" />
+      <stop
+         id="stop4247"
+         style="stop-color:#888888;stop-opacity:1"
+         offset="0.4675" />
+      <stop
+         id="stop4249"
+         style="stop-color:#555555;stop-opacity:1"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient2519"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5034273,0,0,0.4878048,1.0793577,-2.103415)" />
+    <linearGradient
+       id="linearGradient6310-8">
+      <stop
+         id="stop6312-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6314-6"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="24"
+       cy="42"
+       r="21"
+       fx="24"
+       fy="42"
+       id="radialGradient2516"
+       xlink:href="#linearGradient6310-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-1.1428547,32.14366)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5"
+       gradientTransform="matrix(1.1323845,-1.809244e-7,-2.7011291e-8,-0.2162162,-6.3970894,67.235857)"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1013"
+       x1="10"
+       y1="53"
+       x2="10"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1015"
+       x1="13"
+       y1="53"
+       x2="13"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1017"
+       x1="16"
+       y1="53"
+       x2="16"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1019"
+       x1="19"
+       y1="53"
+       x2="19"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1021"
+       x1="22"
+       y1="53"
+       x2="22"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1023"
+       x1="25"
+       y1="53"
+       x2="25"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1025"
+       x1="28"
+       y1="53"
+       x2="28"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1027"
+       x1="31"
+       y1="53"
+       x2="31"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1029"
+       x1="34"
+       y1="53"
+       x2="34"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1031"
+       x1="41"
+       y1="53"
+       x2="41"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-1,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1033"
+       x1="37"
+       y1="53"
+       x2="37"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient959"
+       id="linearGradient961"
+       x1="32"
+       y1="57"
+       x2="32"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999996"
+       y2="48.973789"
+       gradientTransform="matrix(0.97839212,0,0,0.99819206,0.69115353,-0.89218999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1047"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94548623,0,0,1.0001744,1.7444433,-5.995634)"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1084"
+       id="linearGradient1077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94548623,0,0,1.0001744,1.744443,-6.4956322)"
+       x1="31.999998"
+       y1="48.487175"
+       x2="31.999645"
+       y2="49.986916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="8"
+       y2="31.555555"
+       gradientTransform="matrix(-1,0,0,1,64,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1240"
+       id="linearGradient1233"
+       gradientUnits="userSpaceOnUse"
+       x1="56"
+       y1="52"
+       x2="56"
+       y2="55"
+       gradientTransform="translate(1.0000005)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1350"
+       x="-0.28333337"
+       width="1.5666667"
+       y="-0.31874995"
+       height="1.6374999">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.20659725"
+         id="feGaussianBlur1352" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1411"
+       x="-0.6075"
+       width="2.215"
+       y="-0.759375"
+       height="2.51875">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.6328125"
+         id="feGaussianBlur1413" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1539"
+       x="-0.30000065"
+       width="1.6000013"
+       y="-0.29999935"
+       height="1.5999987">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.12416061"
+         id="feGaussianBlur1541" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient987"
+       id="linearGradient989"
+       x1="32"
+       y1="31"
+       x2="32"
+       y2="12"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.94,0,0.83999998)" />
   </defs>
-  <path
-     id="path23417"
-     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
-     d="m 46,59.816784 a 14.000001,3.1818183 0 1 1 -28.000001,0 14.000001,3.1818183 0 1 1 28.000001,0 z" />
   <rect
-     id="rect3448"
-     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:#000000;stroke-width:1.00000012;stroke-opacity:0.29302326"
-     transform="scale(1,-1)"
-     rx="1.0000001"
-     ry="1.0000001"
-     height="19"
-     width="19"
-     y="-60.500004"
-     x="21.5" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="rect2723"
+     y="53.333332"
+     x="7.4204431"
+     height="6.6666665"
+     width="49.159065" />
   <path
-     style="opacity:0.1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
-     d="M 22,49.5 H 40"
-     id="path4538" />
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="path2725"
+     d="m 56.555559,53.333564 c 0,0 0,6.666297 0,6.666297 3.079373,0.01255 7.444439,-1.49358 7.444439,-3.333576 0,-1.839996 -3.436346,-3.332721 -7.444439,-3.332721 z" />
   <path
-     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67441863"
-     d="m 24.5,53.5 v 4 h 4 v -4 z m 9,0 v 4 h 4 v -4 z"
-     id="rect3450" />
-  <rect
-     id="rect3458"
-     style="opacity:0.4;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     transform="scale(1,-1)"
-     height="17"
-     width="17"
-     y="-59.5"
-     x="22.5" />
-  <rect
-     ry="2.5"
-     id="rect5391"
-     style="opacity:1;fill:url(#linearGradient5466-8-3);fill-opacity:1;stroke:none;stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     rx="2.5"
-     height="44"
-     width="26"
-     y="5"
-     x="18" />
-  <rect
-     ry="3"
-     id="rect5391-2"
-     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     rx="3"
-     height="45.000076"
-     width="27.000078"
-     y="4.4999609"
-     x="17.5" />
-  <rect
-     rx="2.0000002"
-     id="rect5391-2-0"
-     style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient3730);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     ry="2"
-     height="43"
-     width="25"
-     y="5.5"
-     x="18.5" />
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2727"
+     d="m 7.4444398,53.333564 c 0,0 0,6.666297 0,6.666297 C 4.3650531,60.012413 0,58.506281 0,56.666285 0,54.826289 3.4363598,53.333564 7.4444398,53.333564 Z" />
   <path
-     d="m 27.961933,41.867923 c 0,-1.858009 0.617533,-2.340038 1.373958,-2.988756 0.607264,-0.293144 0.704295,-0.493272 0.69631,-1.436051 -0.0087,-1.041847 -0.108537,-0.922837 -2.039534,-2.599089 -2.94832,-2.559235 -3.344823,-3.176389 -3.691,-5.744497 -0.255356,-1.894081 -0.07625,-1.47736 -0.809268,-2.205931 -1.349202,-1.340969 -1.118049,-3.307588 0.488095,-4.152812 1.446931,-0.761414 3.160971,0.04841 3.689545,1.743247 0.26052,0.83529 -0.364053,2.277785 -1.202717,2.777705 -0.767465,0.45752 -1.08586,-0.305261 -0.910357,1.38123 0.09713,0.933427 0.333842,2.006953 0.526014,2.385565 0.330046,0.650231 3.561984,3.711218 3.913542,3.711218 L 30,17 h -1.791537 c 0.829079,-1.43707 1.63634,-3.425076 2.439237,-4.871745 l 2.556617,4.872327 h -1.741356 l -0.0035,13.904202 c 0.242192,0 2.616688,-2.409856 3.415658,-3.494785 0.345217,-0.468764 0.304712,-1.635494 0.304712,-2.263572 C 35.179831,24.199183 35.492205,24 34.769714,24 H 34 v -5 h 5 v 5 h -1.343763 c -0.629576,0.07372 -1.079562,0.833238 -1.198411,1.883564 -0.177248,1.566377 -0.598118,2.656935 -3.067042,5.145625 l -1.931317,2.082733 v 5.427381 l 0.570726,0.340621 c 0.388082,0.187343 0.922547,0.792701 1.187706,1.345245 0.943986,1.97088 -0.369449,4.088667 -2.535235,4.088667 -1.569431,-0.05818 -2.721414,-0.863987 -2.721414,-2.4436 z"
-     style="opacity:0.2;fill:#ffffff;stroke-width:1;fill-opacity:1"
-     id="path4540" />
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345"
+     d="M 62,50 54,13.5 c -0.401924,-1.5 -2,-2 -3.5,-2 h -37 c -1.5,0 -3.154236,0.5 -3.5,2 L 2,50"
+     sodipodi:nodetypes="ccsscc" />
   <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50400102;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="m 2,50 8,-36.5 c 0.401924,-1.5 2,-2 3.5,-2 h 37 c 1.5,0 3.154236,0.5 3.5,2 L 62,50"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:1;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431"
+     d="M 58.5,56.5 H 5.5 C 3.5,56.5 3.0357254,56 2.499827,54 L 2,52 C 1,48 5,48.5 7,48.5 h 50 c 2,0 6,-0.5 5,3.5 l -0.5,2 c -0.5,2 -1,2.5 -3,2.5 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <rect
+     style="display:inline;opacity:0.3;fill:url(#radialGradient2516);fill-opacity:1;stroke:none;stroke-width:1"
+     id="rect6300-3"
+     y="49.183899"
+     x="3.0000002"
+     height="6.8160973"
+     width="58.000004" />
+  <g
+     id="g136"
+     style="display:none"
+     transform="translate(1)"
+     inkscape:groupmode="layer">
+    <path
+       style="display:inline;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:#9bdb4d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 57,52 -0.5,2 h -2 L 55,52 Z"
+       id="path915"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.598837;paint-order:normal"
+       d="M 4.972956,54.5 H 42.25 l 0.25,-3 H 4.5002209 Z"
+       id="rect917"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6,51.499999 v 2 h 2 v -2 z"
+       id="path928"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,51.499999 v 2 h 2 v -2 z"
+       id="path928-3"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12,51.499999 v 2 h 2 v -2 z"
+       id="path928-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 15,51.499999 v 2 h 2 v -2 z"
+       id="path928-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 18,51.499999 v 2 h 2 v -2 z"
+       id="path928-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 21,51.499999 v 2 h 2 v -2 z"
+       id="path928-35"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 24,51.499999 v 2 h 2 v -2 z"
+       id="path928-62"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 27,51.499999 v 2 h 2 v -2 z"
+       id="path928-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 30,51.499999 v 2 h 2 v -2 z"
+       id="path928-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1029);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 33,51.499999 v 2 h 2 v -2 z"
+       id="path928-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 36,51.499999 v 2 h 2 v -2 z"
+       id="path928-70"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1031);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 39,51.499999 v 2 h 2 v -2 z"
+       id="path928-93"
+       inkscape:connector-curvature="0" />
+    <g
+       id="path915-6"
+       transform="matrix(1.0028589,0,0,0.9815644,-1.1629934,0.97735801)"
+       style="opacity:1;filter:url(#filter1350)" />
+    <path
+       style="display:inline;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:#d1ff82;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter1411)"
+       d="m 57,52 -0.5,2 h -2 L 55,52 Z"
+       id="path915-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <ellipse
+       style="opacity:0.75;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00672;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter1539)"
+       id="path1417"
+       cx="55.850002"
+       cy="53.000004"
+       rx="0.49664137"
+       ry="0.49664351"
+       transform="matrix(1.5730654,0,0,1.5730994,-31.955706,-30.574244)" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:0.988243;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="M 57.927086,55.505668 H 6.0723098 c -1.9567841,0 -2.4110269,-0.499097 -2.9353453,-2.495481 L 2.6479377,51.013803 C 1.6695454,47.021033 5.5831137,47.52013 7.5398978,47.52013 H 56.459498 c 1.956785,0 5.870352,-0.499097 4.89196,3.493673 l -0.489196,1.996384 c -0.489196,1.996384 -0.978391,2.495481 -2.935176,2.495481 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1047);stroke-width:0.972447;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2"
+     d="M 57.055382,50.514225 H 6.9446174 c -1.8909724,0 -2.3299378,-0.500088 -2.8366221,-2.500437 L 3.6354158,46.01344 c -0.9454864,-4.0007 2.8364585,-3.500611 4.727431,-3.500611 H 55.637154 c 1.890973,0 5.672916,-0.500089 4.72743,3.50061 l -0.472743,2.000349 c -0.472743,2.000349 -0.945485,2.500437 -2.836459,2.500437 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.25;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1077);stroke-width:0.972447;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2-2"
+     d="M 57.055382,50.014225 H 6.944617 c -1.890972,0 -2.329937,-0.500088 -2.836622,-2.500437 L 3.635416,45.51344 c -0.945487,-4.0007 2.836458,-3.500611 4.727431,-3.500611 h 47.274307 c 1.890973,0 5.672916,-0.500089 4.72743,3.50061 l -0.472743,2.000349 c -0.472743,2.000349 -0.945485,2.500437 -2.836459,2.500437 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <path
+     style="display:none;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 58.5,51.5 -0.75,2.75 h -2.5 l 0.5,-2.75 z"
+     id="path915-2"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="m 31.455884,37.5 c -1.632358,0 -3.264705,-1.021738 -3.264705,-2.554342 0,-1.532621 1.632347,-2.554356 2.720589,-2.554356 v -0.739144 c -0.01047,-0.731806 0.292542,-0.648207 -1.940176,-1.825637 -3.408995,-1.797639 -3.86745,-2.231147 -4.267718,-4.035026 -0.295254,-1.330423 -0.0882,-1.037717 -0.93571,-1.549473 -1.56002,-0.941919 -1.292746,-2.323303 0.564353,-2.916992 1.673015,-0.534828 3.654874,0.03401 4.266041,1.224473 0.301222,0.586718 -0.420939,1.599957 -1.390642,1.951112 -0.887385,0.321362 -1.255529,-0.214426 -1.052603,0.970191 0.112307,0.655651 0.386011,1.409711 0.608208,1.675663 0.381611,0.456724 3.741752,2.606813 4.148247,2.606813 V 17.065222 L 28.735295,17.05176 C 29.809195,16.043476 32,14 32,14 l 3.264704,3.065222 -2.17647,-0.01305 v 8.602543 c 0.280036,0 2.917411,-1.692714 3.841221,-2.454794 0.399156,-0.329257 0.641385,-0.796799 0.641385,-1.237972 0,-0.665346 0.361183,-0.805266 -0.474199,-0.805266 h -0.890003 v -3.11778 H 41.25 v 3.117752 h -0.815839 c -0.727948,0.05181 -1.248245,0.277192 -1.385663,1.014953 -0.204944,1.100243 -0.980637,1.822361 -3.83533,3.570468 l -2.124934,1.540507 v 5.108697 c 1.088237,0 2.720589,1.021736 2.720589,2.554356 0,1.532604 -1.632352,2.554343 -3.264708,2.554343 z"
+     style="opacity:0.9;fill:url(#linearGradient989);fill-opacity:1;stroke-width:1.3108"
      id="path3690"
-     style="opacity:0.95;fill:#aaaaaa;stroke-width:1"
-     d="m 27.961933,40.867923 c 0,-1.858009 0.617533,-2.340038 1.373958,-2.988756 0.607264,-0.293144 0.704295,-0.493272 0.69631,-1.436051 -0.0087,-1.041847 -0.108537,-0.922837 -2.039534,-2.599089 -2.94832,-2.559235 -3.344823,-3.176389 -3.691,-5.744497 -0.255356,-1.894081 -0.07625,-1.47736 -0.809268,-2.205931 -1.349202,-1.340969 -1.118049,-3.307588 0.488095,-4.152812 1.446931,-0.761414 3.160971,0.04841 3.689545,1.743247 0.26052,0.83529 -0.364053,2.277785 -1.202717,2.777705 -0.767465,0.45752 -1.08586,-0.305261 -0.910357,1.38123 0.09713,0.933427 0.333842,2.006953 0.526014,2.385565 0.330046,0.650231 3.561984,3.711218 3.913542,3.711218 L 30,16 h -1.791537 c 0.829079,-1.43707 1.63634,-3.425076 2.439237,-4.871745 l 2.556617,4.872327 h -1.741356 l -0.0035,13.904202 c 0.242192,0 2.616688,-2.409856 3.415658,-3.494785 0.345217,-0.468764 0.304712,-1.635494 0.304712,-2.263572 C 35.179831,23.199183 35.492205,23 34.769714,23 H 34 v -5 h 5 v 5 h -1.343763 c -0.629576,0.07372 -1.079562,0.833238 -1.198411,1.883564 -0.177248,1.566377 -0.598118,2.656935 -3.067042,5.145625 l -1.931317,2.082733 v 5.427381 l 0.570726,0.340621 c 0.388082,0.187343 0.922547,0.792701 1.187706,1.345245 0.943986,1.97088 -0.369449,4.088667 -2.535235,4.088667 -1.569431,-0.05818 -2.721414,-0.863987 -2.721414,-2.4436 z" />
+     sodipodi:nodetypes="czccccccccsccccccccssscccccsccczcc" />
 </svg>

--- a/devices/64/drive-removable-media-usb.svg
+++ b/devices/64/drive-removable-media-usb.svg
@@ -13,7 +13,8 @@
    height="64"
    id="svg3338"
    sodipodi:docname="drive-removable-media-usb.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:label="front-usb3">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -28,9 +29,9 @@
      id="namedview82"
      showgrid="true"
      showguides="false"
-     inkscape:zoom="8.0704339"
-     inkscape:cx="17.1568"
-     inkscape:cy="32.262388"
+     inkscape:zoom="6.486602"
+     inkscape:cx="32.057258"
+     inkscape:cy="32.378932"
      inkscape:window-x="16"
      inkscape:window-y="30"
      inkscape:window-maximized="0"
@@ -56,9 +57,33 @@
      id="defs3340">
     <linearGradient
        inkscape:collect="always"
+       id="linearGradient1042">
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop1038" />
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="1"
+         id="stop1040" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1030">
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0"
+         id="stop1025" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:0.75"
+         offset="1"
+         id="stop1027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
        id="linearGradient987">
       <stop
-         style="stop-color:#1a1a1a;stop-opacity:1;"
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="0"
          id="stop983" />
       <stop
@@ -104,11 +129,11 @@
          offset="0.41666666" />
       <stop
          id="stop1102"
-         style="stop-color:#dddddd;stop-opacity:1"
+         style="stop-color:#4d4d4d;stop-opacity:1"
          offset="0.44444445" />
       <stop
          id="stop1104"
-         style="stop-color:#fafafa;stop-opacity:1"
+         style="stop-color:#1a1a1a;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -243,11 +268,11 @@
        id="linearGradient2215">
       <stop
          id="stop2223"
-         style="stop-color:#abacae;stop-opacity:1"
+         style="stop-color:#1a1a1a;stop-opacity:1"
          offset="0" />
       <stop
          id="stop2219"
-         style="stop-color:#d4d4d4;stop-opacity:1"
+         style="stop-color:#4d4d4d;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -493,15 +518,15 @@
          offset="1" />
     </linearGradient>
     <radialGradient
-       cx="24"
-       cy="42"
+       cx="23.933563"
+       cy="51.05397"
        r="21"
-       fx="24"
-       fy="42"
+       fx="23.933563"
+       fy="51.05397"
        id="radialGradient2516"
        xlink:href="#linearGradient6310-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-1.1428547,32.14366)" />
+       gradientTransform="matrix(1.6710353,-1.136226e-8,4.6475873e-8,0.38095237,-8.0855724,37.550869)" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient1045"
@@ -651,7 +676,7 @@
        y1="47.999744"
        x2="31.999996"
        y2="48.973789"
-       gradientTransform="matrix(0.97839212,0,0,0.99819206,0.69115353,-0.89218999)" />
+       gradientTransform="matrix(0.97839212,0,0,0.99819206,0.69115353,-0.39186659)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient1018"
@@ -747,9 +772,28 @@
        x1="32"
        y1="31"
        x2="32"
-       y2="12"
+       y2="-13.659575"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.94,0,0.83999998)" />
+       gradientTransform="matrix(1.0810812,0,0,0.94,-2.5945974,0.83999998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1030"
+       id="linearGradient1032"
+       x1="41"
+       y1="26"
+       x2="62"
+       y2="50"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1042"
+       id="linearGradient1036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3573591,0,0,1.0098512,-7.3634079,6.5517759)"
+       x1="29.736721"
+       y1="43.024384"
+       x2="29.736721"
+       y2="49.956097" />
   </defs>
   <rect
      style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
@@ -776,23 +820,37 @@
      sodipodi:nodetypes="ccsscc" />
   <path
      inkscape:connector-curvature="0"
-     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50400102;marker:none;enable-background:accumulate"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
      id="path6345-6"
      d="m 2,50 8,-36.5 c 0.401924,-1.5 2,-2 3.5,-2 h 37 c 1.5,0 3.154236,0.5 3.5,2 L 62,50"
      sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:none;opacity:1;fill:url(#linearGradient1032);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.972447;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3-2-7"
+     d="M 62,50 C 62,48 57,48.5 32,48.5 7,48.5 2,48 2,50 l 1,-4 c 0,0 0,-3.5 3,-3.5 h 52 c 3,0 3,3.513439 3,3.513439 z"
+     sodipodi:nodetypes="czccsscc" />
   <path
      inkscape:connector-curvature="0"
      style="display:inline;opacity:1;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
      id="rect6431"
      d="M 58.5,56.5 H 5.5 C 3.5,56.5 3.0357254,56 2.499827,54 L 2,52 C 1,48 5,48.5 7,48.5 h 50 c 2,0 6,-0.5 5,3.5 l -0.5,2 c -0.5,2 -1,2.5 -3,2.5 z"
      sodipodi:nodetypes="ccccscccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:none;opacity:1;fill:url(#linearGradient1036);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="path1034"
+     d="M 58.5,56.5 H 5.5 C 3.5,56.5 3.0357254,56 2.499827,54 L 2,52 C 1,48 5,48.5 7,48.5 h 50 c 2,0 6,-0.5 5,3.5 l -0.5,2 c -0.5,2 -1,2.5 -3,2.5 z"
+     sodipodi:nodetypes="ccccscccc" />
   <rect
-     style="display:inline;opacity:0.3;fill:url(#radialGradient2516);fill-opacity:1;stroke:none;stroke-width:1"
+     style="display:none;opacity:0.3;fill:url(#radialGradient2516);fill-opacity:1;stroke:none;stroke-width:1"
      id="rect6300-3"
      y="49.183899"
      x="3.0000002"
      height="6.8160973"
-     width="58.000004" />
+     width="58.000004"
+     inkscape:export-xdpi="700"
+     inkscape:export-ydpi="700" />
   <g
      id="g136"
      style="display:none"
@@ -893,7 +951,7 @@
      inkscape:connector-curvature="0"
      style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:0.988243;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
      id="rect6431-3"
-     d="M 57.927086,55.505668 H 6.0723098 c -1.9567841,0 -2.4110269,-0.499097 -2.9353453,-2.495481 L 2.6479377,51.013803 C 1.6695454,47.021033 5.5831137,47.52013 7.5398978,47.52013 H 56.459498 c 1.956785,0 5.870352,-0.499097 4.89196,3.493673 l -0.489196,1.996384 c -0.489196,1.996384 -0.978391,2.495481 -2.935176,2.495481 z"
+     d="M 57.927086,56.00599 H 6.0723098 c -1.9567841,0 -2.4110269,-0.499097 -2.9353453,-2.495481 L 2.6479377,51.514125 c -0.9783923,-3.99277 2.935176,-3.493673 4.8919601,-3.493673 H 56.459498 c 1.956785,0 5.870352,-0.499097 4.89196,3.493673 l -0.489196,1.996384 c -0.489196,1.996384 -0.978391,2.495481 -2.935176,2.495481 z"
      sodipodi:nodetypes="ccccscccc" />
   <path
      inkscape:connector-curvature="0"
@@ -914,8 +972,8 @@
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccc" />
   <path
-     d="m 31.455884,37.5 c -1.632358,0 -3.264705,-1.021738 -3.264705,-2.554342 0,-1.532621 1.632347,-2.554356 2.720589,-2.554356 v -0.739144 c -0.01047,-0.731806 0.292542,-0.648207 -1.940176,-1.825637 -3.408995,-1.797639 -3.86745,-2.231147 -4.267718,-4.035026 -0.295254,-1.330423 -0.0882,-1.037717 -0.93571,-1.549473 -1.56002,-0.941919 -1.292746,-2.323303 0.564353,-2.916992 1.673015,-0.534828 3.654874,0.03401 4.266041,1.224473 0.301222,0.586718 -0.420939,1.599957 -1.390642,1.951112 -0.887385,0.321362 -1.255529,-0.214426 -1.052603,0.970191 0.112307,0.655651 0.386011,1.409711 0.608208,1.675663 0.381611,0.456724 3.741752,2.606813 4.148247,2.606813 V 17.065222 L 28.735295,17.05176 C 29.809195,16.043476 32,14 32,14 l 3.264704,3.065222 -2.17647,-0.01305 v 8.602543 c 0.280036,0 2.917411,-1.692714 3.841221,-2.454794 0.399156,-0.329257 0.641385,-0.796799 0.641385,-1.237972 0,-0.665346 0.361183,-0.805266 -0.474199,-0.805266 h -0.890003 v -3.11778 H 41.25 v 3.117752 h -0.815839 c -0.727948,0.05181 -1.248245,0.277192 -1.385663,1.014953 -0.204944,1.100243 -0.980637,1.822361 -3.83533,3.570468 l -2.124934,1.540507 v 5.108697 c 1.088237,0 2.720589,1.021736 2.720589,2.554356 0,1.532604 -1.632352,2.554343 -3.264708,2.554343 z"
-     style="opacity:0.9;fill:url(#linearGradient989);fill-opacity:1;stroke-width:1.3108"
+     d="m 31.411768,37.5 c -1.764718,0 -3.52941,-1.021738 -3.52941,-2.554342 0,-1.532621 1.764692,-2.554356 2.941178,-2.554356 v -0.739144 c -0.01137,-0.731806 0.316258,-0.648207 -2.097495,-1.825637 -3.6854,-1.797639 -4.181025,-2.231147 -4.613751,-4.035026 -0.319187,-1.330423 -0.0954,-1.037717 -1.011567,-1.549473 -1.686515,-0.941919 -1.397566,-2.323303 0.610103,-2.916992 1.808663,-0.534828 3.951214,0.03401 4.611941,1.224473 0.325642,0.586718 -0.455074,1.599957 -1.503397,1.951112 -0.95934,0.321362 -1.357334,-0.214426 -1.137953,0.970191 0.121412,0.655651 0.417316,1.409711 0.657528,1.675663 0.412544,0.456724 4.045129,2.606813 4.484591,2.606813 V 17.065222 L 28.470589,17.05176 C 29.631564,16.043476 31.999999,14 31.999999,14 l 3.529409,3.065222 -2.352943,-0.01305 v 8.602543 c 0.302744,0 3.153959,-1.692714 4.152675,-2.454794 0.431518,-0.329257 0.69339,-0.796799 0.69339,-1.237972 0,-0.665346 0.390467,-0.805266 -0.51265,-0.805266 h -0.962164 v -3.11778 H 42 v 3.117752 h -0.881989 c -0.786972,0.05181 -1.349453,0.277192 -1.498014,1.014953 -0.221562,1.100243 -1.06015,1.822361 -4.146303,3.570468 l -2.297229,1.540507 v 5.108697 c 1.176478,0 2.941178,1.021736 2.941178,2.554356 0,1.532604 -1.7647,2.554343 -3.529414,2.554343 z"
+     style="opacity:0.9;fill:url(#linearGradient989);fill-opacity:1;stroke-width:1.36291"
      id="path3690"
      sodipodi:nodetypes="czccccccccsccccccccssscccccsccczcc" />
 </svg>


### PR DESCRIPTION
Updates the look of both SSD and removable USB drive icons

![128](https://user-images.githubusercontent.com/58219504/109400381-5ec88700-7940-11eb-9021-9acbe81e5444.png)
![ssd128](https://user-images.githubusercontent.com/58219504/109400382-5ec88700-7940-11eb-8e04-91dfd93131ce.png)

SSD:
- [x] 16px
- [x] 24px
- [x] 32px
- [x] 48px
- [x] 64px
- [x] 128px

USB:

- [ ] 16px
- [ ] 24px
- [ ] 32px
- [ ] 48px
- [x] 64px
- [ ] 128px

I've followed the HIG and tried to keep it within elementary's style - Though I still feel I should add something to the front of the USB drive, since it looks quite barren