### PR TITLE
SSD icons redesign

### DIFF
--- a/devices/128/drive-harddisk-solidstate.svg
+++ b/devices/128/drive-harddisk-solidstate.svg
@@ -1,171 +1,592 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="128" height="128" id="svg3486" sodipodi:docname="drive-harddisk-solidstate-128.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview82" showgrid="true" inkscape:zoom="1" inkscape:cx="46.669433" inkscape:cy="17.390444" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3486">
-    <inkscape:grid type="xygrid" id="grid1420" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="128"
+   height="128"
+   id="svg3338"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1380"
+     inkscape:window-height="796"
+     id="namedview82"
+     showgrid="true"
+     showguides="true"
+     inkscape:zoom="3.1848218"
+     inkscape:cx="32.705936"
+     inkscape:cy="84.936749"
+     inkscape:window-x="3"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g136"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid892" />
   </sodipodi:namedview>
-  <metadata id="metadata83">
+  <metadata
+     id="metadata83">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3488">
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+  <defs
+     id="defs3340">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1239">
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0"
+         id="stop1234" />
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:1"
+         offset="1"
+         id="stop1237" />
     </linearGradient>
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2624" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.2086243,0,0,0.05625201,-11.402788,87.091152)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2621" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.122534,0,0,0.05625201,40.472356,87.091152)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2618" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.122534,0,0,0.05625201,87.527672,87.091152)" />
-    <linearGradient id="linearGradient2215">
-      <stop id="stop2223" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1158">
+      <stop
+         id="stop1154"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1156"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2714" xlink:href="#linearGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.7797939,0,0,2.0106954,-16.614014,15.013338)" />
-    <linearGradient id="linearGradient3484">
-      <stop id="stop3486" style="stop-color:#969696;stop-opacity:1" offset="0" />
-      <stop id="stop3488" style="stop-color:#b4b4b4;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1144">
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:1"
+         offset="0"
+         id="stop1140" />
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:0"
+         offset="1"
+         id="stop1142" />
     </linearGradient>
-    <linearGradient x1="17.813944" y1="29.796696" x2="18.072828" y2="10.000001" id="linearGradient2710" xlink:href="#linearGradient3484" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.7717117,0,0,2.8041475,-2.5210903,-6.9397837)" />
-    <linearGradient id="linearGradient7056">
-      <stop id="stop7064" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1046">
+      <stop
+         style="stop-color:#1a1a1a;stop-opacity:1"
+         offset="0"
+         id="stop1042" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.79607844"
+         offset="1"
+         id="stop1044" />
     </linearGradient>
-    <radialGradient cx="11.734284" cy="8.4900017" r="23.047892" fx="11.734284" fy="8.4900017" id="radialGradient2708" xlink:href="#linearGradient7056" gradientUnits="userSpaceOnUse" gradientTransform="matrix(3.8158369,1.9550356,-1.297462,2.5920017,-2.657338,-12.37557)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient2704" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.9720948,-0.0142358,0.00719451,0.8190959,-77.067288,-77.616391)" />
-    <linearGradient id="linearGradient7609">
-      <stop id="stop7611" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop7677" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop7613" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop7617" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop7615" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.8888889" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient2701" xlink:href="#linearGradient7609" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.4932064,0,0,-0.3486482,-8.2964585,119.46245)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2697" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-1.0068548,0,0,0.9756095,124.84131,-3.2068583)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2693" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.7477745,-0.1585924,0.084228,0.6299819,-68.769481,-18.546726)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2689" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.7564903,0.1411284,-0.07792703,0.6130007,24.07117,-50.778011)" />
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.44444445" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient2686" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.8154099,0,0,2.6966282,0.4945617,11.359533)" />
-    <linearGradient id="linearGradient4236">
-      <stop id="stop4238" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient959">
+      <stop
+         style="stop-color:#555761;stop-opacity:0.502"
+         offset="0"
+         id="stop955" />
+      <stop
+         style="stop-color:#7e8087;stop-opacity:0.5"
+         offset="1"
+         id="stop957" />
     </linearGradient>
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient2683" xlink:href="#linearGradient4236" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.7758664,0,0,2.9914128,-1.725507,4.105388)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
     </linearGradient>
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient2680" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.5208152,-0.07516752,0.01692892,0.3022039,-21.928264,5.2860233)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient4241" gradientUnits="userSpaceOnUse">
-      <stop id="stop4243" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4245" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop4247" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop4249" style="stop-color:#555555;stop-opacity:1" offset="1" />
-    </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2676" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0068545,0,0,0.9756095,3.158733,-3.2068583)" />
-    <linearGradient id="linearGradient6310-8">
-      <stop id="stop6312-6" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop6314-6" style="stop-color:#ffffff;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         id="stop1043" />
     </linearGradient>
-    <radialGradient cx="24" cy="42" r="21" fx="24" fy="42" id="radialGradient2673" xlink:href="#linearGradient6310-8" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.8095237,-3.195635e-8,7.8140219e-8,1.0714284,-3.428568,61.499973)" />
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2714-3" xlink:href="#linearGradient4236" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.7797939,0,0,2.0106954,-16.614014,15.013338)" />
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4236" id="radialGradient937" cx="64" cy="106.49996" fx="64" fy="106.49996" r="62.535988" gradientTransform="matrix(1,0,0,0.12850201,0,92.814502)" gradientUnits="userSpaceOnUse" />
-    <linearGradient id="linearGradient1139" inkscape:collect="always">
-      <stop id="stop1135" offset="0" style="stop-color:#d1ff82;stop-opacity:1;" />
-      <stop id="stop1137" offset="1" style="stop-color:#9bdb4d;stop-opacity:1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1131" inkscape:collect="always">
-      <stop id="stop1127" offset="0" style="stop-color:#ffe16b;stop-opacity:1" />
-      <stop style="stop-color:#d39220;stop-opacity:1;" offset="0.51300955" id="stop1133" />
-      <stop id="stop1129" offset="1" style="stop-color:#f9c440;stop-opacity:1" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20361741,0,0,0.05517851,-9.5931423,88.768435)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11959325,0,0,0.05517851,41.037014,88.768435)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.11959325,0,0,0.05517851,86.963016,88.768435)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1101">
-      <stop id="stop1091" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop1093" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.25" />
-      <stop id="stop1095" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop1097" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop1099" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="29.736721"
+       y1="43.024384"
+       x2="29.736721"
+       y2="49.956097"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7455621,0,0,2.2649025,-15.621286,2.4757179)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1045">
-      <stop id="stop1041" style="stop-color:#333333;stop-opacity:1" offset="0" />
-      <stop id="stop1043" style="stop-color:#555761;stop-opacity:1" offset="1" />
-    </linearGradient>
-    <linearGradient gradientTransform="matrix(0.1018087,0,0,0.02745099,-82.243162,61.941754)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5048" id="linearGradient2566" y2="609.50507" x2="302.85715" y1="366.64789" x1="302.85715" />
-    <radialGradient gradientTransform="matrix(0.05979662,0,0,0.02745099,-56.928085,61.941754)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="radialGradient2563" fy="486.64789" fx="605.71429" r="117.14286" cy="486.64789" cx="605.71429" />
-    <radialGradient gradientTransform="matrix(-0.05979662,0,0,0.02745099,-33.965085,61.941754)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="radialGradient2560" fy="486.64789" fx="605.71429" r="117.14286" cy="486.64789" cx="605.71429" />
-    <linearGradient gradientTransform="matrix(1.3573591,0,0,1.0098512,-84.809999,25.225035)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2215" id="linearGradient2557" y2="49.999996" x2="30" y1="41" x1="29.9375" />
-    <linearGradient gradientTransform="matrix(1.3526366,0,0,1.3652569,-77.909869,15.838829)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3484" id="linearGradient2553" y2="10.000001" x2="18.072828" y1="29.796696" x1="17.813944" />
-    <radialGradient gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-77.97636,13.192304)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7056" id="radialGradient2551" fy="8.4900017" fx="11.734284" r="23.047892" cy="8.4900017" cx="11.734284" />
-    <radialGradient gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4035" id="radialGradient2547" fy="206.42612" fx="141.74666" r="78.728165" cy="206.42612" cx="141.74666" />
-    <radialGradient gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7609" id="radialGradient2544" fy="191.85428" fx="142.62215" r="78.728165" cy="191.85428" cx="142.62215" />
-    <radialGradient gradientTransform="matrix(-0.5034274,0,0,0.4878048,-14.525935,16.569844)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-5" id="radialGradient2540" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-111.35844,9.8999183)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-5" id="radialGradient2536" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,-65.911021,-6.22984)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-5" id="radialGradient2532" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <linearGradient gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="linearGradient2529" y2="35.28125" x2="24.6875" y1="35.28125" x1="7.0625" />
-    <linearGradient gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4236" id="linearGradient2526" y2="33.758667" x2="12.221823" y1="37.205811" x1="12.277412" />
-    <radialGradient gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4035" id="radialGradient2523" fy="143.82751" fx="127.31733" r="78.728165" cy="143.82751" cx="127.31733" />
-    <radialGradient gradientUnits="userSpaceOnUse" id="radialGradient4241-5" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654">
-      <stop offset="0" style="stop-color:#eeeeee;stop-opacity:1" id="stop4243-9" />
-      <stop offset="0.16" style="stop-color:#cecece;stop-opacity:1" id="stop4245-2" />
-      <stop offset="0.4675" style="stop-color:#888888;stop-opacity:1" id="stop4247-2" />
-      <stop offset="1" style="stop-color:#555555;stop-opacity:1" id="stop4249-8" />
-    </radialGradient>
-    <radialGradient gradientTransform="matrix(0.5034273,0,0,0.4878048,-76.367233,16.569844)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-5" id="radialGradient2519" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-78.589446,50.816919)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient6310-8" id="radialGradient2516" fy="42" fx="24" r="21" cy="42" cx="24" />
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(3.5489286,-0.00675717,-9.4880732e-4,-0.49834382,-43.10113,140.02951)" r="18.5" fy="75.09082" fx="25.960344" cy="75.09082" cx="25.960344" id="radialGradient925" xlink:href="#linearGradient1045" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,3.0000007,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="7" y1="53" x1="7" id="linearGradient1011" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.5000003,0,0,4.609689,4.4999971,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="10" y1="53" x1="10" id="linearGradient1013" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,6.0000014,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="13" y1="53" x1="13" id="linearGradient1015" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,7.5000003,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="16" y1="53" x1="16" id="linearGradient1017" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,9.000001,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="19" y1="53" x1="19" id="linearGradient1019" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,10.500001,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="22" y1="53" x1="22" id="linearGradient1021" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.5000003,0,0,4.609689,11.999993,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="25" y1="53" x1="25" id="linearGradient1023" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,13.500001,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="28" y1="53" x1="28" id="linearGradient1025" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,15.000002,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="31" y1="53" x1="31" id="linearGradient1027" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,16.500002,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="34" y1="53" x1="34" id="linearGradient1029" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.5000003,0,0,4.609689,17.999989,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="41" y1="53" x1="41" id="linearGradient1031" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.4999999,0,0,4.609689,18.000002,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="37" y1="53" x1="37" id="linearGradient1033" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.0994935,0,0,1.7761342,-3.3755811,13.364888)" r="1.6890616" fy="53" fx="58.063545" cy="53" cx="58.063545" id="radialGradient1141-6" xlink:href="#linearGradient1139" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.5000003,0,0,4.609689,23.999989,-136.31351)" gradientUnits="userSpaceOnUse" y2="52" x2="41" y1="53" x1="41" id="linearGradient1031-3" xlink:href="#linearGradient1131" inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960546"
+       cy="72.77832"
+       fx="25.960546"
+       fy="72.77832"
+       r="18.5"
+       gradientTransform="matrix(1.1351352,-1.8092439e-7,-2.7076904e-8,-0.21621619,-6.4687276,67.735856)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1013"
+       x1="10"
+       y1="53"
+       x2="10"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1015"
+       x1="13"
+       y1="53"
+       x2="13"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1017"
+       x1="16"
+       y1="53"
+       x2="16"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1019"
+       x1="19"
+       y1="53"
+       x2="19"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1021"
+       x1="22"
+       y1="53"
+       x2="22"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1023"
+       x1="25"
+       y1="53"
+       x2="25"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1025"
+       x1="28"
+       y1="53"
+       x2="28"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1027"
+       x1="31"
+       y1="53"
+       x2="31"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1029"
+       x1="34"
+       y1="53"
+       x2="34"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1031"
+       x1="41"
+       y1="53"
+       x2="41"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-1.0002299,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1033"
+       x1="37"
+       y1="53"
+       x2="37"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient959"
+       id="linearGradient961"
+       x1="32"
+       y1="57"
+       x2="32"
+       y2="48"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0227235,0,0,2.2428081,-0.72714822,-12.218662)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1158"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999645"
+       y2="49.354958"
+       gradientTransform="matrix(1.9843894,0,0,2.2468524,0.49950238,-12.84589)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000001,0,0,2.0100737,0,-0.6158463)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="10"
+       y2="32"
+       gradientTransform="matrix(-2.0000001,0,0,2.0100737,128.00001,-0.6158463)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1046"
+       id="linearGradient1080"
+       x1="57"
+       y1="53.03125"
+       x2="57"
+       y2="55.65625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.328001,0,0,2.5764055,-78.372068,-30.78697)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1144"
+       id="radialGradient1138"
+       cx="57.125"
+       cy="53.125"
+       fx="57.125"
+       fy="53.125"
+       r="2.875"
+       gradientTransform="matrix(2.7826089,0,0,2.3133625,-47.45653,-16.979329)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1239"
+       id="linearGradient1223"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4000005,0,0,1.5793438,-25.600039,22.069259)"
+       x1="57.125008"
+       y1="54.681816"
+       x2="57.125008"
+       y2="52.136364" />
   </defs>
