### PR TITLE
Actions: Remove arrows from Copy and Paste

### DIFF
--- a/actions/16/edit-copy.svg
+++ b/actions/16/edit-copy.svg
@@ -1,75 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3375"
    height="16"
    width="16"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3377">
-    <radialGradient
-       gradientTransform="matrix(-0.25568731,0,0,-0.17604034,13.353337,17.657486)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient8662-6"
-       id="radialGradient4123"
-       fy="36.421127"
-       fx="24.837126"
-       r="15.644737"
-       cy="36.421127"
-       cx="24.837126" />
-    <linearGradient
-       id="linearGradient8662-6">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop8664-2" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop8666-6" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.27962938,0,0,-0.23975449,1.0220452,13.718559)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       id="linearGradient4125"
-       y2="2.7235911"
-       x2="25.46862"
-       y1="32.841259"
-       x1="25.46862" />
-    <linearGradient
-       gradientTransform="matrix(0,0.28097453,0.327705,0,1.5205692,0.74757282)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4087-7"
-       id="linearGradient4130"
-       y2="20.64884"
-       x2="37.473785"
-       y1="20.64884"
-       x1="20.796995" />
-    <linearGradient
-       id="linearGradient4087-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4089-5" />
-      <stop
-         offset="0.51153916"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4091-6" />
-      <stop
-         offset="0.58522105"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4093-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4095-8" />
-    </linearGradient>
     <linearGradient
        gradientTransform="matrix(0.18918906,0,0,0.24324323,5.4591875,3.162165)"
        gradientUnits="userSpaceOnUse"
@@ -206,25 +148,6 @@
        x2="-51.786404"
        y1="50.786446"
        x1="-51.786404" />
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         offset="0"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         id="stop3244-5-8-5-6-4-3-8" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         id="stop3246-9-5-1-5-3-0-7" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#68b723;stop-opacity:1"
-         id="stop3248-7-2-0-7-5-35-9" />
-      <stop
-         offset="1"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         id="stop3250-8-2-8-5-6-40-4" />
-    </linearGradient>
   </defs>
   <metadata
      id="metadata3380">
@@ -234,7 +157,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -258,20 +180,4 @@
      d="m 13.5,13.5 -7,0 0,-9 7,0 z"
      id="rect6741-1-2"
      style="fill:none;stroke:url(#linearGradient3069);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     d="m 3.0026383,11.245895 a 4.0001608,2.7541062 0 1 1 8.0003217,0 4.0001608,2.7541062 0 0 1 -8.0003217,0 z"
-     id="path3501"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.14117647;fill:url(#radialGradient4123);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
-  <path
-     d="M 5.3028032,4.4424593 C 1.7522365,6.6503709 3.8849552,10.885267 7.5028187,10.885267 l 0,1.754252 4.4971803,-3.2786959 -4.4971803,-3.0657337 0,1.8360706 C 4.9503391,8.2223484 3.8345052,5.9830639 5.6592706,4.4424593 Z"
-     id="path3503"
-     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-  <path
-     d="m 4.6207668,6.128284 c -0.9065244,0.8063712 -0.124651,4.331437 3.8820921,3.8492495 l 0,0.9077335 1.8983001,-1.5244439 -1.8983001,-1.3855923 0,1.1222162 C 4.1058871,9.3132937 4.2466008,6.6740496 4.6207668,6.128284 Z"
-     id="path3505"
-     style="display:block;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient4130);stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-  <path
-     d="M 5.3028032,4.4424594 C 1.7522365,6.650371 3.8849552,10.885267 7.5028187,10.885267 l 0,1.754252 4.4971803,-3.2786958 -4.4971803,-3.0657337 0,1.8360706 C 4.9503391,8.2223485 3.8345052,5.983064 5.6592706,4.4424594 Z"
-     id="path3503-8"
-     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color:#000000;clip-rule:nonzero;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/actions/16/edit-paste.svg
+++ b/actions/16/edit-paste.svg
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg3375">
+   id="svg3375"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3377">
     <radialGradient
@@ -31,43 +31,6 @@
       <stop
          id="stop8666-6"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="25.46862"
-       y1="32.841259"
-       x2="25.46862"
-       y2="2.7235911"
-       id="linearGradient4125"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27962938,0,0,-0.23975449,1.0220452,14.718559)" />
-    <linearGradient
-       x1="20.796995"
-       y1="20.64884"
-       x2="37.473785"
-       y2="20.64884"
-       id="linearGradient4130"
-       xlink:href="#linearGradient4087-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.28097453,0.327705,0,1.5205692,1.7475728)" />
-    <linearGradient
-       id="linearGradient4087-7">
-      <stop
-         id="stop4089-5"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4091-6"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.51153916" />
-      <stop
-         id="stop4093-9"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.58522105" />
-      <stop
-         id="stop4095-8"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -116,25 +79,6 @@
       <stop
          id="stop3604-6-0"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         id="stop3244-5-8-5-6-4-3-8"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-9-5-1-5-3-0-7"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-7-2-0-7-5-35-9"