-  <rect style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2624);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" id="rect2723" y="107.71581" x="13.632071" height="13.661199" width="100.73576" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2621);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" id="path2725" d="m 114.31876,107.71629 c 0,0 0,13.66044 0,13.66044 6.31019,0.0257 15.25499,-3.06061 15.25499,-6.8311 0,-3.77048 -7.04169,-6.82934 -15.25499,-6.82934 z" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2618);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" id="path2727" d="m 13.681244,107.71629 c 0,0 0,13.66044 0,13.66044 -6.310217,0.0257 -15.2549956,-3.06061 -15.2549956,-6.8311 0,-3.77048 7.0417191,-6.82934 15.2549956,-6.82934 z" />
-  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#linearGradient2714);fill-opacity:1;fill-rule:evenodd;stroke:#353537;stroke-width:0.9279989;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" id="rect6431" d="M 1.4640118,98.46396 H 126.53599 l -2.50078,16.072 H 4.2427776 Z" />
-  <rect style="display:inline;fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new" id="rect6381" y="96.278435" x="1.6722411" height="2.7934818" width="124.65551" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2708);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2710);stroke-width:0.99578357;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path6345" d="m 126.5021,98.502072 -18.87434,-72.27504 c -0.5337,-2.058171 -3.32939,-3.729178 -5.6797,-3.729178 H 25.401087 c -3.61082,0 -5.67995,0.55683 -6.441344,3.729178 L 1.4978917,98.431698" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path7046" d="M 125.49993,98.499962 H 2.5000713" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9007" d="m 14.993455,91.98533 c -0.126866,1.660488 -2.026799,3.014632 -4.241883,3.014632 -2.2140731,0 -3.8904862,-1.354144 -3.7424788,-3.014632 0.1470028,-1.65171 2.0459308,-2.985368 4.2388598,-2.985368 2.19394,7.83e-4 3.870352,1.333658 3.745502,2.985368 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2697);fill-opacity:1" id="path9009" d="m 13.560699,90.817522 c 0.202379,0.210719 0.433956,0.548297 0.433956,0.997072 0,0.03222 -0.002,0.06438 -0.004,0.09855 -0.0876,1.144388 -1.570694,2.111218 -3.238047,2.111218 -0.9494637,0 -1.8173717,-0.317072 -2.3208007,-0.849754 -0.2164704,-0.227316 -0.4631534,-0.603904 -0.418851,-1.105366 0.1016909,-1.134636 1.5827736,-2.093658 3.2360327,-2.093658 0.942416,7.8e-4 1.807303,0.315122 2.311736,0.841948 h 9e-6 l -10e-7,-1.4e-5 z" />
-  <path inkscape:connector-curvature="0" style="fill:#f0f0f0;fill-opacity:1" id="path9019" d="m 21.030997,25.61943 c 0.237579,1.052246 1.765539,1.627395 3.410643,1.278494 1.644356,-0.348742 2.77249,-1.487218 2.519216,-2.536133 -0.251792,-1.043405 -1.777218,-1.605485 -3.40587,-1.260071 -1.629338,0.346076 -2.759308,1.470812 -2.523989,2.51771 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2693);fill-opacity:1" id="path9021" d="m 21.994264,24.639666 c -0.132112,0.167962 -0.274955,0.422405 -0.236214,0.712195 0.0028,0.02071 0.007,0.04142 0.01151,0.06298 0.163859,0.725166 1.348799,1.11587 2.587114,0.853242 0.705149,-0.149536 1.322356,-0.491002 1.650254,-0.914267 0.141147,-0.180901 0.291825,-0.462913 0.215648,-0.779745 -0.173495,-0.716654 -1.356251,-1.102634 -2.5841,-0.842225 -0.699848,0.148949 -1.315048,0.488159 -1.644201,0.907803 l -4e-6,5e-6 -10e-6,1.7e-5 z" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9025" d="m 99.000772,24.430821 c -0.0373,1.06111 1.282028,2.178262 2.946298,2.488746 1.66353,0.31034 3.03124,-0.305538 3.05267,-1.369597 0.0213,-1.058417 -1.29873,-2.162557 -2.94637,-2.469933 -1.64846,-0.307015 -3.014472,0.295486 -3.052598,1.350784 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2689);fill-opacity:1" id="path9027" d="m 100.17053,23.897881 c -0.16888,0.104022 -0.369832,0.28367 -0.405681,0.565664 -0.0026,0.02011 -0.0037,0.04062 -0.0047,0.06249 -0.02574,0.731329 1.011481,1.546696 2.264241,1.780402 0.71337,0.133075 1.39078,0.05552 1.81158,-0.208618 0.18082,-0.112475 0.39622,-0.314526 0.40299,-0.635822 0.0142,-0.727174 -1.02197,-1.537352 -2.26413,-1.769086 -0.70814,-0.131596 -1.38308,-0.05531 -1.80415,0.20501 l -1e-5,-8e-6 -1e-4,-3.6e-5 z" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9091" d="m 113.00654,91.98533 c 0.12687,1.660488 2.0268,3.014632 4.24188,3.014632 2.21407,0 3.8905,-1.354144 3.74249,-3.014632 -0.14702,-1.65171 -2.04594,-2.985368 -4.23886,-2.985368 -2.19394,7.83e-4 -3.87035,1.333658 -3.74551,2.985368 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2676);fill-opacity:1" id="path9093" d="m 114.4393,90.817522 c -0.20238,0.210719 -0.43396,0.548297 -0.43396,0.997072 0,0.03222 0.002,0.06438 0.004,0.09855 0.0876,1.144388 1.57069,2.111218 3.23803,2.111218 0.94947,0 1.81738,-0.317072 2.32081,-0.849754 0.21646,-0.227316 0.46315,-0.603904 0.41885,-1.105366 -0.1017,-1.134636 -1.58277,-2.093658 -3.23603,-2.093658 -0.94243,7.8e-4 -1.8073,0.315122 -2.31174,0.841948 v 0 l 6e-5,-1.4e-5 z" />
-  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#radialGradient937);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.9279989;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new;opacity:0.323" id="rect6431-5" d="M 1.4640118,98.46396 H 126.53599 l -2.50078,16.072 H 4.2427776 Z" />
-  <path style="opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.59883722;paint-order:normal" d="m 10.424972,110.5 h 79.458714 l 0.644259,-6.91454 H 9.56596 Z" id="rect917" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 12,103.39031 V 108 h 3 v -4.60969 z" id="path928" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 18,103.39031 V 108 h 3 v -4.60969 z" id="path928-3" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 24,103.39031 V 108 h 3 v -4.60969 z" id="path928-6" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 30,103.39031 V 108 h 3 v -4.60969 z" id="path928-7" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 36,103.39031 V 108 h 3 v -4.60969 z" id="path928-5" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 42,103.39031 V 108 h 3 v -4.60969 z" id="path928-35" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 48,103.39031 V 108 h 3 v -4.60969 z" id="path928-62" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 54,103.39031 V 108 h 3 v -4.60969 z" id="path928-9" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 60,103.39031 V 108 h 3 v -4.60969 z" id="path928-1" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1029);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 66,103.39031 V 108 h 3 v -4.60969 z" id="path928-2" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 72,103.39031 V 108 h 3 v -4.60969 z" id="path928-70" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1031);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 78,103.39031 V 108 h 3 v -4.60969 z" id="path928-93" inkscape:connector-curvature="0" />
-  <path style="fill:url(#radialGradient1141-6);fill-opacity:1;stroke:#9bdb4d;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.54444442" d="m 120.91442,105.5 -0.62985,4 h -4.19898 l 0.62985,-4 z" id="path915-6" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="fill:url(#linearGradient1031-3);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 84,103.39031 V 108 h 3 v -4.60969 z" id="path928-93-1" inkscape:connector-curvature="0" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499999;marker:none"
+     id="rect2723"
+     y="108.99951"
+     x="14.840887"
+     height="13.400491"
+     width="98.318138" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499999;marker:none"
+     id="path2725"
+     d="m 113.11112,108.99997 c 0,0 0,13.39974 0,13.39974 6.15875,0.0252 14.88888,-3.0022 14.88888,-6.70073 0,-3.69853 -6.87269,-6.69901 -14.88888,-6.69901 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2727"
+     d="m 14.88888,108.99997 c 0,0 0,13.39974 0,13.39974 C 8.7301066,122.42494 0,119.39751 0,115.69898 c 0,-3.69853 6.8727199,-6.69901 14.88888,-6.69901 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345"
+     d="m 125.00001,99.887839 -17,-73.36769 c -0.80385,-3.015111 -4,-4.020148 -7,-4.020148 H 27.000001 c -3,0 -6.308472,1.005037 -7,4.020148 L 3.0778304,99.887839"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 3.0778304,99.887839 20.000001,26.520149 c 0.803848,-3.015111 4,-4.020148 7,-4.020148 h 74.000009 c 3,0 6.30847,1.005037 7,4.020148 l 17,73.36769"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:1;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431"
+     d="M 116.00001,114.50001 H 12.000001 c -6.0000007,0 -7.0000008,-3.9986 -7.0000008,-3.9986 0,0 -2,-7.00061 -2,-9.00079 0,-4.000357 1,-7.000621 6.9999998,-7.000621 h 108.00001 c 6,0 7,3.000264 7,7.000621 0,2.00018 -2,9.00079 -2,9.00079 0,0 -1,3.9986 -7,3.9986 z"
+     sodipodi:nodetypes="ccccscscc" />
+  <g
+     id="g136"
+     style="display:inline;stroke-width:0.499992"
+     transform="matrix(2.0000123,0,0,2.0000511,1.9999307,-0.00262588)">
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#555761;stroke-width:0.499992;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:normal"
+       d="M 4.9997701,55 H 42.25 l 0.24977,-3.5 H 4.25 Z"
+       id="rect917"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.9997701,51.5 v 2 h 2 v -2 z"
+       id="path928"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.9997701,51.5 v 2 H 10.99977 v -2 z"
+       id="path928-3"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 11.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 14.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 17.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 20.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-35"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 23.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-62"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 26.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 29.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1029);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 32.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 35.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-70"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1031);fill-opacity:1;stroke:none;stroke-width:0.499992px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 38.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-93"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.75;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="M 4.6570796,102.99995 C 3.6512682,95.075875 7.6745142,96.062779 13.709383,96.066384 l 100.581157,0.06009 c 6.03487,7e-6 10.05811,-1.050595 9.05228,6.873476"
+     sodipodi:nodetypes="cscc" />
+  <rect
+     style="opacity:1;fill:url(#linearGradient1080);fill-opacity:1;fill-rule:evenodd;stroke:#d4d4d4;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:normal"
+     id="rect1040"
+     width="12.000003"
+     height="8.5428152"
+     x="105.50001"
+     y="101.89791"
+     rx="4.4794679"
+     ry="4.2519183" />
+  <rect
+     style="fill:url(#linearGradient1223);fill-opacity:1;fill-rule:evenodd;stroke:#3a9104;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:stroke markers fill"
+     id="rect1040-9"
+     width="9.0000019"
+     height="5.5277028"
+     x="107.00001"
+     y="103.40546"
+     rx="3.1118183"
+     ry="2.7638514" />
+  <ellipse
+     style="display:inline;opacity:0.75;fill:url(#radialGradient1138);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.55;paint-order:stroke markers fill"
+     id="path1050-5"
+     cx="111.50001"
+     cy="105.91806"
+     rx="8"
+     ry="7.0352578" />
 </svg>

--- a/devices/16/drive-harddisk-solidstate.svg
+++ b/devices/16/drive-harddisk-solidstate.svg
@@ -1,50 +1,365 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" id="svg3297" height="16" width="16" version="1.0" sodipodi:docname="drive-harddisk-solidstate-16.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview26" showgrid="false" inkscape:zoom="1" inkscape:cx="5.808669" inkscape:cy="8.5528004" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3297">
-    <inkscape:grid type="xygrid" id="grid833" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3297"
+   height="16"
+   width="16"
+   version="1.0"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1423"
+     inkscape:window-height="794"
+     id="namedview26"
+     showgrid="true"
+     inkscape:zoom="21.509691"
+     inkscape:cx="2.9783842"
+     inkscape:cy="13.80559"
+     inkscape:window-x="50"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3297"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
   </sodipodi:namedview>
-  <metadata id="metadata58">
+  <metadata
+     id="metadata58">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3299">
-    <linearGradient id="linearGradient4472">
-      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop4474" />
-      <stop offset="0.02116842" style="stop-color:#ffffff;stop-opacity:0.23529412" id="stop4476" />
-      <stop offset="0.99223143" style="stop-color:#ffffff;stop-opacity:0.15686275" id="stop4478" />
-      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0.39215687" id="stop4480" />
+  <defs
+     id="defs3299">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
     </linearGradient>
-    <linearGradient id="linearGradient2215-9">
-      <stop offset="0" style="stop-color:#7a7a7a;stop-opacity:1" id="stop2223-6" />
-      <stop offset="1" style="stop-color:#474747;stop-opacity:1" id="stop2219-1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000025,0,0,0.99999998,5.9999966,-38.499997)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1308"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000025,0,0,0.99999998,4.0000014,-38.499997)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000025,0,0,0.99999998,1.9999999,-38.499997)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000025,0,0,0.99999998,-1.3e-6,-38.499997)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5"
+       gradientTransform="matrix(0.25801163,-6.0308013e-8,0,-0.07207191,-0.39419448,18.735792)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#555761;stop-opacity:1"
+         id="stop1043" />
     </linearGradient>
-    <linearGradient id="linearGradient7056-0">
-      <stop offset="0" style="stop-color:#e6e6e6;stop-opacity:1" id="stop7064-4" />
-      <stop offset="1" style="stop-color:#c8c8c8;stop-opacity:1" id="stop7060-2" />
+    <linearGradient
+       id="linearGradient1018">
+      <stop
+         id="stop1013"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1015"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient gradientTransform="matrix(1.1767008,1.0376968,-0.76927742,0.87232541,1.0363585,-3.2771526)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7056-0" id="radialGradient8215" fy="2.3117516" fx="4.1993008" r="7.9999995" cy="2.3117516" cx="4.1993008" />
-    <linearGradient gradientTransform="matrix(0.1242128,0,0,0.1863981,0.233129,-3.9907482)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2215-9" id="linearGradient8226" y2="104.28131" x2="53.99139" y1="87.89592" x1="53.99139" />
-    <linearGradient x1="23.99999" y1="7.3399634" x2="23.99999" y2="41.03442" id="linearGradient4161" xlink:href="#linearGradient4472" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.26751495,0,0,0.26751495,4.7162587,-0.01354682)" />
-    <linearGradient y2="54.887066" x2="23.99999" y1="50.676285" x1="23.99999" gradientTransform="matrix(0.26751495,0,0,0.26751495,4.7162587,-0.01354682)" gradientUnits="userSpaceOnUse" id="linearGradient4525" xlink:href="#linearGradient4472" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1018"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999996"
+       y2="48.973789"
+       gradientTransform="matrix(0.24455231,0,0,0.24897057,0.17405298,1.1831599)" />
+    <linearGradient
+       x1="29.000795"
+       y1="42.749775"
+       x2="29.000795"
+       y2="46.964066"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33752081,0,0,0.37646575,-1.7881039,-3.1203192)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="11.337756"
+       y2="31.566195"
+       gradientTransform="matrix(-0.2419978,0,0,0.25649829,15.743712,-0.45144559)" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.88746887" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25000003,0,0,0.2564103,0.09730899,-0.32780822)" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.48879358" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.53991425" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01494915,0,0,0.00686275,10.842686,11.810011)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01494915,0,0,0.00686275,5.101935,11.810011)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02545218,0,0,0.00686275,-1.2268337,11.810011)" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
   </defs>
-  <path style="fill:url(#radialGradient8215);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect2990" d="M 1.4897093,1.4657632 0.514749,12.488885 C 0.505,12.488885 0.5,12.491788 0.5,12.499999 l 14.999999,0 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478485 c 0,0 -0.187746,-0.74340135 -0.909635,-0.74340135 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576325 -0.8205124,0.96576325 z" />
-  <path style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;opacity:0.35" id="rect2990-0" d="M 1.4897093,1.465763 0.514749,12.488885 C 0.505,12.488885 0.5,12.491785 0.5,12.499995 l 14.999999,0 c 0,-0.0082 -0.005,-0.01111 -0.01475,-0.01111 L 14.479867,1.2478483 c 0,0 -0.187746,-0.74340136 -0.909635,-0.74340136 -0.688148,0 -10.5350353,-0.004447 -11.2600103,-0.004447 -0.75868,0 -0.8205124,0.96576326 -0.8205124,0.96576326 z" />
-  <path style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="rect2992" d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
-  <path style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;opacity:0.5" id="rect2992-2" d="m 15.49723,12.5 c -0.304165,2.535038 -0.22639,2.983925 -0.777167,2.983925 -0.21573,0.03617 -8.698317,0 -13.470165,0 C 0.651763,15.483925 0.802893,15.533245 0.5,12.5 Z" />
-  <path d="m 2.4980469,1.5019531 c -0.00136,0.00636 -0.00781,0.027344 -0.00781,0.027344 a 1.0015087,1.0015087 0 0 1 -0.00195,0.023437 l -0.8789062,9.9453126 12.78125,0 -0.892578,-9.9921876 C 12.708012,1.5058107 3.4947245,1.5020781 2.4980469,1.5019531 Z" id="path4266" style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4161);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;color:#000000;clip-rule:nonzero;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
-  <path d="m 1.578125,13.476562 c 0.035324,0.3836 0.082771,0.870078 0.1015625,1.03125 2.352568,8.41e-4 5.411826,0.0094 8.015625,0.01367 1.3716895,0.0023 2.6003495,0.0036 3.4980465,0.002 0.448849,-8.46e-4 0.815103,-0.0034 1.072266,-0.0059 0.0025,-2.4e-5 0.0034,2.4e-5 0.0059,0 0.02745,-0.171355 0.08454,-0.677932 0.125,-1.041016 l -12.818359,0 z" id="path4497" style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;color:#000000;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect835" width="1" height="1" x="2" y="13.6" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect837" width="1" height="0.99999958" x="4" y="13.6" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect839" width="1" height="1" x="6" y="13.6" />
-  <rect style="opacity:1;vector-effect:none;fill:#eabb43;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect841" width="1" height="0.98437452" x="8" y="13.615625" />
-  <rect style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect843" width="1" height="1" x="13" y="13.6" />
-  <circle style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="path845" cx="3.5" cy="2.5" r="0.5" />
-  <circle style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="path845-3" cx="2.5" cy="10.5" r="0.5" />
-  <circle style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="path845-6" cx="12.5" cy="2.5" r="0.5" />
-  <circle style="opacity:1;vector-effect:none;fill:#838383;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="path845-7" cx="13.5" cy="10.5" r="0.5" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.125;marker:none"
+     id="rect2723-5"
+     y="14.326221"
+     x="1.8274198"
+     height="1.6666666"
+     width="12.289766" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.125;marker:none"
+     id="path2725-6"
+     d="m 14.111198,14.326278 c 0,0 0,1.666575 0,1.666575 0.769844,0.0032 1.86111,-0.373395 1.86111,-0.833394 0,-0.459999 -0.859086,-0.833181 -1.86111,-0.833181 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.25;marker:none"
+     id="path2727-2"
+     d="m 1.833419,14.326278 c 0,0 0,1.666575 0,1.666575 -0.7698467,0.0032 -1.86111,-0.373395 -1.86111,-0.833394 0,-0.459999 0.8590899,-0.833181 1.86111,-0.833181 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.253186;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-91"
+     d="M 15.5,13.5 13.375,2 C 13.274518,1.6153845 12.875001,1.5 12.5,1.5 h -9 C 3.1250002,1.5 2.7114411,1.6153845 2.6250001,2 L 0.5,13.5"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 0.5,13.5 2.625,2 C 2.722265,1.6152526 3.1370034,1.5 3.5,1.5 h 9 c 0.362998,0 0.791326,0.1152526 0.875,0.5 L 15.5,13.5"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:#333333;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;enable-background:new"
+     id="rect6431-2"
+     d="M 14,15.500044 H 2 C 1,15.500044 0.5,15 0.5,13.75 0.5,13 1,12.5 2,12.5 h 12 c 1,0 1.5,0.5 1.5,1.25 0,1.25 -0.5,1.750044 -1.5,1.750044 z"
+     sodipodi:nodetypes="cccsccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="M 14.480361,15.249999 H 1.5190905 c -0.4891046,0 -0.60264395,-0.124486 -0.73369912,-0.622427 L 0.6631576,14.129631 C 0.41860514,13.133748 1.3968144,13.258234 1.885919,13.258234 h 12.227613 c 0.489105,0 1.467314,-0.124486 1.222762,0.871397 l -0.122276,0.497941 c -0.122276,0.497941 -0.244552,0.622427 -0.733657,0.622427 z"
+     sodipodi:nodetypes="ccccscccc" />
+  <g
+     id="path915"
+     style="fill:#9bdb4d;fill-opacity:0.75;stroke:none;stroke-width:0.700198;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.504001"
+     transform="matrix(0.49971766,0,0,0.5,0.008082,4.8e-7)" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.74902;fill-rule:evenodd;stroke:#68b723;stroke-width:0.287211;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 14.231394,13.518606 v 0.96279 h -1.212789 l 0.0021,-0.96279 z"
+     id="path1472"
+     sodipodi:nodetypes="ccccc" />
+  <g
+     id="rect917"
+     transform="matrix(0.5185453,0,0,0.5,0.33300186,-0.25)"
+     style="stroke:#333333;stroke-width:0.99963;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.504001"
+     inkscape:groupmode="layer" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.99;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.550975;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 2,14.5 h 9 v -1 H 1.75 Z"
+     id="path1478"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.499999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 3,13.5 v 1 h 1 v -1 z"
+     id="path928"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1259);fill-opacity:1;stroke:none;stroke-width:0.499999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 5,13.5 v 1 h 1 v -1 z"
+     id="path928-3"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1308);fill-opacity:1;stroke:none;stroke-width:0.499999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 7,13.5 v 1 h 1 v -1 z"
+     id="path928-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1394);fill-opacity:1;stroke:none;stroke-width:0.499999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 9,13.5 v 1 h 1 v -1 z"
+     id="path928-9"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/devices/24/drive-harddisk-solidstate.svg
+++ b/devices/24/drive-harddisk-solidstate.svg
@@ -1,122 +1,659 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="24" height="24" id="svg2" sodipodi:docname="drive-harddisk-solidstate-24.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview93" showgrid="true" inkscape:zoom="27.812867" inkscape:cx="18.934484" inkscape:cy="9.3374569" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg2">
-    <inkscape:grid type="xygrid" id="grid900" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="24"
+   height="24"
+   id="svg2"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1293"
+     inkscape:window-height="755"
+     id="namedview93"
+     showgrid="true"
+     inkscape:zoom="18.603563"
+     inkscape:cx="5.8603659"
+     inkscape:cy="1.8924988"
+     inkscape:window-x="16"
+     inkscape:window-y="39"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid900" />
   </sodipodi:namedview>
-  <metadata id="metadata88">
+  <metadata
+     id="metadata88">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs4">
-    <linearGradient id="linearGradient4075">
-      <stop id="stop4077" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4079" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.03367912" />
-      <stop id="stop4081" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4083" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4075">
+      <stop
+         id="stop4077"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4079"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03367912" />
+      <stop
+         id="stop4081"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4083"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="53.99139" y1="87.89592" x2="53.99139" y2="104.28131" id="linearGradient2872" xlink:href="#linearGradient2215-9" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.1904597,0,0,0.2485308,0.090799,-3.484712)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2877" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.02218262,0,0,0.01085997,16.259269,17.380799)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2880" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.02218262,0,0,0.01085997,7.7407365,17.380799)" />
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2883" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.03776775,0,0,0.01085997,-1.650341,17.380799)" />
-    <linearGradient id="linearGradient7056-0">
-      <stop id="stop7064-4" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060-2" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="53.99139"
+       y1="87.89592"
+       x2="53.99139"
+       y2="104.28131"
+       id="linearGradient2872"
+       xlink:href="#linearGradient2215-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1904597,0,0,0.2485308,0.090799,-3.484712)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2877"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02218262,0,0,0.01085997,16.259269,17.380799)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2880"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02218262,0,0,0.01085997,7.7407365,17.380799)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2883"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03776775,0,0,0.01085997,-1.650341,17.380799)" />
+    <linearGradient
+       id="linearGradient7056-0">
+      <stop
+         id="stop7064-4"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060-2"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient2215-9">
-      <stop id="stop2223-6" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219-1" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient2215-9">
+      <stop
+         id="stop2223-6"
+         style="stop-color:#7a7a7a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219-1"
+         style="stop-color:#474747;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="7.2203388" cy="4.2332726" r="12" fx="7.2203388" fy="4.2332726" id="radialGradient4072" xlink:href="#linearGradient7056-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.5193809,0.00371571,-0.00302474,1.2368318,-3.737301,0.06783288)" />
-    <linearGradient x1="23.99999" y1="51.346149" x2="23.99999" y2="53.354122" id="linearGradient4525" xlink:href="#linearGradient4472" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.42777307,0,0,0.51069006,6.7368356,-6.2528082)" />
-    <linearGradient id="linearGradient4472">
-      <stop id="stop4474" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4476" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.02116842" />
-      <stop id="stop4478" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4480" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    <radialGradient
+       cx="7.2203388"
+       cy="4.2332726"
+       r="12"
+       fx="7.2203388"
+       fy="4.2332726"
+       id="radialGradient4072"
+       xlink:href="#linearGradient7056-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5193809,0.00371571,-0.00302474,1.2368318,-3.737301,0.06783288)" />
+    <linearGradient
+       x1="23.99999"
+       y1="51.346149"
+       x2="23.99999"
+       y2="53.354122"
+       id="linearGradient4525"
+       xlink:href="#linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42777307,0,0,0.51069006,6.7368356,-6.2528082)" />
+    <linearGradient
+       id="linearGradient4472">
+      <stop
+         id="stop4474"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4476"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02116842" />
+      <stop
+         id="stop4478"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99223143" />
+      <stop
+         id="stop4480"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="23.99999" y1="6.5391083" x2="23.99999" y2="42.102226" id="linearGradient4161-4" xlink:href="#linearGradient4075" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.26232885,0,0,0.42474288,8.0835877,-0.81629626)" />
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient8490" xlink:href="#linearGradient6309" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.2092209,1.4719088)" />
-    <linearGradient id="linearGradient6309">
-      <stop id="stop6311" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop6313" style="stop-color:#bbbbbb;stop-opacity:0" offset="1" />
-    </linearGradient>
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient8487" xlink:href="#linearGradient4236-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.73758861,0,0,0.53932582,-2.7959675,2.1869583)" />
-    <linearGradient id="linearGradient4236-0">
-      <stop id="stop4238-4" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240-3" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
-    </linearGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient8447" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient4241" gradientUnits="userSpaceOnUse">
-      <stop id="stop4243" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4245" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop4247" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop4249" style="stop-color:#555555;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.5391083"
+       x2="23.99999"
+       y2="42.102226"
+       id="linearGradient4161-4"
+       xlink:href="#linearGradient4075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26232885,0,0,0.42474288,8.0835877,-0.81629626)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8447"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient4241"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop4243"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4245"
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="0.16" />
+      <stop
+         id="stop4247"
+         style="stop-color:#888888;stop-opacity:1"
+         offset="0.4675" />
+      <stop
+         id="stop4249"
+         style="stop-color:#555555;stop-opacity:1"
+         offset="1" />
     </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient8443" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient8471" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.18614571,-0.00314024,0.00137767,0.18068297,-15.012876,-20.635958)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8443"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8498"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <radialGradient
+       cx="113.0654"
+       cy="97.587898"
+       r="2.5631001"
+       fx="113.667"
+       fy="98"
+       id="radialGradient8494"
+       xlink:href="#radialGradient4241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04163856,0,0,0.01122713,-3.0867404,16.048711)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0244561,0,0,0.01122713,7.2668246,16.048711)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0244561,0,0,0.01122713,16.658421,16.048711)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40898817,0,0,0.41947507,-0.9205058,-3.8081848)" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.48879358" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.53991425" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient8464" xlink:href="#linearGradient7609-6" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.09247618,0,0,-0.08716215,-1.5555849,24.365579)" />
-    <linearGradient id="linearGradient7609-6">
-      <stop id="stop7611-3" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop7677-2" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop7613-4" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop7617-3" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop7615-6" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="11.337756"
+       y2="31.566195"
+       gradientTransform="matrix(-0.39589691,0,0,0.41961902,24.676267,-4.0104497)" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.88746887" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient8475" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.10005865,-0.02337636,0.00821684,0.05971738,-5.2741109,-0.9113469)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient8498" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient8494" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
+    <linearGradient
+       x1="29.000795"
+       y1="42.749775"
+       x2="29.000795"
+       y2="46.964066"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5175541,0,0,0.62816384,-3.0090837,-7.5696044)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960344"
+       cy="75.09082"
+       fx="25.960344"
+       fy="75.09082"
+       r="18.5"
+       gradientTransform="matrix(0.45868731,-1.2061608e-7,0,-0.14414387,-2.2563447,30.471591)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#555761;stop-opacity:1"
+         id="stop1043" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000006,0,0,2.0000008,-3.0000031,-84.000035)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000004,0,0,2.0000008,1.0000007,-84.000035)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1308"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999694,0,0,2.0000008,5.0000279,-84.000035)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9999997,0,0,2.0000008,8.9999955,-84.000035)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
   </defs>