-         style="stop-color:#68b723;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-8-2-8-5-6-40-4"
-         style="stop-color:#1d7e0d;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -247,7 +191,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -293,16 +236,4 @@
      style="display:inline;overflow:visible;visibility:visible;opacity:0.14117647;fill:url(#radialGradient4123);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
      id="path3501"
      d="m 3.0026383,12.245895 a 4.0001609,2.7541062 0 1 1 8.0003217,0 4.0001609,2.7541062 0 0 1 -8.0003217,0 z" />
-  <path
-     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     id="path3503"
-     d="M 5.3028032,5.4424593 C 1.7522365,7.6503709 3.8849552,11.885267 7.5028187,11.885267 l 0,1.754252 4.4971803,-3.278696 -4.4971803,-3.0657336 0,1.8360706 C 4.9503391,9.222348 3.8345052,6.9830639 5.6592706,5.4424593 Z" />
-  <path
-     style="display:block;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient4130);stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     id="path3505"
-     d="m 4.6207668,7.128284 c -0.9065244,0.8063712 -0.124651,4.331437 3.8820921,3.84925 l 0,0.907733 1.8983001,-1.524444 -1.8983001,-1.3855922 0,1.1222162 C 4.1058871,10.313294 4.2466008,7.6740496 4.6207668,7.128284 Z" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3503-8"
-     d="M 5.3028032,5.4424594 C 1.7522365,7.650371 3.8849552,11.885267 7.5028187,11.885267 l 0,1.754252 4.4971803,-3.278696 -4.4971803,-3.0657335 0,1.8360705 C 4.9503391,9.222349 3.8345052,6.983064 5.6592706,5.4424594 Z" />
 </svg>

--- a/actions/24/edit-copy.svg
+++ b/actions/24/edit-copy.svg
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="24"
    height="24"
-   id="svg3810">
+   id="svg3810"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3812">
     <linearGradient
@@ -102,25 +102,6 @@
        xlink:href="#linearGradient3104-9"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         id="stop3244-5-8-5-6-4-3-8"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-9-5-1-5-3-0-7"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-7-2-0-7-5-35-9"
-         style="stop-color:#68b723;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-8-2-8-5-6-40-4"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <radialGradient
        cx="24.837126"
        cy="36.421127"
@@ -131,43 +112,6 @@
        xlink:href="#linearGradient4440"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-0.25567703,0,0,-0.1917577,17.35292,22.983986)" />
-    <linearGradient
-       x1="25.46862"
-       y1="32.841259"
-       x2="25.46862"
-       y2="2.7235911"
-       id="linearGradient4125"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27961814,0,0,-0.26116043,5.022124,18.69338)" />
-    <linearGradient
-       x1="20.796995"
-       y1="20.64884"
-       x2="37.473785"
-       y2="20.64884"
-       id="linearGradient4130"
-       xlink:href="#linearGradient4087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.3060607,0.32769183,0,5.520628,4.5643088)" />
-    <linearGradient
-       id="linearGradient4087">
-      <stop
-         id="stop4089"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4091"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.51153916" />
-      <stop
-         id="stop4093"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.58522105" />
-      <stop
-         id="stop4095"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient5048-9-5">
       <stop
@@ -267,7 +211,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -341,16 +284,4 @@
        id="path2881-6-1-3-7"
        style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3177-6-5-6-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   </g>
-  <path
-     d="M 9.30271,8.5890848 C 5.752286,10.994125 7.884919,15.607124 11.502637,15.607124 l 0,1.910877 5,-3.571427 -5,-3.339451 0,2 C 8.95026,12.706453 7.834471,10.267239 9.659163,8.5890848 Z"
-     id="path3503"
-     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-  <path
-     d="M 8.620701,9.8331758 C 7.368233,11.303791 8.496055,15.143584 12.502637,14.618346 l 0,0.988778 2.330149,-1.66055 -2.330149,-1.509302 0,0.791685 C 8.105842,13.464075 8.24655,10.427669 8.620701,9.8331758 Z"
-     id="path3505"
-     style="display:block;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient4130);stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-  <path
-     d="m 9.30271,8.589085 c -3.550424,2.40504 -1.417791,7.018039 2.199927,7.018039 l 0,1.910877 5,-3.571427 -5,-3.339451 0,2 C 8.95026,12.706453 7.834471,10.267239 9.659163,8.589085 Z"
-     id="path3503-2"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/actions/24/edit-paste.svg
+++ b/actions/24/edit-paste.svg
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3810"
    height="24"
    width="24"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3812">
     <linearGradient
@@ -64,25 +64,6 @@
          style="stop-color:#000000;stop-opacity:0.24691358"
          id="stop3108-5" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         offset="0"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         id="stop3244-5-8-5-6-4-3-8" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         id="stop3246-9-5-1-5-3-0-7" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#68b723;stop-opacity:1"
-         id="stop3248-7-2-0-7-5-35-9" />
-      <stop
-         offset="1"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         id="stop3250-8-2-8-5-6-40-4" />
-    </linearGradient>
     <radialGradient
        gradientTransform="matrix(-0.25567703,0,0,-0.1917577,17.35292,22.983986)"
        gradientUnits="userSpaceOnUse"
@@ -93,43 +74,6 @@
        r="15.644737"
        cy="36.421127"
        cx="24.837126" />
-    <linearGradient
-       gradientTransform="matrix(0.27961814,0,0,-0.26116043,5.022124,18.69338)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       id="linearGradient4125"
-       y2="2.7235911"
-       x2="25.46862"
-       y1="32.841259"
-       x1="25.46862" />
-    <linearGradient
-       gradientTransform="matrix(0,0.3060607,0.32769183,0,5.520628,4.5643088)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4087"
-       id="linearGradient4130"
-       y2="20.64884"
-       x2="37.473785"
-       y1="20.64884"
-       x1="20.796995" />
-    <linearGradient
-       id="linearGradient4087">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4089" />
-      <stop
-         offset="0.51153916"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4091" />
-      <stop
-         offset="0.58522105"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4093" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4095" />
-    </linearGradient>
     <linearGradient
        id="linearGradient5048-9-5">
       <stop
@@ -340,7 +284,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -442,16 +385,4 @@
        id="path2881-6-1-3-7"
        d="m 35.492,10.898364 c 0,0 0,1.499919 0,1.499919 0.413648,0.0029 1,-0.336056 1,-0.750057 0,-0.413999 -0.4616,-0.749862 -1,-0.749862 z" />
   </g>