-  <rect width="18.236429" height="2.6374204" x="2.8817775" y="21.362579" id="rect2723" style="opacity:0.40206185;fill:url(#linearGradient2883);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="m 21.109321,21.362672 c 0,0 0,2.637274 0,2.637274 1.142348,0.005 2.761647,-0.59088 2.761647,-1.318806 0,-0.727927 -1.274774,-1.318468 -2.761647,-1.318468 z" id="path2725" style="opacity:0.40206185;fill:url(#radialGradient2880);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="m 2.890679,21.362672 c 0,0 0,2.637274 0,2.637274 -1.142353,0.005 -2.761647,-0.59088 -2.761647,-1.318806 0,-0.727927 1.274779,-1.318468 2.761647,-1.318468 z" id="path2727" style="opacity:0.40206185;fill:url(#radialGradient2877);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 l 23,0 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.50000001 19.5,0.50000001 l -15,0 C 3.6666667,0.50000001 2.5992572,1.172599 2.5,2 z" id="rect2990" style="fill:url(#radialGradient4072);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 l 23,0 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.49999997 19.5,0.49999997 l -15,0 C 3.6666667,0.49999997 2.5992572,1.172599 2.5,2 z" id="rect2990-5" style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 0,-4.9e-5 z" id="rect2992" style="fill:url(#linearGradient2872);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 0,-4.9e-5 z" id="rect2992-0" style="opacity:0.5;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 1.8811692,21.468685 20.1351998,0.01866 c 0.0552,-0.198713 0.332357,-1.987316 0.332357,-1.987316 l -20.7291868,0 c 0,0 0.1806404,1.463168 0.26163,1.968656 z" id="path4497" style="opacity:0.2;color:#000000;fill:none;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="M 4.5,1.46875 C 4.3477124,1.46875 4.0083027,1.5891821 3.78125,1.75 3.5541973,1.9108179 3.4725109,2.0936491 3.46875,2.125 L 1.625,17.53125 l 20.75,0 L 20.53125,2.125 C 20.527489,2.0936468 20.445803,1.910818 20.21875,1.75 19.991697,1.589182 19.652287,1.46875 19.5,1.46875 l -15,0 z" id="path4034" style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <g transform="matrix(0.06610079,-0.01141585,0.00791914,0.04585394,-0.89214226,-6.4254019)" id="g9164">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9166" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9168" style="fill:url(#radialGradient8447);fill-opacity:1" />
+  <g
+     id="g1094"
+     style="display:none">
+    <rect
+       width="18.236429"
+       height="2.6374204"
+       x="2.8817775"
+       y="21.362579"
+       id="rect2723"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient2883);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="m 21.109321,21.362672 c 0,0 0,2.637274 0,2.637274 1.142348,0.005 2.761647,-0.59088 2.761647,-1.318806 0,-0.727927 -1.274774,-1.318468 -2.761647,-1.318468 z"
+       id="path2725"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient2880);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="m 2.890679,21.362672 c 0,0 0,2.637274 0,2.637274 -1.142353,0.005 -2.761647,-0.59088 -2.761647,-1.318806 0,-0.727927 1.274779,-1.318468 2.761647,-1.318468 z"
+       id="path2727"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient2877);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 h 23 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.50000001 19.5,0.50000001 H 4.5 C 3.6666667,0.50000001 2.5992572,1.172599 2.5,2 Z"
+       id="rect2990"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4072);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+    <path
+       d="M 2.5,2 0.522616,18.483328 c -0.014949,0 -0.022616,0.0044 -0.022616,0.01667 h 23 c 0,-0.01232 -0.0077,-0.01667 -0.02261,-0.01667 L 21.5,2 C 21.40074,1.172599 20.333333,0.49999997 19.5,0.49999997 H 4.5 C 3.6666667,0.49999997 2.5992572,1.172599 2.5,2 Z"
+       id="rect2990-5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 z"
+       id="rect2992"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2872);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 23.5,18.5 c -0.466387,3.38005 -0.351379,3.981514 -1.195903,3.981514 -0.330786,0.04823 -13.33742,0 -20.654254,0 -0.917139,0 -0.685406,0.06576 -1.149843,-3.978565 l 23,-0.0029 z"
+       id="rect2992-0"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 1.8811692,21.468685 20.1351998,0.01866 c 0.0552,-0.198713 0.332357,-1.987316 0.332357,-1.987316 H 1.6195392 c 0,0 0.1806404,1.463168 0.26163,1.968656 z"
+       id="path4497"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;stroke:url(#linearGradient4525);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="M 4.5,1.46875 C 4.3477124,1.46875 4.0083027,1.5891821 3.78125,1.75 3.5541973,1.9108179 3.4725109,2.0936491 3.46875,2.125 L 1.625,17.53125 h 20.75 L 20.53125,2.125 C 20.527489,2.0936468 20.445803,1.910818 20.21875,1.75 19.991697,1.589182 19.652287,1.46875 19.5,1.46875 Z"
+       id="path4034"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="matrix(0.06610079,-0.01141585,0.00791914,0.04585394,-0.89214226,-6.4254019)"
+       id="g9164">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9166"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9168"
+         style="fill:url(#radialGradient8447);fill-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.06707933,0,0,0.04653275,15.651438,-7.213077)"
+       id="g9170">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9172"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9174"
+         style="fill:url(#radialGradient8443);fill-opacity:1" />
+    </g>
+    <g
+       transform="matrix(-0.09781119,0,0,0.1076727,8.1622105,-3.8182515)"
+       id="g9158">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9160"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9162"
+         style="fill:url(#radialGradient8498);fill-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.09781119,0,0,0.1076727,15.777316,-3.8182515)"
+       id="g9190">
+      <path
+         d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z"
+         id="path9192"
+         style="fill:#e6e6e6;fill-opacity:1" />
+      <path
+         d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z"
+         id="path9194"
+         style="fill:url(#radialGradient8494);fill-opacity:1" />
+    </g>
+    <rect
+       style="opacity:1;vector-effect:none;fill:#0e141f;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal"
+       id="rect902"
+       width="11"
+       height="1"
+       x="2"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect904"
+       width="1"
+       height="1"
+       x="20"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect906"
+       width="1"
+       height="1"
+       x="3"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect908"
+       width="1"
+       height="1"
+       x="5"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect910"
+       width="1"
+       height="1"
+       x="7"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect912"
+       width="1"
+       height="1"
+       x="9"
+       y="20" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal"
+       id="rect914"
+       width="1"
+       height="1"
+       x="11"
+       y="20" />
   </g>
-  <g transform="matrix(0.06707933,0,0,0.04653275,15.651438,-7.213077)" id="g9170">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9172" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9174" style="fill:url(#radialGradient8443);fill-opacity:1" />
-  </g>
-  <g transform="matrix(-0.09781119,0,0,0.1076727,8.1622105,-3.8182515)" id="g9158">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9160" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9162" style="fill:url(#radialGradient8498);fill-opacity:1" />
-  </g>
-  <g transform="matrix(0.09781119,0,0,0.1076727,15.777316,-3.8182515)" id="g9190">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9192" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9194" style="fill:url(#radialGradient8494);fill-opacity:1" />
-  </g>
-  <rect style="opacity:1;vector-effect:none;fill:#0e141f;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-opacity:0.6;paint-order:normal" id="rect902" width="11" height="1" x="2" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect904" width="1" height="1" x="20" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect906" width="1" height="1" x="3" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect908" width="1" height="1" x="5" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect910" width="1" height="1" x="7" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect912" width="1" height="1" x="9" y="20" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect914" width="1" height="1" x="11" y="20" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.204494;marker:none"
+     id="rect2723-5"
+     y="20.16511"
+     x="1.9098734"
+     height="2.7265873"
+     width="20.105473" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.204494;marker:none"
+     id="path2725-6"
+     d="m 22.005551,20.165204 c 0,0 0,2.726438 0,2.726438 1.259428,0.0052 3.044687,-0.610857 3.044687,-1.363393 0,-0.752537 -1.405424,-1.363045 -3.044687,-1.363045 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.408988;marker:none"
+     id="path2727-2"
+     d="m 1.9196875,20.165204 c 0,0 0,2.726438 0,2.726438 C 0.6602549,22.896842 -1.125,22.280785 -1.125,21.528249 c 0,-0.752537 1.40543025,-1.363045 3.0446875,-1.363045 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.4142;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345-91"
+     d="M 23.5,20 20.75,2 C 20.612053,1 20,0.5 19,0.5 H 5.0003873 C 4,0.5 3.4027779,1 3.2500001,2 L 0.5,20"
+     sodipodi:nodetypes="ccsssc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 0.5,20 3.2499999,2 C 3.3786424,1 4,0.5 5.0013847,0.5 H 19 c 1,0 1.597222,0.5 1.75,1.5 l 2.75,18"
+     sodipodi:nodetypes="ccsssc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:#333333;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;enable-background:new"
+     id="rect6431-2"
+     d="M 21,23.499992 H 3 C 1,23.499992 0.5,22 0.5,20.5 c 0,-1.5 0.5,-2 2,-2 H 21 c 2,0 2.5,0.5 2.5,2 0,1.5 -0.5,2.999992 -2.5,2.999992 z"
+     sodipodi:nodetypes="cccsccc" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:0.74902;fill-rule:evenodd;stroke:#68b723;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 22,20 v 2 h -2.0028 l 0.0036,-2 z"
+     id="path1472"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.99;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="M 2.2025324,22.000001 H 17.797469 l 0.202532,-2 H 2.0000006 Z"
+     id="path1478" />
+  <path
+     style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.817979px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 3,20 v 2 h 2 v -2 z"
+     id="path928"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1259);fill-opacity:1;stroke:none;stroke-width:0.817979px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 7,20 v 2 h 2 v -2 z"
+     id="path928-3"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1308);fill-opacity:1;stroke:none;stroke-width:0.817979px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 11,20 v 2 h 2 v -2 z"
+     id="path928-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="display:inline;fill:url(#linearGradient1394);fill-opacity:1;stroke:none;stroke-width:0.817979px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 15,20 v 2 h 2 v -2 z"
+     id="path928-9"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/devices/32/drive-harddisk-solidstate.svg
+++ b/devices/32/drive-harddisk-solidstate.svg
@@ -1,127 +1,532 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="32" height="32" id="svg3786" sodipodi:docname="drive-harddisk-solidstate-32.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview95" showgrid="true" inkscape:zoom="41.7193" inkscape:cx="14.678206" inkscape:cy="2.5671693" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3786">
-    <inkscape:grid type="xygrid" id="grid902" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="32"
+   height="32"
+   id="svg3338"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1380"
+     inkscape:window-height="796"
+     id="namedview82"
+     showgrid="true"
+     showguides="true"
+     inkscape:zoom="24.894354"
+     inkscape:cx="5.6075393"
+     inkscape:cy="23.775158"
+     inkscape:window-x="3"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3338"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid892" />
   </sodipodi:namedview>
-  <metadata id="metadata90">
+  <metadata
+     id="metadata83">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3788">
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+  <defs
+     id="defs3340">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1239">
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0"
+         id="stop1234" />
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:1"
+         offset="1"
+         id="stop1237" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient1158">
+      <stop
+         id="stop1154"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1156"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2465" xlink:href="#linearGradient2215-9" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.6886478,0,0,0.5067185,-3.9708843,4.4552574)" />
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2471" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.07635654,0,0,0.02184879,1.4025717,30.138555)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2473" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.04484747,0,0,0.02184879,20.38888,30.138555)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2475" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.04484747,0,0,0.02184879,37.61113,30.138555)" />
-    <linearGradient id="linearGradient2215-9">
-      <stop id="stop2223-6" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219-1" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1144">
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:1"
+         offset="0"
+         id="stop1140" />
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:0"
+         offset="1"
+         id="stop1142" />
     </linearGradient>
-    <linearGradient id="linearGradient7056-0">
-      <stop id="stop7064-4" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060-2" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1046">
+      <stop
+         style="stop-color:#1a1a1a;stop-opacity:1"
+         offset="0"
+         id="stop1042" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.79607844"
+         offset="1"
+         id="stop1044" />
     </linearGradient>
-    <radialGradient cx="10" cy="7.2368369" r="16" fx="10" fy="7.2368369" id="radialGradient5024" xlink:href="#linearGradient7056-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.4045128,0,0,0.9375,-4.0451283,4.2154656)" />
-    <linearGradient id="linearGradient4472">
-      <stop id="stop4474" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4476" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.02116842" />
-      <stop id="stop4478" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4480" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.8888889" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="23.99999" y1="51.346149" x2="23.99999" y2="53.354122" id="linearGradient3171" xlink:href="#linearGradient4472" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.58810697,0,0,0.51394954,8.8319415,0.58279532)" />
-    <linearGradient x1="23.99999" y1="6.5391083" x2="23.99999" y2="42.102226" id="linearGradient3168-6" xlink:href="#linearGradient4075-8" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.26232885,0,0,0.42474288,5.0669059,6.097143)" />
-    <linearGradient id="linearGradient4075-8">
-      <stop id="stop4077-4" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4079-5" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.03367912" />
-      <stop id="stop4081-2" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4083-4" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.44444445" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3789" xlink:href="#radialGradient3437" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3437" gradientUnits="userSpaceOnUse">
-      <stop id="stop3439" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop3441" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop3443" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop3445" style="stop-color:#555555;stop-opacity:1" offset="1" />
-    </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3793" xlink:href="#radialGradient3437" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient3831" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.24573995,-0.00308859,0.00181873,0.17771138,-19.666102,-13.139935)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient959">
+      <stop
+         style="stop-color:#555761;stop-opacity:0.502"
+         offset="0"
+         id="stop955" />
+      <stop
+         style="stop-color:#7e8087;stop-opacity:0.5"
+         offset="1"
+         id="stop957" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient3820" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.12330157,0,0,-0.08625852,-2.074113,31.247748)" />
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient3827" xlink:href="#linearGradient5026" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.12092245,-0.01546848,0.00546562,0.04607914,-4.4169742,6.9719925)" />
-    <linearGradient id="linearGradient5026">
-      <stop id="stop5028" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop5030" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.27751356" />
-      <stop id="stop5032" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.52359134" />
-      <stop id="stop5034" style="stop-color:#dddddd;stop-opacity:1" offset="1" />
-      <stop id="stop5036" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
     </linearGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3797" xlink:href="#radialGradient3437" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient3801" xlink:href="#radialGradient3437" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.4956521,0,0,2.4956521,-223.97574,-53.226089)" />
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient4238" xlink:href="#linearGradient6309" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.79304646,0,0,0.53932582,-0.57833673,8.4719087)" />
-    <linearGradient id="linearGradient6309">
-      <stop id="stop6311" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop6313" style="stop-color:#bbbbbb;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         id="stop1043" />
     </linearGradient>
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient4235" xlink:href="#linearGradient4236-0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.79304646,0,0,0.53932582,-1.209199,9.1869582)" />
-    <linearGradient id="linearGradient4236-0">
-      <stop id="stop4238-4" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240-3" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05090435,0,0,0.0135875,-2.3982855,23.018175)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02989831,0,0,0.0135875,10.259253,23.018175)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02989831,0,0,0.0135875,21.740754,23.018175)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="29.736721"
+       y1="43.024384"
+       x2="29.736721"
+       y2="49.956097"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68639053,0,0,0.56048375,-3.9053216,1.046258)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960546"
+       cy="72.77832"
+       fx="25.960546"
+       fy="72.77832"
+       r="18.5"
+       gradientTransform="matrix(1.1351352,-1.8092439e-7,-2.7076904e-8,-0.21621619,-6.4687276,67.735856)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999992,0,0,2.0203116,1.0815023,-53.14997)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1013"
+       x1="10"
+       y1="53"
+       x2="10"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0271674,0,0,2.0203116,1.9456667,-53.14997)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1015"
+       x1="13"
+       y1="53"
+       x2="13"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0271672,0,0,2.0203116,2.9728337,-53.14997)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1017"
+       x1="16"
+       y1="53"
+       x2="16"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0271672,0,0,2.0203116,4.0000007,-53.14997)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1019"
+       x1="19"
+       y1="53"
+       x2="19"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0271672,0,0,2.0203116,5.027168,-53.14997)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1021"
+       x1="22"
+       y1="53"
+       x2="22"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0271672,0,0,2.0203116,6.054336,-53.14997)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient959"
+       id="linearGradient961"
+       x1="32"
+       y1="57"
+       x2="32"
+       y2="48"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50568087,0,0,0.55501618,-0.18178705,-2.590084)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1158"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999645"
+       y2="49.354958"
+       gradientTransform="matrix(0.49323096,0,0,0.56139405,0.21661122,-2.8985968)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50000002,0,0,0.49497316,0,0.30780862)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="10"
+       y2="32"
+       gradientTransform="matrix(-0.50000002,0,0,0.49497316,32.000001,0.30780862)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1046"
+       id="linearGradient1080"
+       x1="57"
+       y1="53.03125"
+       x2="57"
+       y2="55.65625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97066696,0,0,0.75396881,-27.379359,-13.579394)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1144"
+       id="radialGradient1138"
+       cx="57.125"
+       cy="53.125"
+       fx="57.125"
+       fy="53.125"
+       r="2.875"
+       gradientTransform="matrix(0.86956529,0,0,0.65764821,-21.673918,-8.4375634)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1239"
+       id="linearGradient1223"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.60000012,0,0,0.35714292,-6.2750117,7.4821386)"
+       x1="57.125008"
+       y1="54.681816"
+       x2="57.125008"
+       y2="52.136364" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1662"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0271672,0,0,2.0203116,10.163005,-53.14997)"
+       x1="22"
+       y1="53"
+       x2="22"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1678"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0271672,0,0,2.0203116,14.271674,-53.14997)"
+       x1="22"
+       y1="53"
+       x2="22"
+       y2="52" />
   </defs>
-  <path d="M 31.502339,25.502101 26.821023,8.3812814 C 26.688651,7.8937324 25.995252,7.4978971 25.412312,7.4978971 l -18.9855897,0 c -0.8955749,0 -1.4087718,0.1319037 -1.597617,0.8833843 L 0.49812296,25.485432" id="path6345" style="fill:url(#radialGradient5024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99578333;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="M 31.502339,25.502101 26.821023,8.381281 C 26.688651,7.893732 25.995252,7.4978967 25.412312,7.4978967 l -18.9855897,0 c -0.8955749,0 -1.4087718,0.1319037 -1.597617,0.8833843 L 0.49812296,25.485432 z" id="path6345-9" style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <g transform="matrix(0.6666596,0,0,0.6259973,-3.3331284,3.7969778)" id="g6029" style="display:inline;enable-background:new">
-    <rect width="36.869301" height="5.3061337" x="10.565332" y="38.149361" id="rect2723" style="opacity:0.40206185;fill:url(#linearGradient2471);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path d="m 47.41667,38.149545 c 0,0 0,5.30584 0,5.30584 2.30953,0.01 5.58333,-1.18877 5.58333,-2.65326 0,-1.46449 -2.57726,-2.65258 -5.58333,-2.65258 z" id="path2725" style="opacity:0.40206185;fill:url(#radialGradient2473);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path d="m 10.58333,38.149545 c 0,0 0,5.30584 0,5.30584 C 8.2737899,43.465375 5,42.266615 5,40.802125 c 0,-1.46449 2.5772699,-2.65258 5.58333,-2.65258 z" id="path2727" style="opacity:0.40206185;fill:url(#radialGradient2475);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="rect2723"
+     y="28"
+     x="3.7102218"
+     height="3.2998209"
+     width="24.579535" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="path2725"
+     d="m 28.277781,28.000114 c 0,0 0,3.299638 0,3.299638 C 29.817467,31.305964 32,30.56047 32,29.649721 32,28.738973 30.281827,28.000114 28.277781,28.000114 Z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none"
+     id="path2727"
+     d="m 3.72222,28.000114 c 0,0 0,3.299638 0,3.299638 C 2.1825266,31.305965 0,30.56047 0,29.649721 0,28.738973 1.71818,28.000114 3.72222,28.000114 Z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345"
+     d="M 31.5,24.5 27.000001,6.4949731 c -0.200962,-0.7424598 -1,-0.9899463 -1.75,-0.9899463 H 6.7500003 c -0.7500001,0 -1.5771181,0.2474865 -1.7500001,0.9899463 L 0.5,24.5"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#555761;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 0.5,24.5 5.0000002,6.4949731 c 0.200962,-0.7424598 1,-0.9899463 1.7500001,-0.9899463 H 25.250001 c 0.75,0 1.577118,0.2474865 1.75,0.9899463 L 31.5,24.5"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:1;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431"
+     d="M 29.000001,29.5 H 3.0000001 C 1.5000001,29.5 1,28.5 1,28.5 c 0,0 -0.5,-2.505027 -0.5,-3 0,-0.989947 -1e-7,-2 1.5,-2 h 28 c 1.5,0 1.5,1.010053 1.5,2 0,0.494973 -0.5,3 -0.5,3 0,0 -0.499999,1 -1.999999,1 z"
+     sodipodi:nodetypes="ccccscscc" />
+  <g
+     id="g136"
+     style="display:inline;stroke-width:1.01947;stroke-miterlimit:4;stroke-dasharray:none"
+     transform="matrix(0.48687003,0,0,0.4940749,0.55043499,0.3560766)">
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#555761;stroke-width:1.01947;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:normal"
+       d="M 5.0271671,55.441777 42.005191,55.413687 V 51.401155 H 3.9999998 Z"
+       id="rect917"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:1.01947;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 7.0815018,51.906231 v 2.020311 h 1.9999997 v -2.020311 z"
+       id="path928"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:1.01947;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.190171,51.906231 v 2.020311 h 2.054335 v -2.020311 z"
+       id="path928-3"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:1.01947;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 15.298841,51.906231 v 2.020311 h 2.054334 v -2.020311 z"
+       id="path928-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:1.01947;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.40751,51.906231 v 2.020311 h 2.054335 v -2.020311 z"
+       id="path928-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:1.01947;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23.516179,51.906231 v 2.020311 h 2.054335 v -2.020311 z"
+       id="path928-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:1.01947;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 27.624849,51.906231 v 2.020311 h 2.054335 v -2.020311 z"
+       id="path928-35"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1662);fill-opacity:1;stroke:none;stroke-width:1.01947;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.733518,51.906231 v 2.020311 h 2.054335 v -2.020311 z"
+       id="path928-35-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1678);fill-opacity:1;stroke:none;stroke-width:1.01947;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 35.842187,51.906231 v 2.020311 h 2.054335 v -2.020311 z"
+       id="path928-35-06"
+       inkscape:connector-curvature="0" />
   </g>
-  <rect width="31" height="1" x="0.5" y="25" id="rect6381" style="fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
-  <path d="m 0.50764664,25.485779 30.98450536,0 -0.619526,4.050331 -29.6765863,0 -0.68839306,-4.050331 z" id="rect6431" style="fill:url(#linearGradient2465);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
-  <path d="m 0.50764664,25.5 30.98450536,0 -0.619526,4 -29.6765863,0 -0.68839306,-4 z" id="rect6431-1" style="opacity:0.5;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 6.4375,8.5 c -0.4014515,0 -0.6181328,0.05924 -0.625,0.0625 -0.00687,0.00326 0.045405,-0.1181812 0,0.0625 L 1.78125,24.5 30.1875,24.5 25.84375,8.65625 a 1.0079748,1.0079748 0 0 1 0,-0.03125 c 0.03231,0.119003 0.01552,0.065777 -0.09375,0 C 25.640731,8.559223 25.474426,8.5 25.40625,8.5 L 6.4375,8.5 z" id="path4094" style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient3168-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 2.0163276,28.5 27.9776234,2e-6 c 0.07589,-0.199983 0.332492,-2 0.332492,-2 l -28.6075888,0 c 0,0 0.1861288,1.491284 0.2974734,1.999998 z" id="path4497" style="opacity:0.2;color:#000000;fill:none;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <g transform="matrix(0.06707933,0,0,0.04653275,2.4611632,-0.2130773)" id="g9164" style="display:inline;enable-background:new">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9166" style="fill:#f0f0f0;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9168" style="fill:url(#radialGradient3789);fill-opacity:1" />
-  </g>
-  <g transform="matrix(0.06707933,0,0,0.04653275,21.361163,-0.2130773)" id="g9170" style="display:inline;enable-background:new">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9172" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9174" style="fill:url(#radialGradient3793);fill-opacity:1" />
-  </g>
-  <g transform="matrix(-0.09781119,0,0,0.1076727,9.1622105,3.1817482)" id="g9158" style="display:inline;enable-background:new">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9160" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9162" style="fill:url(#radialGradient3797);fill-opacity:1" />
-  </g>
-  <g transform="matrix(0.09781119,0,0,0.1076727,22.777316,3.1817482)" id="g9190" style="display:inline;enable-background:new">
-    <path d="m 48.2999,190.27968 c 0.31446,4.2476 5.02375,7.71156 10.51419,7.71156 5.48794,0 9.6432,-3.46396 9.27634,-7.71156 -0.36437,-4.22514 -5.07117,-7.6367 -10.5067,-7.6367 -5.43803,0.002 -9.59329,3.41156 -9.28383,7.6367 z" id="path9192" style="fill:#e6e6e6;fill-opacity:1" />
-    <path d="m 51.85122,187.29238 c -0.50163,0.53906 -1.07563,1.40256 -1.07563,2.55056 0,0.0824 0.005,0.16471 0.01,0.25206 0.21713,2.9274 3.89322,5.40059 8.02602,5.40059 2.3534,0 4.50465,-0.81109 5.75248,-2.17371 0.53656,-0.58149 1.148,-1.54481 1.03819,-2.82758 -0.25206,-2.90244 -3.92316,-5.35567 -8.02103,-5.35567 -2.33593,0.002 -4.47969,0.8061 -5.73001,2.15375 z" id="path9194" style="fill:url(#radialGradient3801);fill-opacity:1" />
-  </g>
-  <rect style="opacity:1;vector-effect:none;fill:#d1ff82;fill-opacity:1;fill-rule:nonzero;stroke:#9bdb4d;stroke-opacity:0.60000002;paint-order:normal" id="rect904" width="1" height="1" x="28" y="27" />
-  <path style="opacity:1;vector-effect:none;fill:#95a3ab;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:0.6;paint-order:normal" d="M 2.7,27 H 17.1 L 17,28 H 2.8 Z" id="rect904-3" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:0.9;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect922" width="1" height="1" x="3" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect924" width="1" height="1" x="5" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect926" width="1" height="1" x="7" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect928" width="1" height="1" x="9" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect930" width="1" height="1" x="11" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect932" width="1" height="1" x="13" y="27" />
-  <rect style="opacity:1;vector-effect:none;fill:#f9c440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:0.6;paint-order:normal" id="rect932-6" width="1" height="1" x="15" y="27" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.75;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="M 1.25,26.046413 C 1,24.06652 2.0000001,24.313106 3.5000001,24.314007 l 25.0000009,0.01501 c 1.5,2e-6 2.5,-0.262499 2.25,1.717394"
+     sodipodi:nodetypes="cscc" />
+  <rect
+     style="display:inline;opacity:1;fill:url(#linearGradient1080);fill-opacity:1;fill-rule:evenodd;stroke:#d4d4d4;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:normal"
+     id="rect1040"
+     width="3.500001"
+     height="2.500001"
+     x="26.25"
+     y="25.25"
+     rx="1.3065115"
+     ry="1.244297" />
+  <rect
+     style="display:inline;fill:url(#linearGradient1223);fill-opacity:1;fill-rule:evenodd;stroke:#3a9104;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:stroke markers fill"
+     id="rect1040-9"
+     width="2.2500005"
+     height="1.25"
+     x="26.875"
+     y="25.875"
+     rx="0.77795458"
+     ry="0.625" />
+  <ellipse
+     style="display:inline;opacity:0.75;fill:url(#radialGradient1138);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.55;paint-order:stroke markers fill"
+     id="path1050-5"
+     cx="28"
+     cy="26.5"
+     rx="2.5"
+     ry="2" />
 </svg>

--- a/devices/48/drive-harddisk-solidstate.svg
+++ b/devices/48/drive-harddisk-solidstate.svg
@@ -1,173 +1,502 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="48" height="48" id="svg3786" sodipodi:docname="drive-harddisk-solidstate-48.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview87" showgrid="true" inkscape:zoom="1" inkscape:cx="17.862146" inkscape:cy="6.4289738" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3786">
-    <inkscape:grid type="xygrid" id="grid1385" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="48"
+   height="48"
+   id="svg3338"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1380"
+     inkscape:window-height="796"
+     id="namedview82"
+     showgrid="true"
+     showguides="true"
+     inkscape:zoom="13.83853"
+     inkscape:cx="19.71726"
+     inkscape:cy="28.365902"
+     inkscape:window-x="14"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3338"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid892" />
   </sodipodi:namedview>
-  <metadata id="metadata82">
+  <metadata
+     id="metadata83">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3788">
-    <linearGradient id="linearGradient4231">
-      <stop id="stop4233" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4235" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.00818416" />
-      <stop id="stop4237" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99223143" />
-      <stop id="stop4239" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+  <defs
+     id="defs3340">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1239">
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0"
+         id="stop1234" />
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:1"
+         offset="1"
+         id="stop1237" />
     </linearGradient>
-    <linearGradient id="linearGradient4170">
-      <stop id="stop4172" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop4174" style="stop-color:#ffffff;stop-opacity:0.23529412" offset="0.02783963" />
-      <stop id="stop4176" style="stop-color:#ffffff;stop-opacity:0.15686275" offset="0.99811679" />
-      <stop id="stop4178" style="stop-color:#ffffff;stop-opacity:0.39215687" offset="1" />
+    <linearGradient
+       id="linearGradient1158">
+      <stop
+         id="stop1154"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1156"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1144">
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:1"
+         offset="0"
+         id="stop1140" />
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:0"
+         offset="1"
+         id="stop1142" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1046">
+      <stop
+         style="stop-color:#1a1a1a;stop-opacity:1"
+         offset="0"
+         id="stop1042" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.79607844"
+         offset="1"
+         id="stop1044" />
     </linearGradient>
-    <linearGradient id="linearGradient2215">
-      <stop id="stop2223" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.8888889" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient7056">
-      <stop id="stop7064" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.44444445" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="11.734284" cy="8.4900017" r="23.047892" fx="11.734284" fy="8.4900017" id="radialGradient2927" xlink:href="#linearGradient7056" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3767077,0.69719425,-0.46810846,0.92434578,-0.04915651,-2.9386274)" />
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2933" xlink:href="#linearGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0017502,0,0,0.7596403,-5.0508975,4.9363745)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2936" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.04484747,0,0,0.02058824,32.61113,32.451372)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2939" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.04484747,0,0,0.02058824,15.38888,32.451372)" />
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2942" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.07635654,0,0,0.02058824,-3.5974283,32.451372)" />
-    <linearGradient x1="34.947395" y1="50.909214" x2="34.947395" y2="53.83601" id="linearGradient3308" xlink:href="#linearGradient4231" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.84051728,0,0,1.0278991,14.415778,-14.334416)" />
-    <linearGradient x1="23.99999" y1="6.2531767" x2="23.99999" y2="42.941334" id="linearGradient3311-4" xlink:href="#linearGradient4170" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.26232885,0,0,0.65751536,6.9297476,6.8105801)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient2923" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.35160878,-0.0050244,0.00260227,0.28909275,-27.02434,-25.217538)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient959">
+      <stop
+         style="stop-color:#555761;stop-opacity:0.502"
+         offset="0"
+         id="stop955" />
+      <stop
+         style="stop-color:#7e8087;stop-opacity:0.5"
+         offset="1"
+         id="stop957" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient2920" xlink:href="#linearGradient7609" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.18495239,0,0,-0.13074306,-3.1111723,45.048436)" />
-    <linearGradient id="linearGradient7609">
-      <stop id="stop7611" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop7677" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop7613" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop7617" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop7615" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
     </linearGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2965" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.32948872,0,0,0.34974643,41.963041,0.4938254)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient4241" gradientUnits="userSpaceOnUse">