-  <path
-     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     id="path3503"
-     d="M 9.30271,8.5890848 C 5.752286,10.994125 7.884919,15.607124 11.502637,15.607124 l 0,1.910877 5,-3.571427 -5,-3.339451 0,2 C 8.95026,12.706453 7.834471,10.267239 9.659163,8.5890848 Z" />
-  <path
-     style="display:block;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient4130);stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     id="path3505"
-     d="M 8.620701,9.8331758 C 7.368233,11.303791 8.496055,15.143584 12.502637,14.618346 l 0,0.988778 2.330149,-1.66055 -2.330149,-1.509302 0,0.791685 C 8.105842,13.464075 8.24655,10.427669 8.620701,9.8331758 Z" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3503-2"
-     d="m 9.30271,8.589085 c -3.550424,2.40504 -1.417791,7.018039 2.199927,7.018039 l 0,1.910877 5,-3.571427 -5,-3.339451 0,2 C 8.95026,12.706453 7.834471,10.267239 9.659163,8.589085 Z" />
 </svg>

--- a/actions/32/edit-copy.svg
+++ b/actions/32/edit-copy.svg
@@ -1,66 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg5018"
    height="32"
    width="32"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs5020">
-    <linearGradient
-       id="linearGradient4087">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4089" />
-      <stop
-         offset="0.51153916"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4091" />
-      <stop
-         offset="0.58522105"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4093" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4095" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.39222363,0,0,-0.36562471,4.8278194,25.163568)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       id="linearGradient3162"
-       y2="-1.1839229"
-       x2="27.974298"
-       y1="36.127529"
-       x1="27.974298" />
-    <radialGradient
-       gradientTransform="matrix(-0.38351555,0,0,-0.25567694,22.275669,31.384178)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient8662"
-       id="radialGradient3173"
-       fy="36.421127"
-       fx="24.837126"
-       r="15.644737"
-       cy="36.421127"
-       cx="24.837126" />
-    <linearGradient
-       id="linearGradient8662">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop8664" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop8666" />
-    </linearGradient>
     <linearGradient
        gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,26.980547)"
        gradientUnits="userSpaceOnUse"
@@ -307,44 +258,6 @@
        x2="23.99999"
        y1="5.5641499"
        x1="23.99999" />
-    <radialGradient
-       cx="24.837126"
-       cy="36.421127"
-       r="15.644737"
-       fx="24.837126"
-       fy="36.421127"
-       id="radialGradient3449"
-       xlink:href="#linearGradient8662"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.70660609,0,0,-0.47076982,-0.754985,39.964493)" />
-    <linearGradient
-       x1="38.940514"
-       y1="15.991243"
-       x2="20.576487"
-       y2="15.991243"
-       id="linearGradient3855"
-       xlink:href="#linearGradient4087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.39571558,0.42801014,0,6.4033107,30.903618)" />
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         id="stop3244-5-8-5-6-4-3-8"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-9-5-1-5-3-0-7"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-7-2-0-7-5-35-9"
-         style="stop-color:#68b723;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-8-2-8-5-6-40-4"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
   </defs>
   <metadata
      id="metadata5023">
@@ -354,7 +267,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -416,24 +328,4 @@
        id="rect6741-1-2"
        style="fill:none;stroke:url(#linearGradient3185);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