-      <stop id="stop4243" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4245" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop4247" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop4249" style="stop-color:#555555;stop-opacity:1" offset="1" />
-    </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2959" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.22282769,-0.03752228,0.02509892,0.149051,-18.145918,0.5322802)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2953" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.22333209,0.03439303,-0.02300572,0.14938839,14.791441,-7.631841)" />
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient2908" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0212766,0,0,0.89887639,2.1092738,20.498378)" />
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient2905" xlink:href="#linearGradient4236" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0212766,0,0,0.89887639,0.3816013,20.266398)" />
-    <linearGradient id="linearGradient4236">
-      <stop id="stop4238" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         id="stop1043" />
     </linearGradient>
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient2902" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.19054222,-0.02505584,0.00619351,0.10073457,-7.4371744,4.4286863)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2947" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.32948872,0,0,0.34974643,6.0549235,0.4938254)" />
-    <linearGradient id="linearGradient1139" inkscape:collect="always">
-      <stop id="stop1135" offset="0" style="stop-color:#d1ff82;stop-opacity:1;" />
-      <stop id="stop1137" offset="1" style="stop-color:#9bdb4d;stop-opacity:1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1131" inkscape:collect="always">
-      <stop id="stop1127" offset="0" style="stop-color:#ffe16b;stop-opacity:1" />
-      <stop style="stop-color:#d39220;stop-opacity:1;" offset="0.51300955" id="stop1133" />
-      <stop id="stop1129" offset="1" style="stop-color:#f9c440;stop-opacity:1" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07635653,0,0,0.02051934,-3.5974283,33.393368)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04484747,0,0,0.02051934,15.38888,33.393368)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04484747,0,0,0.02051934,32.61113,33.393368)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1101">
-      <stop id="stop1091" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop1093" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.25" />
-      <stop id="stop1095" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop1097" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop1099" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="29.736721"
+       y1="43.024384"
+       x2="29.736721"
+       y2="49.956097"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0127073,0,0,0.9059609,-5.368507,-1.3097097)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1045">
-      <stop id="stop1041" style="stop-color:#333333;stop-opacity:1" offset="0" />
-      <stop id="stop1043" style="stop-color:#555761;stop-opacity:1" offset="1" />
-    </linearGradient>
-    <linearGradient gradientTransform="matrix(0.1018087,0,0,0.02745099,-69.338943,29.531208)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5048" id="linearGradient2566" y2="609.50507" x2="302.85715" y1="366.64789" x1="302.85715" />
-    <radialGradient gradientTransform="matrix(0.05979662,0,0,0.02745099,-44.023866,29.531208)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="radialGradient2563" fy="486.64789" fx="605.71429" r="117.14286" cy="486.64789" cx="605.71429" />
-    <radialGradient gradientTransform="matrix(-0.05979662,0,0,0.02745099,-21.060866,29.531208)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="radialGradient2560" fy="486.64789" fx="605.71429" r="117.14286" cy="486.64789" cx="605.71429" />
-    <linearGradient gradientTransform="matrix(1.3573591,0,0,1.0098512,-71.90578,-7.1855111)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2215" id="linearGradient2557" y2="49.999996" x2="30" y1="41" x1="29.9375" />
-    <linearGradient id="linearGradient3484">
-      <stop offset="0" style="stop-color:#969696;stop-opacity:1" id="stop3486" />
-      <stop offset="1" style="stop-color:#b4b4b4;stop-opacity:1" id="stop3488" />
-    </linearGradient>
-    <linearGradient gradientTransform="matrix(1.3526366,0,0,1.3652569,-65.00565,-16.571717)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3484" id="linearGradient2553" y2="10.000001" x2="18.072828" y1="29.796696" x1="17.813944" />
-    <radialGradient gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-65.072141,-19.218242)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7056" id="radialGradient2551" fy="8.4900017" fx="11.734284" r="23.047892" cy="8.4900017" cx="11.734284" />
-    <radialGradient gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4035" id="radialGradient2547" fy="206.42612" fx="141.74666" r="78.728165" cy="206.42612" cx="141.74666" />
-    <radialGradient gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7609" id="radialGradient2544" fy="191.85428" fx="142.62215" r="78.728165" cy="191.85428" cx="142.62215" />
-    <radialGradient gradientTransform="matrix(-0.5034274,0,0,0.4878048,-1.621716,-15.840702)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-8" id="radialGradient2540" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-98.454216,-22.510628)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-8" id="radialGradient2536" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <radialGradient gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,-53.006802,-38.640386)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-8" id="radialGradient2532" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <linearGradient gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient5060" id="linearGradient2529" y2="35.28125" x2="24.6875" y1="35.28125" x1="7.0625" />
-    <linearGradient gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4236" id="linearGradient2526" y2="33.758667" x2="12.221823" y1="37.205811" x1="12.277412" />
-    <radialGradient gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4035" id="radialGradient2523" fy="143.82751" fx="127.31733" r="78.728165" cy="143.82751" cx="127.31733" />
-    <radialGradient gradientUnits="userSpaceOnUse" id="radialGradient4241-8" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654">
-      <stop offset="0" style="stop-color:#eeeeee;stop-opacity:1" id="stop4243-7" />
-      <stop offset="0.16" style="stop-color:#cecece;stop-opacity:1" id="stop4245-9" />
-      <stop offset="0.4675" style="stop-color:#888888;stop-opacity:1" id="stop4247-2" />
-      <stop offset="1" style="stop-color:#555555;stop-opacity:1" id="stop4249-0" />
-    </radialGradient>
-    <radialGradient gradientTransform="matrix(0.5034273,0,0,0.4878048,-63.463014,-15.840702)" gradientUnits="userSpaceOnUse" xlink:href="#radialGradient4241-8" id="radialGradient2519" fy="98" fx="113.667" r="2.5631001" cy="97.587898" cx="113.0654" />
-    <linearGradient id="linearGradient6310-8">
-      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop6312-6" />
-      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0" id="stop6314-6" />
-    </linearGradient>
-    <radialGradient gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-65.685227,18.406373)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient6310-8" id="radialGradient2516" fy="42" fx="24" r="21" cy="42" cx="24" />
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.77483523,-1.809244e-7,-1.8482502e-8,-0.2162162,-2.9570507,53.735858)" r="18.5" fy="75.09082" fx="25.960344" cy="75.09082" cx="25.960344" id="radialGradient925" xlink:href="#linearGradient1045" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.99999995,0,0,2,-0.9999998,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="7" y1="53" x1="7" id="linearGradient1011" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.0000002,0,0,2,-1.0000022,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="10" y1="53" x1="10" id="linearGradient1013" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.99999924,0,0,2,-3.9999894,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="16" y1="53" x1="16" id="linearGradient1017" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.0000007,0,0,2,-4.0000134,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="19" y1="53" x1="19" id="linearGradient1019" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(1.0000007,0,0,2,-7.0000178,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="25" y1="53" x1="25" id="linearGradient1023" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.97384771,0,0,2,-6.2938899,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="28" y1="53" x1="28" id="linearGradient1025" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.99999999,0,0,2,-7.0000001,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="31" y1="53" x1="31" id="linearGradient1027" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <linearGradient gradientTransform="matrix(0.99999999,0,0,2,-10,-65.999998)" gradientUnits="userSpaceOnUse" y2="52" x2="37" y1="53" x1="37" id="linearGradient1033" xlink:href="#linearGradient1131" inkscape:collect="always" />
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.88806701,-14.819406,-7.5675518)" r="1.6890617" fy="53" fx="58.063544" cy="53" cx="58.063544" id="radialGradient1141" xlink:href="#linearGradient1139" inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960546"
+       cy="72.77832"
+       fx="25.960546"
+       fy="72.77832"
+       r="18.5"
+       gradientTransform="matrix(1.1351352,-1.8092439e-7,-2.7076904e-8,-0.21621619,-6.4687276,67.735856)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3305037,0,0,2.6756214,0.25738847,-86.962284)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient959"
+       id="linearGradient961"
+       x1="32"
+       y1="57"
+       x2="32"
+       y2="48"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74608651,0,0,0.89712314,0.12523226,-7.1874598)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1158"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999645"
+       y2="49.354958"
+       gradientTransform="matrix(0.71703657,0,0,0.6412769,1.0548742,5.4362955)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.75000002,0,0,0.74748991,0,0.15386605)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="10"
+       y2="32"
+       gradientTransform="matrix(-0.75000002,0,0,0.74748991,48.000001,0.15386605)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1046"
+       id="linearGradient1080"
+       x1="57"
+       y1="53.03125"
+       x2="57"
+       y2="55.65625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2480003,0,0,0.9801594,-29.952027,-12.228209)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1144"
+       id="radialGradient1138"
+       cx="57.125"
+       cy="53.125"
+       fx="57.125"
+       fy="53.125"
+       r="2.875"
+       gradientTransform="matrix(1.1304348,0,0,0.90426626,-23.326083,-8.289147)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1239"
+       id="linearGradient1223"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.79999999,0,0,0.50000005,-4.4500052,13.249997)"
+       x1="57.125008"
+       y1="54.681816"
+       x2="57.125008"
+       y2="52.136364" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1380"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3305037,0,0,2.6756214,5.5794033,-86.962284)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1396"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3305037,0,0,2.6756214,10.901416,-86.962284)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3305037,0,0,2.6756214,16.223429,-86.962284)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3305037,0,0,2.6756214,21.545444,-86.962284)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1444"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3305037,0,0,2.6756214,26.867459,-86.962284)"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52" />
   </defs>
-  <path d="M 46.55,36.601962 39.740367,10.827625 c -0.192553,-0.733973 -1.2012,-1.329879 -2.049166,-1.329879 l -27.617218,0 c -1.30274,0 -2.049257,0.198573 -2.323959,1.329879 L 1.45,36.576866 z" id="path6345" style="fill:url(#radialGradient2927);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99578345;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <rect width="36.869301" height="5" x="5.5653324" y="40" id="rect2723" style="opacity:0.3;fill:url(#linearGradient2942);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="m 42.41667,40.000174 c 0,0 0,4.999723 0,4.999723 C 44.7262,45.009311 48,43.879712 48,42.499715 48,41.119718 45.42274,40.000174 42.41667,40.000174 z" id="path2725" style="opacity:0.3;fill:url(#radialGradient2939);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="m 5.58333,40.000174 c 0,0 0,4.999723 0,4.999723 C 3.2737899,45.009311 0,43.879712 0,42.499715 0,41.119718 2.5772699,40.000174 5.58333,40.000174 z" id="path2727" style="opacity:0.3;fill:url(#radialGradient2936);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path d="M 46.55,36.5 39.740367,10.824766 c -0.192553,-0.731151 -1.2012,-1.3247661 -2.049166,-1.3247661 l -27.617218,0 c -1.30274,0 -2.049257,0.1978095 -2.323959,1.3247661 L 1.45,36.475001 z" id="path6345-1" style="opacity:0.35;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 10.0625,10.46875 c -0.6058109,0 -0.9673014,0.09427 -1.09375,0.15625 -0.1264486,0.06198 -0.1572339,0.02421 -0.25,0.40625 l -6.03125,24.5625 42.625,0.03125 -6.5,-24.5625 c -0.0041,-0.01553 -0.138916,-0.199012 -0.375,-0.34375 -0.236084,-0.144738 -0.549495,-0.25 -0.75,-0.25 l -27.625,0 z" id="path4129" style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient3311-4);stroke-width:1.00312006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" transform="matrix(1,0,0,0.99378882,0,0.09627324)" />
-  <path d="m 1.4638537,36.464001 45.0720003,0 -0.901202,6.072 -43.1694186,0 -1.0013797,-6.072 z" id="rect6431" style="fill:url(#linearGradient2933);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
-  <path d="m 1.4638537,36.5 45.0720003,0 -0.901202,6 -43.1694185,0 -1.0013798,-6 z" id="rect6431-3" style="opacity:0.5;color:#000000;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path d="m 3.3117397,41.499995 41.4657843,3e-6 c 0.108461,-0.399966 0.576759,-4 0.576759,-4 H 2.654475 c 0,0 0.4981314,2.982569 0.6572647,3.999997 z" id="path4497" style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;stroke:url(#linearGradient3308);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-  <path d="M 6.0158229,34.619284 C 5.9743059,35.214553 5.3525618,35.7 4.6276859,35.7 c -0.7245458,0 -1.2731445,-0.485447 -1.2247097,-1.080716 0.048106,-0.592121 0.6695217,-1.070225 1.3871481,-1.070225 0.7179564,2.81e-4 1.2665551,0.478104 1.2256986,1.070225 z" id="path9007" style="fill:#e1e1e1;fill-opacity:1" />
-  <path d="m 5.5469595,34.200637 c 0.066228,0.07554 0.1420102,0.196558 0.1420102,0.357441 0,0.01155 -6.602e-4,0.02308 -0.00132,0.03533 -0.028667,0.410252 -0.5140028,0.756851 -1.0596361,0.756851 -0.3107079,0 -0.5947269,-0.113668 -0.7594717,-0.304629 -0.070839,-0.08149 -0.1515649,-0.216493 -0.1370672,-0.396263 0.033278,-0.406755 0.5179556,-0.750556 1.0589773,-0.750556 0.3084014,2.8e-4 0.5914315,0.112968 0.7565052,0.301831 h 2.6e-6 z" id="path9009" style="fill:url(#radialGradient2965);fill-opacity:1" />
-  <path d="m 8.6135352,10.981804 c 0.070795,0.248957 0.526108,0.385035 1.0163294,0.302486 0.4899984,-0.08251 0.8261694,-0.351869 0.7506954,-0.600038 -0.07503,-0.246865 -0.5295895,-0.379851 -1.0149081,-0.298127 -0.4855218,0.08188 -0.8222397,0.347988 -0.7521167,0.595679 z" id="path9019" style="fill:#f0f0f0;fill-opacity:1" />
-  <path d="m 8.9005762,10.749996 c -0.039367,0.03974 -0.081933,0.09994 -0.070388,0.168502 8.287e-4,0.0049 0.0021,0.0098 0.00343,0.0149 0.048828,0.171572 0.4019255,0.264011 0.7709282,0.201874 0.2101265,-0.03538 0.3940466,-0.116169 0.4917566,-0.216312 0.04206,-0.0428 0.08696,-0.109523 0.06426,-0.184484 -0.0517,-0.169557 -0.4041467,-0.260879 -0.7700306,-0.199267 -0.2085465,0.03524 -0.3918682,0.115496 -0.4899513,0.214782 l -1.8e-6,1e-6 z" id="path9021" style="fill:url(#radialGradient2959);fill-opacity:1" />
-  <path d="m 36.912257,10.696563 c -0.01101,0.258593 0.37848,0.530843 0.869811,0.606508 0.491108,0.07563 0.894887,-0.07446 0.901213,-0.333771 0.0063,-0.257936 -0.383413,-0.527015 -0.869831,-0.601923 -0.486659,-0.07482 -0.889937,0.07201 -0.901193,0.329186 z" id="path9025" style="fill:#e1e1e1;fill-opacity:1" />
-  <path d="m 37.257597,10.566686 c -0.04986,0.02535 -0.109185,0.06913 -0.119768,0.137852 -7.6e-4,0.0049 -0.0011,0.0099 -0.0014,0.01523 -0.0076,0.178225 0.298614,0.37693 0.668452,0.433884 0.210602,0.03243 0.410591,0.01353 0.534819,-0.05084 0.05338,-0.02741 0.116973,-0.07665 0.118971,-0.15495 0.0042,-0.177212 -0.301707,-0.374653 -0.668419,-0.431126 -0.209057,-0.03207 -0.408312,-0.01348 -0.532624,0.04996 l -2e-6,-1e-6 z" id="path9027" style="fill:url(#radialGradient2953);fill-opacity:1" />
-  <path d="M 42.002142,34.619284 C 42.043662,35.214553 42.665403,35.7 43.390279,35.7 c 0.724546,0 1.273145,-0.485447 1.22471,-1.080716 -0.04811,-0.592121 -0.669522,-1.070225 -1.387148,-1.070225 -0.717957,2.81e-4 -1.266555,0.478104 -1.225699,1.070225 z" id="path9091" style="fill:#e1e1e1;fill-opacity:1" />
-  <path d="m 42.471006,34.200637 c -0.06623,0.07554 -0.142011,0.196558 -0.142011,0.357441 0,0.01155 6.6e-4,0.02308 0.0013,0.03533 0.02867,0.410252 0.514002,0.756851 1.059636,0.756851 0.310708,0 0.594727,-0.113668 0.759471,-0.304629 0.07084,-0.08149 0.151565,-0.216493 0.137068,-0.396263 -0.03328,-0.406755 -0.517956,-0.750556 -1.058978,-0.750556 -0.308401,2.8e-4 -0.591431,0.112968 -0.756505,0.301831 h -2e-6 z" id="path9093" style="fill:url(#radialGradient2947);fill-opacity:1" />
-  <path style="fill:url(#radialGradient1141);fill-opacity:1;stroke:#9bdb4d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.54444442" d="m 44.380594,38.5 -0.3,2 h -2 l 0.3,-2 z" id="path915" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.59883722;paint-order:normal" d="M 4.2,40.5 H 30.258207 L 30.5,38.5 H 3.9 Z" id="rect917" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 5.0000001,38 v 2 H 7 v -2 z" id="path928" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 8,38 v 2 h 2 v -2 z" id="path928-3" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 11,38 v 2 h 1.999999 v -2 z" id="path928-7" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 14,38 v 2 h 2 v -2 z" id="path928-5" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 17,38 v 2 h 2 v -2 z" id="path928-62" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 20,38 v 2 h 1.947694 v -2 z" id="path928-9" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 23,38 v 2 h 2 v -2 z" id="path928-1" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 26,38 v 2 h 2 v -2 z" id="path928-70" inkscape:connector-curvature="0" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="rect2723"
+     y="40.916733"
+     x="5.5653324"
+     height="4.9832659"
+     width="36.869301" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="path2725"
+     d="m 42.41667,40.916905 c 0,0 0,4.98299 0,4.98299 C 44.7262,45.909276 48,44.783459 48,43.408081 48,42.032702 45.42274,40.916905 42.41667,40.916905 Z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2727"
+     d="m 5.58333,40.916905 c 0,0 0,4.98299 0,4.98299 C 3.2737899,45.909277 0,44.783459 0,43.408081 0,42.032702 2.5772699,40.916905 5.58333,40.916905 Z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345"
+     d="M 46.5,37.5 40.5,10 C 40.231151,9 39,8.5 38,8.5 H 10 C 9,8.5 7.7312836,9 7.5000002,10 L 1.5,37.5"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 1.5,37.5 7.5000002,10 C 7.7688493,9 9,8.5 10,8.5 h 28 c 1,0 2.268718,0.5 2.500001,1.5 L 46.5,37.5"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:1;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431"
+     d="M 43.180328,43.5 H 4.8196722 C 2.6065575,43.5 2.2377049,41.900561 2.2377049,41.900561 2.2377049,41.900561 1.5,39.100315 1.5,38.300246 1.5,36.700106 1.8688525,35.5 4.0819673,35.5 H 43.918033 c 2.213115,0 2.581967,1.200106 2.581967,2.800246 0,0.800069 -0.737705,3.600315 -0.737705,3.600315 0,0 -0.368852,1.599439 -2.581967,1.599439 z"
+     sodipodi:nodetypes="ccccscscc" />
+  <g
+     id="g136"
+     style="display:inline;stroke-width:1.33415"
+     transform="matrix(0.75159506,0,0,0.74748991,0.8065479,0.00343218)">
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#555761;stroke-width:1.33415;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:normal"
+       d="M 4.9141516,55.514552 H 42.168255 L 42.667194,51.50112 4.25,51.5 Z"
+       id="rect917"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:1.33415px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.2404109,52.170026 v 2.675621 h 2.6610051 v -2.675621 z"
+       id="path928"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1380);fill-opacity:1;stroke:none;stroke-width:1.33415px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 13.562422,52.170026 v 2.675621 h 2.661007 v -2.675621 z"
+       id="path928-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1396);fill-opacity:1;stroke:none;stroke-width:1.33415px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 18.884437,52.170026 v 2.675621 h 2.661008 v -2.675621 z"
+       id="path928-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1412);fill-opacity:1;stroke:none;stroke-width:1.33415px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 24.206451,52.170026 v 2.675621 h 2.661008 v -2.675621 z"
+       id="path928-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1428);fill-opacity:1;stroke:none;stroke-width:1.33415px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 29.528466,52.170026 v 2.675621 h 2.661008 v -2.675621 z"
+       id="path928-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1444);fill-opacity:1;stroke:none;stroke-width:1.33415px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 34.850481,52.170026 v 2.675621 h 2.661008 v -2.675621 z"
+       id="path928-61"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.75;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:0.99999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="m 2.5571675,38.499999 c -0.3634386,-2.261618 1.0903157,-1.979944 3.270947,-1.978917 l 36.3438555,0.01716 c 2.180631,3e-6 3.634386,-0.299851 3.270947,1.961768"
+     sodipodi:nodetypes="cscc" />
+  <rect
+     style="opacity:1;fill:url(#linearGradient1080);fill-opacity:1;fill-rule:evenodd;stroke:#d4d4d4;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:normal"
+     id="rect1040"
+     width="4.500001"
+     height="3.2500012"
+     x="39"
+     y="38.25"
+     rx="1.6798005"
+     ry="1.617586" />
+  <rect
+     style="fill:url(#linearGradient1223);fill-opacity:1;fill-rule:evenodd;stroke:#3a9104;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:stroke markers fill"
+     id="rect1040-9"
+     width="3"
+     height="1.75"
+     x="39.75"
+     y="39"
+     rx="1.0372726"
+     ry="0.875" />
+  <ellipse
+     style="display:inline;opacity:0.75;fill:url(#radialGradient1138);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.55;paint-order:stroke markers fill"
+     id="path1050-5"
+     cx="41.25"
+     cy="39.75"
+     rx="3.25"
+     ry="2.75" />
 </svg>