-  <path
-     d="m 6.750245,22.072131 a 6,4.0000002 0 1 1 12,0 6,4.0000002 0 0 1 -12,0 z"
-     id="path3501"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.14117647;fill:url(#radialGradient3173);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
-  <path
-     d="m 10.832248,11.017552 c -4.9802216,3.367056 -2.0511186,9.550728 3.5,9.5 l 0,3.000485 7,-5 -7,-5 0,2.976351 c -3.580248,0.139062 -5.5595156,-3.12742 -3,-5.476836 z"
-     id="path3503"
-     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3162);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-  <path
-     d="m 9.8755864,12.759279 c -1.756852,2.058862 -0.225017,7.434574 5.3950626,6.699241 l 0.0616,2.197396 4.369328,-3.137879 -4.369328,-3.064428 0,2.059765 C 9.1648074,17.842539 9.3507614,13.59157 9.8755874,12.759279 Z"
-     id="path3505"
-     style="display:block;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3855);stroke-width:0.96400005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color:#000000;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     d="m -29.359717,22.818517 a 11.054667,7.3650752 0 1 1 22.109334,0 11.054667,7.3650752 0 0 1 -22.109334,0 z"
-     id="path3501-0"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.14117647;fill:url(#radialGradient3449);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
-  <path
-     d="m 10.832248,11.017552 c -4.9802216,3.367056 -2.0511186,9.550728 3.5,9.5 l 0,3.000485 6.999999,-5 -6.999999,-5 0,2.976351 c -3.580248,0.139062 -5.5595156,-3.12742 -3,-5.476836 z"
-     id="path3503-4"
-     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color:#000000;clip-rule:nonzero;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/actions/32/edit-paste.svg
+++ b/actions/32/edit-paste.svg
@@ -1,55 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg5018">
+   id="svg5018"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs5020">
-    <linearGradient
-       id="linearGradient4087">
-      <stop
-         id="stop4089"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4091"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.51153916" />
-      <stop
-         id="stop4093"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.58522105" />
-      <stop
-         id="stop4095"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="27.974298"
-       y1="36.127529"
-       x2="27.974298"
-       y2="-1.1839229"
-       id="linearGradient3162"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39222363,0,0,-0.36562471,5.8278194,26.163568)" />
-    <radialGradient
-       cx="24.837126"
-       cy="36.421127"
-       r="15.644737"
-       fx="24.837126"
-       fy="36.421127"
-       id="radialGradient3173"
-       xlink:href="#linearGradient8662"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.38351555,0,0,-0.25567694,23.275669,32.384178)" />
     <linearGradient
        id="linearGradient8662">
       <stop
@@ -163,34 +125,6 @@
          id="stop3985-4"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0,-0.39571558,0.42801014,0,7.4033107,31.903618)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4087"
-       id="linearGradient3855"
-       y2="15.991243"
-       x2="20.576487"
-       y1="15.41246"
-       x1="45.243652" />
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         offset="0"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         id="stop3244-5-8-5-6-4-3-8" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         id="stop3246-9-5-1-5-3-0-7" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#68b723;stop-opacity:1"
-         id="stop3248-7-2-0-7-5-35-9" />
-      <stop
-         offset="1"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         id="stop3250-8-2-8-5-6-40-4" />
     </linearGradient>
     <linearGradient
        y2="609.50507"
@@ -340,7 +274,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -441,24 +374,5 @@
        style="fill:none;stroke:url(#linearGradient3185);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect6741-1-2"
        d="m 19.5,29.5 -15.0000004,0 0,-19 L 19.5,10.5 Z" />
-  </g>
-  <g
-     id="g4345">
-    <path
-       d="m 7.750245,23.072131 a 6,4.0000002 0 1 1 12,0 6,4.0000002 0 0 1 -12,0 z"
-       id="path3501"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.14117647;fill:url(#radialGradient3173);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
-    <path
-       d="m 11.832248,12.017552 c -4.9802216,3.367056 -2.0511186,9.550728 3.5,9.5 l 0,3.000485 7,-5 -7,-5 0,2.976351 c -3.580248,0.139062 -5.5595156,-3.12742 -3,-5.476836 z"
-       id="path3503"
-       style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3162);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-    <path
-       d="m 10.875586,13.759279 c -1.7568516,2.058862 -0.225017,7.434574 5.395063,6.699241 l 0.0616,2.197396 4.369328,-3.137879 -4.369328,-3.064428 0,2.059765 c -6.167442,0.329165 -5.981488,-3.921804 -5.456662,-4.754095 z"
-       id="path3505"
-       style="color:#000000;clip-rule:nonzero;display:block;overflow:visible;visibility:visible;opacity:0.8;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3855);stroke-width:0.96400005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <path
-       d="m 11.832248,12.017552 c -4.9802216,3.367056 -2.0511186,9.550728 3.5,9.5 l 0,3.000485 6.999999,-5 -6.999999,-5 0,2.976351 c -3.580248,0.139062 -5.5595156,-3.12742 -3,-5.476836 z"
-       id="path3503-4"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   </g>
 </svg>