--- a/devices/64/drive-harddisk-solidstate.svg
+++ b/devices/64/drive-harddisk-solidstate.svg
@@ -1,146 +1,591 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" width="64" height="64" id="svg3338" sodipodi:docname="drive-harddisk-solidstate.svg" inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="962" id="namedview82" showgrid="false" showguides="false" inkscape:zoom="22.627417" inkscape:cx="16.321056" inkscape:cy="10.875431" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg3338">
-    <inkscape:grid type="xygrid" id="grid892" />
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="64"
+   height="64"
+   id="svg3338"
+   sodipodi:docname="drive-harddisk-solidstate.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1380"
+     inkscape:window-height="796"
+     id="namedview82"
+     showgrid="true"
+     showguides="true"
+     inkscape:zoom="10.968182"
+     inkscape:cx="11.124402"
+     inkscape:cy="49.964714"
+     inkscape:window-x="3"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3338"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid892" />
   </sodipodi:namedview>
-  <metadata id="metadata83">
+  <metadata
+     id="metadata83">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs3340">
-    <linearGradient inkscape:collect="always" id="linearGradient1139">
-      <stop style="stop-color:#d1ff82;stop-opacity:1;" offset="0" id="stop1135" />
-      <stop style="stop-color:#9bdb4d;stop-opacity:1" offset="1" id="stop1137" />
+  <defs
+     id="defs3340">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1239">
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0"
+         id="stop1234" />
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:1"
+         offset="1"
+         id="stop1237" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient1131">
-      <stop style="stop-color:#ffe16b;stop-opacity:1" offset="0" id="stop1127" />
-      <stop id="stop1133" offset="0.51300955" style="stop-color:#d39220;stop-opacity:1;" />
-      <stop style="stop-color:#f9c440;stop-opacity:1" offset="1" id="stop1129" />
+    <linearGradient
+       id="linearGradient1158">
+      <stop
+         id="stop1154"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1156"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient id="linearGradient1101">
-      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop1091" />
-      <stop offset="0.25" style="stop-color:#e7e7e7;stop-opacity:1" id="stop1093" />
-      <stop offset="0.67183787" style="stop-color:#8c8c8c;stop-opacity:1" id="stop1095" />
-      <stop offset="0.83542866" style="stop-color:#dddddd;stop-opacity:1" id="stop1097" />
-      <stop offset="1" style="stop-color:#a8a8a8;stop-opacity:1" id="stop1099" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1144">
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:1"
+         offset="0"
+         id="stop1140" />
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:0"
+         offset="1"
+         id="stop1142" />
     </linearGradient>
-    <linearGradient id="linearGradient1045">
-      <stop offset="0" style="stop-color:#333333;stop-opacity:1" id="stop1041" />
-      <stop offset="1" style="stop-color:#555761;stop-opacity:1" id="stop1043" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1046">
+      <stop
+         style="stop-color:#1a1a1a;stop-opacity:1"
+         offset="0"
+         id="stop1042" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0.79607844"
+         offset="1"
+         id="stop1044" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" style="stop-color:#000000;stop-opacity:0" offset="0" />
-      <stop id="stop5056" style="stop-color:#000000;stop-opacity:1" offset="0.5" />
-      <stop id="stop5052" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient1151">
+      <stop
+         id="stop1143"
+         style="stop-color:#f5f5f5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1145"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.8888889" />
+      <stop
+         id="stop1147"
+         style="stop-color:#dddddd;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507" id="linearGradient2566" xlink:href="#linearGradient5048" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.1018087,0,0,0.02745099,-4.7965709,43.268495)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2563" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.05979662,0,0,0.02745099,20.518506,43.268495)" />
-    <radialGradient cx="605.71429" cy="486.64789" r="117.14286" fx="605.71429" fy="486.64789" id="radialGradient2560" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.05979662,0,0,0.02745099,43.481506,43.268495)" />
-    <linearGradient id="linearGradient2215">
-      <stop id="stop2223" style="stop-color:#7a7a7a;stop-opacity:1" offset="0" />
-      <stop id="stop2219" style="stop-color:#474747;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1106">
+      <stop
+         id="stop1096"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1098"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.44444445" />
+      <stop
+         id="stop1102"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop1104"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="29.9375" y1="41" x2="30" y2="49.999996" id="linearGradient2557" xlink:href="#linearGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3573591,0,0,1.0098512,-7.3634079,6.5517759)" />
-    <linearGradient id="linearGradient3484">
-      <stop id="stop3486" style="stop-color:#969696;stop-opacity:1" offset="0" />
-      <stop id="stop3488" style="stop-color:#b4b4b4;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient959">
+      <stop
+         style="stop-color:#555761;stop-opacity:0.502"
+         offset="0"
+         id="stop955" />
+      <stop
+         style="stop-color:#7e8087;stop-opacity:0.5"
+         offset="1"
+         id="stop957" />
     </linearGradient>
-    <linearGradient x1="17.813944" y1="29.796696" x2="18.072828" y2="10.000001" id="linearGradient2553" xlink:href="#linearGradient3484" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3526366,0,0,1.3652569,-0.463278,-2.8344302)" />
-    <linearGradient id="linearGradient7056">
-      <stop id="stop7064" style="stop-color:#e6e6e6;stop-opacity:1" offset="0" />
-      <stop id="stop7060" style="stop-color:#c8c8c8;stop-opacity:1" offset="1" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1131">
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="0"
+         id="stop1127" />
+      <stop
+         id="stop1133"
+         offset="0.51300955"
+         style="stop-color:#d39220;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="1"
+         id="stop1129" />
     </linearGradient>
-    <radialGradient cx="11.734284" cy="8.4900017" r="23.047892" fx="11.734284" fy="8.4900017" id="radialGradient2551" xlink:href="#linearGradient7056" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.8621852,0.9518493,-0.6331808,1.2619694,-0.5297689,-5.4809546)" />
-    <radialGradient cx="141.74666" cy="206.42612" r="78.728165" fx="141.74666" fy="206.42612" id="radialGradient2547" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.475706,-0.00690855,0.00352072,0.3975024,-37.03293,-36.799112)" />
-    <linearGradient id="linearGradient7609">
-      <stop id="stop7611" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop7677" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop7613" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.67183787" />
-      <stop id="stop7617" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop7615" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       id="linearGradient1045">
+      <stop
+         offset="0"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop1041" />
+      <stop
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         id="stop1043" />
     </linearGradient>
-    <radialGradient cx="142.62215" cy="191.85428" r="78.728165" fx="142.62215" fy="191.85428" id="radialGradient2544" xlink:href="#linearGradient7609" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.2466032,0,0,-0.1743241,-4.1482291,59.731248)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2540" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.5034274,0,0,0.4878048,62.920656,-2.103415)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2536" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.374113,-0.07929617,0.04213943,0.3149909,-33.911844,-8.7733407)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2532" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.3782453,0.07056425,-0.03896353,0.3065004,11.53557,-24.903099)" />
-    <linearGradient id="linearGradient5060">
-      <stop id="stop5062" style="stop-color:#000000;stop-opacity:1" offset="0" />
-      <stop id="stop5064" style="stop-color:#000000;stop-opacity:0" offset="1" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="7.0625" y1="35.28125" x2="24.6875" y2="35.28125" id="linearGradient2529" xlink:href="#linearGradient5060" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3801029,0,0,1.2584266,-8.0712936,29.10113)" />
-    <linearGradient id="linearGradient4236">
-      <stop id="stop4238" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4240" style="stop-color:#eeeeee;stop-opacity:0" offset="1" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient2566"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1018087,0,0,0.02745099,-4.7965709,44.468161)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2563"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05979662,0,0,0.02745099,20.518506,44.468161)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2560"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.05979662,0,0,0.02745099,43.481506,44.468161)" />
+    <linearGradient
+       id="linearGradient2215">
+      <stop
+         id="stop2223"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
     </linearGradient>
-    <linearGradient x1="12.277412" y1="37.205811" x2="12.221823" y2="33.758667" id="linearGradient2526" xlink:href="#linearGradient4236" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3504215,0,0,1.2464221,-0.08267968,10.210591)" />
-    <linearGradient id="linearGradient4035">
-      <stop id="stop4037" style="stop-color:#f5f5f5;stop-opacity:1" offset="0" />
-      <stop id="stop4039" style="stop-color:#e7e7e7;stop-opacity:1" offset="0.47025558" />
-      <stop id="stop4041" style="stop-color:#8c8c8c;stop-opacity:1" offset="0.69348532" />
-      <stop id="stop4043" style="stop-color:#dddddd;stop-opacity:1" offset="0.83542866" />
-      <stop id="stop4045" style="stop-color:#a8a8a8;stop-opacity:1" offset="1" />
+    <linearGradient
+       x1="29.736721"
+       y1="43.024384"
+       x2="29.736721"
+       y2="49.956097"
+       id="linearGradient2557"
+       xlink:href="#linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.372781,0,0,1.1323518,-7.8106428,1.4918978)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient cx="127.31733" cy="143.82751" r="78.728165" fx="127.31733" fy="143.82751" id="radialGradient2523" xlink:href="#linearGradient4035" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.2540562,-0.03579406,0.00825801,0.1439066,-9.916226,3.6124102)" />
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient4241" gradientUnits="userSpaceOnUse">
-      <stop id="stop4243" style="stop-color:#eeeeee;stop-opacity:1" offset="0" />
-      <stop id="stop4245" style="stop-color:#cecece;stop-opacity:1" offset="0.16" />
-      <stop id="stop4247" style="stop-color:#888888;stop-opacity:1" offset="0.4675" />
-      <stop id="stop4249" style="stop-color:#555555;stop-opacity:1" offset="1" />
-    </radialGradient>
-    <radialGradient cx="113.0654" cy="97.587898" r="2.5631001" fx="113.667" fy="98" id="radialGradient2519" xlink:href="#radialGradient4241" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.5034273,0,0,0.4878048,1.0793577,-2.103415)" />
-    <linearGradient id="linearGradient6310-8">
-      <stop id="stop6312-6" style="stop-color:#ffffff;stop-opacity:1" offset="0" />
-      <stop id="stop6314-6" style="stop-color:#ffffff;stop-opacity:0" offset="1" />
-    </linearGradient>
-    <radialGradient cx="24" cy="42" r="21" fx="24" fy="42" id="radialGradient2516" xlink:href="#linearGradient6310-8" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3809524,-1.4521173e-8,3.8407907e-8,0.486864,-1.1428547,32.14366)" />
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient1045" id="radialGradient925" cx="25.960344" cy="75.09082" fx="25.960344" fy="75.09082" r="18.5" gradientTransform="matrix(1.1323845,-1.809244e-7,-2.7011291e-8,-0.2162162,-6.3970894,67.235857)" gradientUnits="userSpaceOnUse" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1011" x1="7" y1="53" x2="7" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1013" x1="10" y1="53" x2="10" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1015" x1="13" y1="53" x2="13" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1017" x1="16" y1="53" x2="16" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1019" x1="19" y1="53" x2="19" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1021" x1="22" y1="53" x2="22" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1023" x1="25" y1="53" x2="25" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1025" x1="28" y1="53" x2="28" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1027" x1="31" y1="53" x2="31" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1029" x1="34" y1="53" x2="34" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1031" x1="41" y1="53" x2="41" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,-1,-52.499999)" />
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient1131" id="linearGradient1033" x1="37" y1="53" x2="37" y2="52" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,2,0,-52.499999)" />
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient1139" id="radialGradient1141" cx="58.063544" cy="53" fx="58.063544" fy="53" r="1.6890617" gradientTransform="matrix(1,0,0,0.88806701,0,5.9324482)" gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1045"
+       id="radialGradient925"
+       cx="25.960546"
+       cy="72.77832"
+       fx="25.960546"
+       fy="72.77832"
+       r="18.5"
+       gradientTransform="matrix(1.1351352,-1.8092439e-7,-2.7076904e-8,-0.21621619,-6.4687276,67.735856)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1011"
+       x1="7"
+       y1="53"
+       x2="7"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1013"
+       x1="10"
+       y1="53"
+       x2="10"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1015"
+       x1="13"
+       y1="53"
+       x2="13"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1017"
+       x1="16"
+       y1="53"
+       x2="16"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1019"
+       x1="19"
+       y1="53"
+       x2="19"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1021"
+       x1="22"
+       y1="53"
+       x2="22"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1023"
+       x1="25"
+       y1="53"
+       x2="25"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1025"
+       x1="28"
+       y1="53"
+       x2="28"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1027"
+       x1="31"
+       y1="53"
+       x2="31"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1029"
+       x1="34"
+       y1="53"
+       x2="34"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1031"
+       x1="41"
+       y1="53"
+       x2="41"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-1.0002299,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1131"
+       id="linearGradient1033"
+       x1="37"
+       y1="53"
+       x2="37"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,2,-2.2993924e-4,-52.499998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient959"
+       id="linearGradient961"
+       x1="32"
+       y1="57"
+       x2="32"
+       y2="48"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0113617,0,0,1.1213056,-0.36357409,-5.8546455)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1158"
+       id="linearGradient1010"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999645"
+       y1="47.999744"
+       x2="31.999645"
+       y2="49.354958"
+       gradientTransform="matrix(0.98646189,0,0,1.1341909,0.43322243,-6.4779381)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1106"
+       id="linearGradient1094"
+       x1="-8"
+       y1="28"
+       x2="28"
+       y2="36"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1151"
+       id="linearGradient1140"
+       gradientUnits="userSpaceOnUse"
+       x1="-8"
+       y1="28"
+       x2="10"
+       y2="32"
+       gradientTransform="matrix(-1,0,0,1,64,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1046"
+       id="linearGradient1080"
+       x1="57"
+       y1="53.03125"
+       x2="57"
+       y2="55.65625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6640004,0,0,1.2817468,-39.186032,-15.009959)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1144"
+       id="radialGradient1138"
+       cx="57.125"
+       cy="53.125"
+       fx="57.125"
+       fy="53.125"
+       r="2.875"
+       gradientTransform="matrix(1.3913044,0,0,1.1508844,-23.728264,-8.1407377)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1239"
+       id="linearGradient1223"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2000002,0,0,0.78571438,-12.800019,11.285708)"
+       x1="57.125008"
+       y1="54.681816"
+       x2="57.125008"
+       y2="52.136364" />
   </defs>