--- a/actions/48/edit-copy.svg
+++ b/actions/48/edit-copy.svg
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg4427"
    height="48"
    width="48"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4429">
     <linearGradient
@@ -249,55 +249,6 @@
          style="stop-color:#000000;stop-opacity:0"
          id="stop5052" />
     </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(-0.52995454,0,0,-0.35307735,33.453547,44.335677)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient8662"
-       id="radialGradient3482"
-       fy="36.421127"
-       fx="24.837126"
-       r="15.644737"
-       cy="36.421127"
-       cx="24.837126" />
-    <linearGradient
-       id="linearGradient8662">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop8664" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop8666" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.54198763,0,0,-0.50490985,9.2302131,36.510495)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       id="linearGradient3496"
-       y2="2.9916131"
-       x2="29.096212"
-       y1="32.699886"
-       x1="29.096212" />
-    <linearGradient
-       id="linearGradient4087">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4089" />
-      <stop
-         offset="0.51153916"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4091" />
-      <stop
-         offset="0.58522105"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4093" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4095" />
-    </linearGradient>
     <linearGradient
        gradientTransform="matrix(0.04576928,0,0,0.00823529,1.457689,29.980594)"
        gradientUnits="userSpaceOnUse"
@@ -307,34 +258,6 @@
        x2="302.85715"
        y1="366.64789"
        x1="302.85715" />
-    <linearGradient
-       x1="38.940514"
-       y1="15.991243"
-       x2="20.576487"
-       y2="15.991243"
-       id="linearGradient3198-5"
-       xlink:href="#linearGradient4087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.4678367,0.50462101,0,13.338459,41.670864)" />
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         id="stop3244-5-8-5-6-4-3-8"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-9-5-1-5-3-0-7"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-7-2-0-7-5-35-9"
-         style="stop-color:#68b723;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-8-2-8-5-6-40-4"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
   </defs>
   <metadata
      id="metadata4432">
@@ -344,7 +267,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -398,20 +320,4 @@
      d="m 40.500013,40.5 -21,0 0,-27 21,0 z"
      id="rect6741-1"
      style="fill:none;stroke:url(#linearGradient4288);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     d="m 12,31.476195 a 8.2909995,5.5238047 0 1 1 16.581999,0 8.2909995,5.5238047 0 0 1 -16.581999,0 z"
-     id="path3501"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.14117647;fill:url(#radialGradient3482);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
-  <path
-     d="m 17.527332,16.97554 c -5.627431,4.904762 -3.627431,12.904762 4.87257,13.119034 l 0,4.143524 9,-6.904755 -9,-6.904756 0,4.110195 C 17.452595,24.73082 14.681424,20.219968 18.218248,16.97554 Z"
-     id="path3503"
-     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3496);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-  <path
-     d="m 16.205384,19.38078 c -2.427676,2.843187 -0.904437,10.266782 7.151958,9.715932 l 0.08512,3.150649 6.340803,-4.914018 -6.340803,-4.870664 0,2.902512 c -7.709311,0.744941 -7.962299,-4.835058 -7.237079,-5.984411 z"
-     id="path3505"
-     style="display:block;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:url(#linearGradient3198-5);stroke-width:0.96392488;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color:#000000;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     d="m 17.527332,16.97554 c -5.627431,4.904762 -3.627431,12.904762 4.87257,13.119034 l 0,4.143524 9,-6.904755 -9,-6.904756 0,4.110195 C 17.452595,24.73082 14.681424,20.219968 18.218248,16.97554 Z"
-     id="path3503-1"
-     style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color:#000000;clip-rule:nonzero;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/actions/48/edit-paste.svg
+++ b/actions/48/edit-paste.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg4427">
+   id="svg4427"
+   sodipodi:docname="edit-paste.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview88"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="24"
+     inkscape:cy="23.5"
+     inkscape:window-width="2560"
+     inkscape:window-height="1379"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4427" />
   <defs
      id="defs4429">
     <linearGradient