-  <rect style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" id="rect2723" y="53.333332" x="7.4204431" height="6.6666665" width="49.159065" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" id="path2725" d="m 56.555559,53.333564 c 0,0 0,6.666297 0,6.666297 3.079373,0.01255 7.444439,-1.49358 7.444439,-3.333576 0,-1.839996 -3.436346,-3.332721 -7.444439,-3.332721 z" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" id="path2727" d="m 7.4444398,53.333564 c 0,0 0,6.666297 0,6.666297 C 4.3650531,60.012413 0,58.506281 0,56.666285 0,54.826289 3.4363598,53.333564 7.4444398,53.333564 Z" />
-  <path inkscape:connector-curvature="0" style="display:inline;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:#353537;stroke-width:0.9279989;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" id="rect6431" d="M 1.4639996,48.463998 H 62.536003 l -1.221119,8.072 H 2.8208566 Z" />
-  <rect style="display:inline;fill:#d2d2d3;fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new" id="rect6381" y="47.626324" x="1.5656769" height="1.3632195" width="60.868649" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2551);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2553);stroke-width:0.99578357;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path6345" d="M 62.501957,48.502108 53.290998,13.313517 C 53.030543,12.311454 51.666211,11.49789 50.51922,11.49789 H 13.16316 c -1.762134,0 -2.7719,0.271104 -3.143472,1.815627 L 1.4980451,48.467845" />
-  <path inkscape:connector-curvature="0" style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" id="path7046" d="M 61.499999,48.515874 2.5,48.484128" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9007" d="M 7.9967277,45.492684 C 7.9332943,46.322928 6.9833279,47 5.8757865,47 4.7687495,47 3.9305429,46.322928 4.0045466,45.492684 4.078048,44.666829 5.027512,44 6.1239769,44 c 1.096969,3.91e-4 1.9351757,0.666829 1.8727508,1.492684 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2540);fill-opacity:1" id="path9009" d="m 7.280349,44.90878 c 0.1011901,0.105359 0.2169781,0.274148 0.2169781,0.498536 0,0.01611 -0.00101,0.03219 -0.00202,0.04928 -0.0438,0.572194 -0.7853474,1.055609 -1.6190232,1.055609 -0.474732,0 -0.908686,-0.158536 -1.1604005,-0.424877 -0.1082352,-0.113658 -0.2315767,-0.301952 -0.2094255,-0.552683 0.050846,-0.567318 0.7913868,-1.046829 1.6180165,-1.046829 0.471208,3.9e-4 0.9036511,0.157561 1.1558678,0.420974 h 4.1e-6 l -5e-7,-7e-6 z" />
-  <path inkscape:connector-curvature="0" style="fill:#f0f0f0;fill-opacity:1" id="path9019" d="m 11.015508,13.309735 c 0.118861,0.526123 0.883302,0.813697 1.706351,0.639247 0.822674,-0.174371 1.387082,-0.743609 1.260368,-1.268067 -0.125972,-0.521702 -0.889146,-0.802742 -1.703963,-0.630035 -0.815161,0.173038 -1.380487,0.735406 -1.262756,1.258855 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2536);fill-opacity:1" id="path9021" d="m 11.497432,12.819853 c -0.0661,0.08398 -0.137561,0.211202 -0.118178,0.356097 0.0014,0.01035 0.0035,0.02071 0.0058,0.03149 0.08198,0.362583 0.674806,0.557935 1.294338,0.426621 0.352787,-0.07477 0.661577,-0.245501 0.825625,-0.457134 0.07062,-0.09045 0.146001,-0.231456 0.107889,-0.389872 -0.0868,-0.358327 -0.678535,-0.551317 -1.29283,-0.421113 -0.350136,0.07447 -0.657921,0.24408 -0.822597,0.453902 l -2e-6,2e-6 -5e-6,9e-6 z" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9025" d="m 49.000386,12.701322 c -0.01865,0.530555 0.641011,1.089131 1.473151,1.244373 0.831763,0.15517 1.515621,-0.152769 1.526335,-0.684798 0.01067,-0.529209 -0.649366,-1.081279 -1.473185,-1.234967 -0.824228,-0.153508 -1.507238,0.147743 -1.526301,0.675392 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2532);fill-opacity:1" id="path9027" d="m 49.58527,12.434852 c -0.08445,0.05201 -0.184921,0.141835 -0.202845,0.282832 -0.0013,0.01005 -0.0019,0.02031 -0.0024,0.03125 -0.01287,0.365665 0.505746,0.773348 1.132121,0.890201 0.356685,0.06654 0.695395,0.02776 0.905794,-0.104309 0.09041,-0.05624 0.198111,-0.157263 0.201496,-0.317911 0.0071,-0.363587 -0.510985,-0.768676 -1.132066,-0.884543 -0.354069,-0.0658 -0.691536,-0.02765 -0.902077,0.102505 l -4e-6,-4e-6 -4.7e-5,-1.8e-5 z" />
-  <path inkscape:connector-curvature="0" style="fill:#e1e1e1;fill-opacity:1" id="path9091" d="M 56.003272,45.492684 C 56.066707,46.322928 57.016672,47 58.124213,47 59.23125,47 60.069458,46.322928 59.995454,45.492684 59.921945,44.666829 58.972488,44 57.876023,44 c -1.09697,3.91e-4 -1.935174,0.666829 -1.872751,1.492684 z" />
-  <path inkscape:connector-curvature="0" style="fill:url(#radialGradient2519);fill-opacity:1" id="path9093" d="m 56.719652,44.90878 c -0.101194,0.105359 -0.216979,0.274148 -0.216979,0.498536 0,0.01611 10e-4,0.03219 0.002,0.04928 0.04381,0.572194 0.785346,1.055609 1.619022,1.055609 0.474732,0 0.908686,-0.158536 1.160399,-0.424877 0.108237,-0.113658 0.231578,-0.301952 0.209427,-0.552683 -0.05085,-0.567318 -0.791387,-1.046829 -1.618016,-1.046829 -0.471209,3.9e-4 -0.903651,0.157561 -1.155869,0.420974 h -3e-6 l 3.3e-5,-7e-6 z" />
-  <rect style="opacity:0.3;fill:url(#radialGradient2516);fill-opacity:1;stroke:none;stroke-width:1" id="rect6300-3" y="49.183899" x="3.0000002" height="6.8160973" width="58.000004" />
-  <path style="fill:url(#radialGradient1141);fill-opacity:1;stroke:#9bdb4d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.54444442" d="m 59.2,52 -0.3,2 h -2 l 0.3,-2 z" id="path915" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#474747;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5988372;paint-order:normal" d="m 4.972956,54.5 h 37.17246 l 0.301398,-3 H 4.5710916 Z" id="rect917" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" />
-  <path style="fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 6,51.499999 v 2 h 2 v -2 z" id="path928" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 9,51.499999 v 2 h 2 v -2 z" id="path928-3" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 12,51.499999 v 2 h 2 v -2 z" id="path928-6" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 15,51.499999 v 2 h 2 v -2 z" id="path928-7" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 18,51.499999 v 2 h 2 v -2 z" id="path928-5" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 21,51.499999 v 2 h 2 v -2 z" id="path928-35" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 24,51.499999 v 2 h 2 v -2 z" id="path928-62" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 27,51.499999 v 2 h 2 v -2 z" id="path928-9" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 30,51.499999 v 2 h 2 v -2 z" id="path928-1" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1029);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 33,51.499999 v 2 h 2 v -2 z" id="path928-2" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 36,51.499999 v 2 h 2 v -2 z" id="path928-70" inkscape:connector-curvature="0" />
-  <path style="fill:url(#linearGradient1031);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 39,51.499999 v 2 h 2 v -2 z" id="path928-93" inkscape:connector-curvature="0" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2566);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="rect2723"
+     y="54.533001"
+     x="7.4204431"
+     height="6.6666665"
+     width="49.159065" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none"
+     id="path2725"
+     d="m 56.555559,54.53323 c 0,0 0,6.666297 0,6.666297 3.079373,0.01255 7.444439,-1.49358 7.444439,-3.333576 0,-1.839996 -3.436346,-3.332721 -7.444439,-3.332721 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2560);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2727"
+     d="m 7.4444398,54.53323 c 0,0 0,6.666297 0,6.666297 C 4.3650531,61.212079 0,59.705947 0,57.865951 0,56.025955 3.4363598,54.53323 7.4444398,54.53323 Z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.504001;marker:none;enable-background:accumulate"
+     id="path6345"
+     d="M 62.5,50 54,13.5 c -0.401924,-1.5 -2,-2 -3.5,-2 h -37 c -1.5,0 -3.154236,0.5 -3.5,2 L 1.5389151,50"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1140);fill-opacity:1;fill-rule:nonzero;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+     id="path6345-6"
+     d="M 1.5389151,50 10,13.5 c 0.401924,-1.5 2,-2 3.5,-2 h 37 c 1.5,0 3.154236,0.5 3.5,2 L 62.5,50"
+     sodipodi:nodetypes="ccsscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:1;fill:url(#linearGradient2557);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient961);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431"
+     d="M 58,57.499124 H 6 C 3,57.499124 2.5,55.5 2.5,55.5 2.5,55.5 1.5,52 1.5,51 1.5,49 2,47.5 5,47.5 h 54 c 3,0 3.5,1.5 3.5,3.5 0,1 -1,4.5 -1,4.5 0,0 -0.5,1.999124 -3.5,1.999124 z"
+     sodipodi:nodetypes="ccccscscc" />
+  <g
+     id="g136"
+     style="display:inline"
+     transform="translate(1)">
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:url(#radialGradient925);fill-opacity:1;fill-rule:nonzero;stroke:#555761;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:normal"
+       d="M 4.9997701,55 H 42.25 l 0.24977,-3.5 H 4.25 Z"
+       id="rect917"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.9997701,51.5 v 2 h 2 v -2 z"
+       id="path928"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1013);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.9997701,51.5 v 2 H 10.99977 v -2 z"
+       id="path928-3"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1015);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 11.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1017);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 14.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1019);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 17.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1021);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 20.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-35"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1023);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 23.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-62"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1025);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 26.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1027);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 29.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1029);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 32.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient1033);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 35.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-70"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient1031);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 38.99977,51.5 v 2 h 2 v -2 z"
+       id="path928-93"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;opacity:0.75;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1010);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+     id="rect6431-3"
+     d="M 2.5,52 C 2,48 4,48.49818 7,48.5 l 50,0.03033 C 60,48.530334 62,48 61.5,52"
+     sodipodi:nodetypes="cscc" />
+  <rect
+     style="opacity:1;fill:url(#linearGradient1080);fill-opacity:1;fill-rule:evenodd;stroke:#d4d4d4;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:normal"
+     id="rect1040"
+     width="6.000001"
+     height="4.250001"
+     x="52.75"
+     y="51"
+     rx="2.2397339"
+     ry="2.1153047" />
+  <rect
+     style="fill:url(#linearGradient1223);fill-opacity:1;fill-rule:evenodd;stroke:#3a9104;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902;paint-order:stroke markers fill"
+     id="rect1040-9"
+     width="4.500001"
+     height="2.75"
+     x="53.5"
+     y="51.75"
+     rx="1.555909"
+     ry="1.375" />
+  <ellipse
+     style="display:inline;opacity:0.75;fill:url(#radialGradient1138);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.55;paint-order:stroke markers fill"
+     id="path1050-5"
+     cx="55.75"
+     cy="53"
+     rx="3.9999998"
+     ry="3.5" />
 </svg>


### PR DESCRIPTION
Redesigned the icons for solid-state drives, will follow up later with a similar redesign for USB drives.
I tried to keep to the orginal SSD icon's perspective while also actually making it look good. 
I've only used elementary brand colours and made sure to give all the main shapes a 1px 50% outline.
Please give any constructive criticisms that come to mind!
![drive-harddisk-solidstate](https://user-images.githubusercontent.com/58219504/110160600-2283a380-7de4-11eb-979e-22bc81d1496a.png)
![drive-harddisk-solidstate](https://user-images.githubusercontent.com/58219504/110160613-26172a80-7de4-11eb-9cf1-0fad0ab70a75.png)
<img width="24" alt="drive-harddisk-solidstate" src="https://user-images.githubusercontent.com/58219504/110160619-29121b00-7de4-11eb-8911-16b4bbf1cd79.png">
![drive-harddisk-solidstate](https://user-images.githubusercontent.com/58219504/110160628-2adbde80-7de4-11eb-868e-48ee654d9b58.png)
![drive-harddisk-solidstate](https://user-images.githubusercontent.com/58219504/110160636-2d3e3880-7de4-11eb-85cc-42a3a0d8f6a9.png)
![drive-harddisk-solidstate](https://user-images.githubusercontent.com/58219504/110160649-30d1bf80-7de4-11eb-8008-f0fc51c57986.png)