@@ -265,62 +287,6 @@
        gradientUnits="userSpaceOnUse"
        id="radialGradient4484"
        xlink:href="#linearGradient5060" />
-    <linearGradient
-       x1="29.096212"
-       y1="32.699886"
-       x2="29.096212"
-       y2="2.9916131"
-       id="linearGradient3496"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.54198763,0,0,-0.50490985,35.829934,35.83431)" />
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         offset="0"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         id="stop3244-5-8-5-6-4-3-8" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         id="stop3246-9-5-1-5-3-0-7" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#68b723;stop-opacity:1"
-         id="stop3248-7-2-0-7-5-35-9" />
-      <stop
-         offset="1"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         id="stop3250-8-2-8-5-6-40-4" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0,-0.4678367,-0.50462101,0,31.721688,40.994679)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4087"
-       id="linearGradient3198-5"
-       y2="17.001398"
-       x2="19.628845"
-       y1="17.516216"
-       x1="36.83989" />
-    <linearGradient
-       id="linearGradient4087">
-      <stop
-         id="stop4089"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4091"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.51153916" />
-      <stop
-         id="stop4093"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.58522105" />
-      <stop
-         id="stop4095"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
   </defs>
   <metadata
      id="metadata4432">
@@ -330,7 +296,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -437,20 +402,4 @@
      style="fill:none;stroke:url(#linearGradient4288);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect6741-1"
      d="m 41.500013,42.5 -21,0 0,-27 21,0 z" />
-  <g
-     id="g4212"
-     transform="translate(0.11736251,3.2403736)">
-    <path
-       d="m 17.527332,16.97554 c -5.627431,4.904762 -3.627431,12.904762 4.87257,13.119034 l 0,4.143524 9,-6.904755 -9,-6.904756 0,4.110195 C 17.452595,24.73082 14.681424,20.219968 18.218248,16.97554 Z"
-       id="path3503"
-       style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3496);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-    <path
-       d="m 16.205384,19.38078 c -2.427676,2.843187 -0.904437,10.266782 7.151958,9.715932 l 0.08512,3.150649 6.340803,-4.914018 -6.340803,-4.870664 0,2.902512 c -7.709311,0.744941 -7.962299,-4.835058 -7.237079,-5.984411 z"
-       id="path3505"
-       style="color:#000000;clip-rule:nonzero;display:block;overflow:visible;visibility:visible;opacity:0.7;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3198-5);stroke-width:0.96392488;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <path
-       d="m 17.527332,16.97554 c -5.627431,4.904762 -3.627431,12.904762 4.87257,13.119034 l 0,4.143524 9,-6.904755 -9,-6.904756 0,4.110195 C 17.452595,24.73082 14.681424,20.219968 18.218248,16.97554 Z"
-       id="path3503-1"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0f5a00;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  </g>
 </svg>

--- a/data/icons.appdata.xml.in
+++ b/data/icons.appdata.xml.in
@@ -20,6 +20,7 @@
         <ul>
           <li>Additional sizes for playlist-queue</li>
           <li>Additional sizes for emblem-downloads</li>
+          <li>Remove arrows from Copy and Paste actions</li>
         </ul>
       </description>
     </release>


### PR DESCRIPTION
Symbolic versions don't have an arrow and they seem still to convey their meaning. Also helps reduce noise in uses like: https://github.com/elementary/terminal/pull/639

And saves me having to update an arrow shape yay lol