### PR TITLE
Updates to the mime office icons

### DIFF
--- a/mimes/128/application-vnd.oasis.opendocument.graphics-template.svg
+++ b/mimes/128/application-vnd.oasis.opendocument.graphics-template.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/mimes/128/application-vnd.oasis.opendocument.presentation-template.svg
+++ b/mimes/128/application-vnd.oasis.opendocument.presentation-template.svg
@@ -1,0 +1,1 @@
+x-office-presentation-template.svg

--- a/mimes/128/application-vnd.oasis.opendocument.presentation.svg
+++ b/mimes/128/application-vnd.oasis.opendocument.presentation.svg
@@ -1,0 +1,1 @@
+x-office-presentation.svg

--- a/mimes/128/application-vnd.oasis.opendocument.spreadsheet-template.svg
+++ b/mimes/128/application-vnd.oasis.opendocument.spreadsheet-template.svg
@@ -1,0 +1,1 @@
+x-office-spreadsheet-template.svg

--- a/mimes/128/application-vnd.oasis.opendocument.text-template.svg
+++ b/mimes/128/application-vnd.oasis.opendocument.text-template.svg
@@ -1,0 +1,1 @@
+x-office-document-template.svg

--- a/mimes/128/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
+++ b/mimes/128/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/128/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
+++ b/mimes/128/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/128/application-vnd.openxmlformats-officedocument.presentationml.template.svg
+++ b/mimes/128/application-vnd.openxmlformats-officedocument.presentationml.template.svg
@@ -1,0 +1,429 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3172"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.presentationml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="795"
+     inkscape:window-height="480"
+     id="namedview43"
+     showgrid="false"
+     inkscape:zoom="6.1953125"
+     inkscape:cx="64"
+     inkscape:cy="64"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3172" />
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3019-2"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="42.194839"
+       id="linearGradient3016-9"
+       xlink:href="#linearGradient3977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         id="stop3979-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00648027" />
+      <stop
+         id="stop3983-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99423188" />
+      <stop
+         id="stop3985-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-486"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(0,20.070196,-24.639786,0,309.31219,-176.94833)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       id="radialGradient3029-2"
+       fy="9.9571075"
+       fx="6.0330806"
+       r="12.671875"
+       cy="9.9571075"
+       cx="6.5633106" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         id="stop3750-1-0-7" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         id="stop3752-3-7-4" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         id="stop3754-1-8-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ac441f;stop-opacity:1"
+         id="stop3756-1-6-2" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-5"
+       id="radialGradient3159-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.89962666,0.93506368,0,-81.62938,-32.204086)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       id="linearGradient5060-5">
+      <stop
+         id="stop5062-5"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-3"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-5"
+       id="radialGradient3157-51"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.89962666,0.93506368,0,-33.629364,44.798864)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient22140"
+       id="linearGradient3161-7"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661"
+       gradientTransform="matrix(1.0133332,0,0,0.89962576,-0.0436346,3.8658836)" />
+    <linearGradient
+       id="linearGradient22140">
+      <stop
+         id="stop22142"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop22148"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop22144"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3412"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.4100631,-5.3070628,0,309.7614,-121.83734)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient6240"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,0,0,2.0008421,236.50002,-127.60767)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
+    <linearGradient
+       id="linearGradient6240">
+      <stop
+         id="stop6242"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6244"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g978"
+     style="opacity:0.2;stroke-width:1.03923047"
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
+    <rect
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect2801"
+       y="116.00149"
+       x="103.78947"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-121.00149"
+       x="-24.210518"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3700"
+       y="116.00149"
+       x="24.210518"
+       height="5"
+       width="79.578949" />
+  </g>
+  <path
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
+  <path
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3065-3"
+     d="m 67.999999,34 -33.999998,6 v 44 l 33.999998,6 z m 2,8 v 2 h 22 v 26 h 2 V 44 42 h -2 z m 0,4 v 4.3125 c 0.64032,-0.16512 1.3081,-0.3125 2,-0.3125 v 8 h 8 c 0,4.418278 -3.58172,8 -8,8 -0.6919,0 -1.35968,-0.14736 -2,-0.3125 V 68 h 14 v 2 h -14 v 4 h 14 v 2 h -14 v 6 h 20 V 46 Z m 4,2 c 4.41828,0 8,3.581722 8,8 h -8 z m -22.249998,4.5 c 2.00408,0.03422 3.02166,0.432436 3.875,1.25 1.11312,1.066432 1.57576,2.468512 1.5625,4.9375 -0.0218,4.052498 -2.43778,6.5625 -6.25,6.5625 h -1.4375 l -0.125,3.25 -0.0624,3.3125 -1.5,-0.125 -1.5625,-0.0625 V 62.1875 52.75 l 3.125,-0.1875 c 0.92354,-0.05238 1.70696,-0.0739 2.375,-0.0625 z m -2.3125,3.375 v 2.875 c 0,1.578194 0.143,2.955506 0.25,3.0625 0.31264,0.31263 1.18156,0.25892 2.25,-0.1875 1.29652,-0.54172 1.8852,-2.234614 1.375,-3.9375 -0.37618,-1.255598 -1.21008,-1.8125 -2.8125,-1.8125 z" />
+  <g
+     transform="translate(2e-6,-4.8512673e-5)"
+     id="g4345">
+    <g
+       style="opacity:0.3"
+       id="g22150"
+       transform="matrix(-1.833334,0,0,1.4291655,126.00003,68.47502)">
+      <rect
+         style="fill:url(#radialGradient3159-2);fill-opacity:1;stroke:none"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-41.650166"
+         x="-48"
+         height="6.2973804"
+         width="3.2727261" />
+      <rect
+         style="fill:url(#radialGradient3157-51);fill-opacity:1;stroke:none"
+         id="rect22120"
+         y="35.352787"
+         x="1.6387316e-05"
+         height="6.2973804"
+         width="3.2727261" />
+      <rect
+         style="fill:url(#linearGradient3161-7);fill-opacity:1;stroke:none"
+         id="rect22138"
+         y="35.352787"
+         x="3.2727439"
+         height="6.2973785"
+         width="41.454529" />
+    </g>
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="M 121.50004,45.207214 41.212776,125.5 121.50004,125.499 Z m -16,37.002288 v 27.290538 l -27.295082,-8e-5 z" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3103"
+       d="m 98.500032,124.49288 v -2.98929" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3091"
+       d="m 109.50003,125.49882 v -4.00168 m -11.999998,4.00168 v -4.00168 m -12,4.00168 v -3.95406 m -12,3.95406 v -4.00168 m -12,4.00168 v -4.00168" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="M 120.5,47.615627 V 124.5 H 43.626721 Z M 106.5,79.790078 75.779061,110.5 H 106.5 Z" />
+    <path
+       d="m 110.50005,124.49288 v -2.98929"
+       id="path4292"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 86.50005,124.49288 v -2.98929"
+       id="path4294"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4296"
+       d="m 74.50005,124.49288 v -2.98929" />
+    <path
+       d="m 62.50005,124.49288 v -2.98929"
+       id="path4298"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 120.50286,78.499968 h -2.98929"
+       id="path4300"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 121.5088,65.49995 h -4.00168 m 4.00168,12 h -4.00168 m 4.00168,12 h -3.95406 m 3.95406,12 h -4.00168 m 4.00168,12 h -4.00168"
+       id="path4302"
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4304"
+       d="m 120.50286,66.49995 h -2.98929" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4306"
+       d="m 120.50286,90.49995 h -2.98929" />
+    <path
+       d="m 120.50286,102.49995 h -2.98929"
+       id="path4308"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4310"
+       d="m 120.50286,114.49995 h -2.98929" />
+  </g>
+</svg>

--- a/mimes/128/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
+++ b/mimes/128/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
@@ -1,0 +1,429 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3172"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview43"
+     showgrid="false"
+     inkscape:zoom="6.1953125"
+     inkscape:cx="64.322825"
+     inkscape:cy="64"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3172" />
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3019-2"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="42.194839"
+       id="linearGradient3016-9"
+       xlink:href="#linearGradient3977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         id="stop3979-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00648027" />
+      <stop
+         id="stop3983-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99423188" />
+      <stop
+         id="stop3985-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-486"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       xlink:href="#linearGradient3242-7-3-8-0-4-58"
+       id="radialGradient4777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-7.5059748e-8,20.51788,-25.189398,-9.0204266e-8,314.78472,-177.21844)"
+       cx="5.6155143"
+       cy="9.9571075"
+       fx="5.0852842"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58">
+      <stop
+         offset="0"
+         style="stop-color:#bdff69;stop-opacity:1;"
+         id="stop3244-5-8-5-6-4-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#8ed451;stop-opacity:1;"
+         id="stop3246-9-5-1-5-3-0" />
+      <stop
+         offset="0.66093999"
+         style="stop-color:#58aa30;stop-opacity:1;"
+         id="stop3248-7-2-0-7-5-35" />
+      <stop
+         offset="1"
+         style="stop-color:#2a6c1f;stop-opacity:1;"
+         id="stop3250-8-2-8-5-6-40" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-5"
+       id="radialGradient3159-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.89962666,0.93506368,0,-81.62938,-32.204086)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       id="linearGradient5060-5">
+      <stop
+         id="stop5062-5"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-3"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-5"
+       id="radialGradient3157-51"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.89962666,0.93506368,0,-33.629364,44.798864)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient22140"
+       id="linearGradient3161-7"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661"
+       gradientTransform="matrix(1.0133332,0,0,0.89962576,-0.0436346,3.8658836)" />
+    <linearGradient
+       id="linearGradient22140">
+      <stop
+         id="stop22142"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop22148"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop22144"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3412"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.4100631,-5.3070628,0,309.7614,-121.83734)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient6240"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,0,0,2.0008421,236.50002,-127.60767)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
+    <linearGradient
+       id="linearGradient6240">
+      <stop
+         id="stop6242"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6244"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g978"
+     style="opacity:0.2;stroke-width:1.03923047"
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
+    <rect
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect2801"
+       y="116.00149"
+       x="103.78947"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-121.00149"
+       x="-24.210518"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3700"
+       y="116.00149"
+       x="24.210518"
+       height="5"
+       width="79.578949" />
+  </g>
+  <path
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
+  <path
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4777);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 68,33.999998 -34,6 V 84 l 34,6 z m 2,4 v 4 h 8 v 6 h -8 v 2 h 8 v 6 h -8 v 2 h 8 v 6 h -8 v 2 h 8 V 72 h -8 v 2 h 8 v 6 h -8 v 4 H 94 V 37.999998 Z m 10,4 h 10 v 6 H 80 Z m 0,8 h 10 v 6 H 80 Z m -22.6875,1.4375 c 0.36324,-0.007 0.56268,-0.0152 0.5625,0 -2.8e-4,0.0304 -1.02288,2.35512 -2.3125,5.125 l -2.375,5 2.375,5.000002 c 1.28962,2.73274 2.3125,5.07312 2.3125,5.1875 0,0.24018 -1.72324,0.2001 -3.1875,-0.0625 -0.96924,-0.1738 -1.01768,-0.2826 -2.25,-3.375 -0.70226,-1.76229 -1.38174,-3.314232 -1.5,-3.437502 -0.1182,-0.12326 -0.80422,1.212148 -1.5,2.937502 -0.69578,1.72534 -1.34336,3.208798 -1.4375,3.3125 -0.0942,0.1038 -0.94968,0.1038 -1.9375,0 l -1.8125,-0.1875 2.1875,-4.625 2.1875,-4.625002 -1.9375,-4.4375 c -1.06082,-2.44826 -1.9375,-4.63884 -1.9375,-4.8125 0,-0.19384 0.73246,-0.3125 1.875,-0.3125 H 48.5 l 1.0625,3 c 0.59716,1.64213 1.20212,3.06647 1.3125,3.1875 0.1104,0.12102 0.8537,-1.33902 1.625,-3.25 l 1.375,-3.4375 2,-0.125 c 0.55132,-0.0262 1.07424,-0.0552 1.4375,-0.0625 z M 80,57.999998 h 10 v 6 H 80 Z m 0,8 H 90 V 72 H 80 Z M 80,74 h 10 v 6 H 80 Z"
+     id="path4881" />
+  <g
+     transform="translate(2e-6,-4.8512673e-5)"
+     id="g4345">
+    <g
+       style="opacity:0.3"
+       id="g22150"
+       transform="matrix(-1.833334,0,0,1.4291655,126.00003,68.47502)">
+      <rect
+         style="fill:url(#radialGradient3159-2);fill-opacity:1;stroke:none"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-41.650166"
+         x="-48"
+         height="6.2973804"
+         width="3.2727261" />
+      <rect
+         style="fill:url(#radialGradient3157-51);fill-opacity:1;stroke:none"
+         id="rect22120"
+         y="35.352787"
+         x="1.6387316e-05"
+         height="6.2973804"
+         width="3.2727261" />
+      <rect
+         style="fill:url(#linearGradient3161-7);fill-opacity:1;stroke:none"
+         id="rect22138"
+         y="35.352787"
+         x="3.2727439"
+         height="6.2973785"
+         width="41.454529" />
+    </g>
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="M 121.50004,45.207214 41.212776,125.5 121.50004,125.499 Z m -16,37.002288 v 27.290538 l -27.295082,-8e-5 z" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3103"
+       d="m 98.500032,124.49288 v -2.98929" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3091"
+       d="m 109.50003,125.49882 v -4.00168 m -11.999998,4.00168 v -4.00168 m -12,4.00168 v -3.95406 m -12,3.95406 v -4.00168 m -12,4.00168 v -4.00168" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="M 120.5,47.615627 V 124.5 H 43.626721 Z M 106.5,79.790078 75.779061,110.5 H 106.5 Z" />
+    <path
+       d="m 110.50005,124.49288 v -2.98929"
+       id="path4292"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 86.50005,124.49288 v -2.98929"
+       id="path4294"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4296"
+       d="m 74.50005,124.49288 v -2.98929" />
+    <path
+       d="m 62.50005,124.49288 v -2.98929"
+       id="path4298"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 120.50286,78.499968 h -2.98929"
+       id="path4300"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 121.5088,65.49995 h -4.00168 m 4.00168,12 h -4.00168 m 4.00168,12 h -3.95406 m 3.95406,12 h -4.00168 m 4.00168,12 h -4.00168"
+       id="path4302"
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4304"
+       d="m 120.50286,66.49995 h -2.98929" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4306"
+       d="m 120.50286,90.49995 h -2.98929" />
+    <path
+       d="m 120.50286,102.49995 h -2.98929"
+       id="path4308"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4310"
+       d="m 120.50286,114.49995 h -2.98929" />
+  </g>
+</svg>

--- a/mimes/128/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
+++ b/mimes/128/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
@@ -1,0 +1,429 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3172"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview43"
+     showgrid="false"
+     inkscape:zoom="6.1953125"
+     inkscape:cx="64.322825"
+     inkscape:cy="64"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3172" />
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3019-2"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="42.194839"
+       id="linearGradient3016-9"
+       xlink:href="#linearGradient3977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         id="stop3979-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00648027" />
+      <stop
+         id="stop3983-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99423188" />
+      <stop
+         id="stop3985-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-486"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(-4.3420676e-7,17.702744,-21.733318,-5.3138873e-7,280.37217,-161.4174)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3"
+       id="radialGradient3107"
+       fy="9.9571075"
+       fx="5.118885"
+       r="12.671875"
+       cy="9.9571075"
+       cx="5.6491151" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-1-0" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop3752-3-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop3754-1-8" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-1-6" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-5"
+       id="radialGradient3159-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.89962666,0.93506368,0,-81.62938,-32.204086)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       id="linearGradient5060-5">
+      <stop
+         id="stop5062-5"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-3"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-5"
+       id="radialGradient3157-51"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.89962666,0.93506368,0,-33.629364,44.798864)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient22140"
+       id="linearGradient3161-7"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661"
+       gradientTransform="matrix(1.0133332,0,0,0.89962576,-0.0436346,3.8658836)" />
+    <linearGradient
+       id="linearGradient22140">
+      <stop
+         id="stop22142"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop22148"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop22144"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3412"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.4100631,-5.3070628,0,309.7614,-121.83734)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient6240"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,0,0,2.0008421,236.50002,-127.60767)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
+    <linearGradient
+       id="linearGradient6240">
+      <stop
+         id="stop6242"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6244"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g978"
+     style="opacity:0.2;stroke-width:1.03923047"
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
+    <rect
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect2801"
+       y="116.00149"
+       x="103.78947"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-121.00149"
+       x="-24.210518"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3700"
+       y="116.00149"
+       x="24.210518"
+       height="5"
+       width="79.578949" />
+  </g>
+  <path
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
+  <path
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 68,34 -34,5.999999 v 44 L 68,90 Z m 2,5.999999 V 46 h 18 v 2 H 70 v 4 h 18 v 1.999999 H 70 V 58 h 18 v 2 H 70 v 4 h 18 v 2 H 70 v 3.999999 H 88 V 72 H 70 v 4 h 18 v 2 H 70 v 5.999999 h 24 v -44 z M 58.25,51.8125 h 1.9375 c 1.777032,0 1.889532,0.11882 1.6875,1 -0.12028,0.52462 -1.138,5.187088 -2.25,10.375 l -2,9.4375 h -2.0625 c -1.124636,0 -2.040948,-0.06672 -2.0625,-0.125001 -0.02154,-0.0583 -0.667556,-3.144368 -1.4375,-6.874999 -0.769942,-3.730634 -1.500198,-6.537246 -1.625,-6.1875 -0.1248,0.349748 -0.781388,3.416951 -1.4375,6.75 L 47.8125,72.25 45.9375,72.125 44,72 42.4375,63.687499 C 41.565714,59.14079 40.742832,54.92944 40.625,54.3125 40.43004,53.291785 40.56362,53.160392 41.9375,53 c 1.914248,-0.223478 1.996204,-0.02582 3.125,7.3125 0.482236,3.13502 0.872082,5.747088 0.9375,5.8125 0.06542,0.06542 0.7527,-2.907408 1.5,-6.562501 0.7473,-3.655091 1.586918,-6.754521 1.875,-6.937499 0.829112,-0.526616 3.158128,-0.39604 3.375,0.1875 0.10832,0.291456 0.780456,3.44424 1.4375,7 1.099274,5.949016 1.871668,8.115747 1.875,5.25 0.0013,-1.14455 0.87908,-6.609436 1.75,-11 z"
+     id="rect3139"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3107);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     transform="translate(2e-6,-4.8512673e-5)"
+     id="g4345">
+    <g
+       style="opacity:0.3"
+       id="g22150"
+       transform="matrix(-1.833334,0,0,1.4291655,126.00003,68.47502)">
+      <rect
+         style="fill:url(#radialGradient3159-2);fill-opacity:1;stroke:none"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-41.650166"
+         x="-48"
+         height="6.2973804"
+         width="3.2727261" />
+      <rect
+         style="fill:url(#radialGradient3157-51);fill-opacity:1;stroke:none"
+         id="rect22120"
+         y="35.352787"
+         x="1.6387316e-05"
+         height="6.2973804"
+         width="3.2727261" />
+      <rect
+         style="fill:url(#linearGradient3161-7);fill-opacity:1;stroke:none"
+         id="rect22138"
+         y="35.352787"
+         x="3.2727439"
+         height="6.2973785"
+         width="41.454529" />
+    </g>
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="M 121.50004,45.207214 41.212776,125.5 121.50004,125.499 Z m -16,37.002288 v 27.290538 l -27.295082,-8e-5 z" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3103"
+       d="m 98.500032,124.49288 v -2.98929" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3091"
+       d="m 109.50003,125.49882 v -4.00168 m -11.999998,4.00168 v -4.00168 m -12,4.00168 v -3.95406 m -12,3.95406 v -4.00168 m -12,4.00168 v -4.00168" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="M 120.5,47.615627 V 124.5 H 43.626721 Z M 106.5,79.790078 75.779061,110.5 H 106.5 Z" />
+    <path
+       d="m 110.50005,124.49288 v -2.98929"
+       id="path4292"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 86.50005,124.49288 v -2.98929"
+       id="path4294"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4296"
+       d="m 74.50005,124.49288 v -2.98929" />
+    <path
+       d="m 62.50005,124.49288 v -2.98929"
+       id="path4298"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 120.50286,78.499968 h -2.98929"
+       id="path4300"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 121.5088,65.49995 h -4.00168 m 4.00168,12 h -4.00168 m 4.00168,12 h -3.95406 m 3.95406,12 h -4.00168 m 4.00168,12 h -4.00168"
+       id="path4302"
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4304"
+       d="m 120.50286,66.49995 h -2.98929" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4306"
+       d="m 120.50286,90.49995 h -2.98929" />
+    <path
+       d="m 120.50286,102.49995 h -2.98929"
+       id="path4308"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4310"
+       d="m 120.50286,114.49995 h -2.98929" />
+  </g>
+</svg>

--- a/mimes/16/application-vnd.oasis.opendocument.graphics-template.svg
+++ b/mimes/16/application-vnd.oasis.opendocument.graphics-template.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/mimes/16/application-vnd.oasis.opendocument.presentation-template.svg
+++ b/mimes/16/application-vnd.oasis.opendocument.presentation-template.svg
@@ -1,0 +1,1 @@
+x-office-presentation-template.svg

--- a/mimes/16/application-vnd.oasis.opendocument.presentation.svg
+++ b/mimes/16/application-vnd.oasis.opendocument.presentation.svg
@@ -1,0 +1,1 @@
+x-office-presentation.svg

--- a/mimes/16/application-vnd.oasis.opendocument.spreadsheet-template.svg
+++ b/mimes/16/application-vnd.oasis.opendocument.spreadsheet-template.svg
@@ -1,0 +1,1 @@
+x-office-spreadsheet-template.svg

--- a/mimes/16/application-vnd.oasis.opendocument.text-template.svg
+++ b/mimes/16/application-vnd.oasis.opendocument.text-template.svg
@@ -1,0 +1,1 @@
+x-office-document-template.svg

--- a/mimes/16/application-vnd.openofficeorg.extension.svg
+++ b/mimes/16/application-vnd.openofficeorg.extension.svg
@@ -1,0 +1,1 @@
+extension.svg

--- a/mimes/16/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
+++ b/mimes/16/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/16/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
+++ b/mimes/16/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/16/application-vnd.openxmlformats-officedocument.presentationml.template.svg
+++ b/mimes/16/application-vnd.openxmlformats-officedocument.presentationml.template.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.presentationml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="795"
+     inkscape:window-height="480"
+     id="namedview29"
+     showgrid="false"
+     inkscape:zoom="49.5625"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="84"
+     inkscape:window-y="522"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3810" />
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.076912"
+       x2="23.99999"
+       y1="6.9230647"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <radialGradient
+       cx="6.5633106"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
+       id="radialGradient3029"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.6321568,-3.2314473,0,40.106516,-23.337487)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
+      <stop
+         id="stop3750-1-0-7"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7-4"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8-5"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6-2"
+         style="stop-color:#ac441f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,0.6,0.6,0,5.8976269,-12.49769)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3085"
+       y2="30.190546"
+       x2="44.118835"
+       y1="19.948324"
+       x1="33.876614" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         offset="0"
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         id="stop3414" />
+      <stop
+         offset="1"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         id="stop3416" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none" />
+  <path
+     d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 Z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
+     id="path4160-8"
+     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 8,4 4,5.114754 v 5.770492 L 8,12 Z m 0.9998116,1 v 0.6393443 h 2.5411724 v 3.409836 H 12 V 5.6393444 5 h -0.393443 z m 3.769e-4,0.9999999 -3.769e-4,0.4672132 c 0.083978,-0.021659 -0.024979,-0.040984 0.065762,-0.040984 v 1.0491803 h 0.9672132 c 0,0.5794467 -0.3877667,1.0491809 -0.9672133,1.0491809 -0.090741,0 0.018215,-0.01932 -0.065762,-0.04098 v 0.565574 h 1.5575655 v 0.327869 H 8.9998116 v 0.6557377 h 1.5575654 v 0.333756 H 8.9998116 v 0.657213 h 2.0000004 l 3.76e-4,-5.0237599 z m 0.3276804,0.1639344 c 0.5794464,0 0.9672131,0.4697338 0.9672131,1.0491804 H 9.3278689 Z m -3.2387938,0.590164 c 0.2628304,0.00446 0.3962833,0.056715 0.5081969,0.1639344 0.1459831,0.1398598 0.2066571,0.323739 0.2049181,0.6475411 C 6.7993049,8.0970493 6.4824813,8.4262293 5.982518,8.4262293 H 5.7939932 l -0.016392,0.42623 -0.0082,0.434426 -0.1967213,-0.01639 -0.2503847,-0.0082 V 8.0245903 6.7868854 l 0.4553028,-0.02459 c 0.1211199,-0.00687 0.2238635,-0.00969 0.3114753,-0.0082 z m -0.3032784,0.442623 v 0.3770492 c 0,0.2069764 0.018753,0.3876072 0.032788,0.4016393 0.041002,0.041003 0.1549585,0.033961 0.295082,-0.02459 C 6.2837021,7.8797744 6.3609062,7.6577555 6.2939945,7.4344261 6.2446581,7.2697574 6.1352944,7.1967214 5.925141,7.1967214 Z"
+     id="path3065"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     id="g3082"
+     transform="matrix(-1,0,0,1,31.497734,0.69779711)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3410"
+       d="m 16.997627,5.8023097 9,9.0000003 h -9 z m 2,5.0000003 v 2 h 2 z" />
+  </g>
+</svg>

--- a/mimes/16/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
+++ b/mimes/16/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="795"
+     inkscape:window-height="480"
+     id="namedview29"
+     showgrid="false"
+     inkscape:zoom="49.5625"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="660"
+     inkscape:window-y="396"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3810" />
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.076912"
+       x2="23.99999"
+       y1="6.9230647"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <radialGradient
+       xlink:href="#linearGradient3242-7-3-8-0-4-58"
+       id="radialGradient4777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0007967e-8,2.7357173,-3.3585864,-1.2027235e-8,41.437964,-23.895792)"
+       cx="5.6155143"
+       cy="9.9571075"
+       fx="5.0852842"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58">
+      <stop
+         offset="0"
+         style="stop-color:#bdff69;stop-opacity:1;"
+         id="stop3244-5-8-5-6-4-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#8ed451;stop-opacity:1;"
+         id="stop3246-9-5-1-5-3-0" />
+      <stop
+         offset="0.66093999"
+         style="stop-color:#58aa30;stop-opacity:1;"
+         id="stop3248-7-2-0-7-5-35" />
+      <stop
+         offset="1"
+         style="stop-color:#2a6c1f;stop-opacity:1;"
+         id="stop3250-8-2-8-5-6-40" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,0.6,0.6,0,5.8976269,-12.49769)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3085"
+       y2="30.190546"
+       x2="44.118835"
+       y1="19.948324"
+       x1="33.876614" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         offset="0"
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         id="stop3414" />
+      <stop
+         offset="1"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         id="stop3416" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none" />
+  <path
+     d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 Z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
+     id="path4160-8"
+     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4777);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 8,4 4,5.0666667 V 10.933333 L 8,12 Z M 9,5.0711864 V 5.742578 h 1.002825 V 6.385105 H 9 v 0.3636364 h 1.002825 V 7.3912687 H 9 v 0.3466876 h 1.002825 v 0.664304 H 9 v 0.375757 h 1.002825 v 0.591679 H 9 v 0.363637 h 1.002825 V 10.409758 H 9 v 0.664099 h 3 V 5.0711864 Z m 1.467129,0.6713916 h 0.866204 v 0.642527 h -0.866204 z m 0,1.0061634 h 0.866204 V 7.3912687 H 10.467129 Z M 6.690904,6.52387 c 0.048433,-9.333e-4 0.075024,-0.00207 0.075,0 -3.73e-5,0.00407 -0.1363837,0.3140154 -0.308333,0.6833334 L 6.1409043,7.8738703 6.457571,8.5405363 c 0.1719493,0.364366 0.308333,0.676416 0.308333,0.691667 0,0.03203 -0.229765,0.02668 -0.4249997,-0.0083 -0.129232,-0.02317 -0.1356907,-0.03768 -0.3,-0.45 -0.093635,-0.234972 -0.184232,-0.441898 -0.2,-0.458334 -0.01576,-0.01643 -0.1072293,0.16162 -0.2,0.391667 -0.092771,0.230045 -0.1791147,0.42784 -0.1916667,0.441667 -0.01256,0.01384 -0.126624,0.01384 -0.2583333,0 L 4.9492376,9.1238703 5.2409043,8.5072033 5.532571,7.8905363 5.2742376,7.29887 C 5.1327949,6.9724354 5.0159043,6.6803567 5.0159043,6.6572027 c 0,-0.02584 0.097661,-0.041667 0.25,-0.041667 h 0.25 l 0.1416667,0.4 c 0.079621,0.2189507 0.1602826,0.4088627 0.175,0.425 0.01472,0.016133 0.1138266,-0.1785366 0.2166666,-0.433334 L 6.232571,6.5488694 6.4992376,6.5322027 c 0.073509,-0.00347 0.143232,-0.00737 0.1916664,-0.00833 z m 3.776225,1.2140863 h 0.866204 v 0.664304 h -0.866204 z m 0,1.040061 h 0.866204 v 0.591679 h -0.866204 z m 0,0.955316 h 0.866204 v 0.6764247 h -0.866204 z"
+     id="path4881" />
+  <g
+     id="g3082"
+     transform="matrix(-1,0,0,1,31.497734,0.69779711)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3410"
+       d="m 16.997627,5.8023097 9,9.0000003 h -9 z m 2,5.0000003 v 2 h 2 z" />
+  </g>
+</svg>

--- a/mimes/16/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
+++ b/mimes/16/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg3810"
+   sodipodi:docname="application-vnd.oasis.opendocument.text-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview29"
+     showgrid="false"
+     inkscape:zoom="49.5625"
+     inkscape:cx="8.0403531"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3810" />
+  <defs
+     id="defs3812">
+    <linearGradient
+       x1="23.99999"
+       y1="6.9230647"
+       x2="23.99999"
+       y2="41.076912"
+       id="linearGradient3988"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3806"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         id="stop3106-5"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         offset="0" />
+      <stop
+         id="stop3108-5"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3019"
+       xlink:href="#linearGradient3104-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="5.118885"
+       cy="9.9571075"
+       cx="5.6491151"
+       gradientTransform="matrix(-5.1086766e-8,2.3603657,-2.5570421,-7.085182e-8,32.987014,-21.789244)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3441"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-1-0" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop3752-3-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop3754-1-8" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-1-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,0.6,0.6,0,5.8976269,-12.49769)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3085"
+       y2="30.190546"
+       x2="44.118835"
+       y1="19.948324"
+       x1="33.876614" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         offset="0"
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         id="stop3414" />
+      <stop
+         offset="1"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         id="stop3416" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none"
+     id="path4160"
+     d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1"
+     d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 Z" />
+  <path
+     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-8"
+     d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z" />
+  <path
+     id="path3439"
+     d="M 8,4 4,5.066406 v 5.867187 L 8,12 Z m 1,1.066406 v 0.8190104 h 2.166667 V 6.1575519 H 9 v 0.5455728 h 2.166667 V 6.9752601 H 9 v 0.5455733 h 2.166667 V 7.7942707 H 9 v 0.5442705 h 2.166667 v 0.273438 H 9 v 0.545573 h 2.166667 v 0.272135 H 9 v 0.545573 h 2.166667 V 10.247395 H 9 v 0.819011 h 3 v -6 z M 6.8541667,6.6419267 h 0.2265627 c 0.2090786,0 0.2216873,0.015327 0.1979166,0.1328127 C 7.264493,6.8446864 7.146458,7.4658301 7.0156254,8.1575522 L 6.779948,9.4166662 H 6.5364584 c -0.1323202,0 -0.2396518,-0.0092 -0.2421876,-0.01693 C 6.2917042,9.3919662 6.2155887,8.9804902 6.125,8.4830732 6.0344125,7.9856527 5.9482764,7.6109194 5.9335938,7.6575521 5.9189091,7.7041854 5.8428205,8.1141874 5.765625,8.5585932 L 5.625,9.3671872 5.404948,9.3489582 5.1770833,9.3333332 4.9934896,8.2239582 C 4.8909196,7.6177307 4.7938118,7.0562174 4.7799479,6.9739581 c -0.022937,-0.1360954 -0.008,-0.1530934 0.1536458,-0.1744794 0.2252215,-0.029793 0.2343784,-0.00313 0.3671876,0.9752607 0.056735,0.4180028 0.1042825,0.7660178 0.1119791,0.7747398 0.00769,0.0087 0.086556,-0.387655 0.1744792,-0.8750005 0.087924,-0.4873453 0.1874598,-0.9000813 0.2213542,-0.9244786 0.09755,-0.070217 0.3716194,-0.05306 0.3971354,0.02474 0.012743,0.03886 0.091966,0.4594926 0.1692708,0.933594 0.1293352,0.7932021 0.2209624,1.0813191 0.2213542,0.6992191 1.51e-4,-0.152607 0.1032612,-0.8807385 0.2057292,-1.4661465 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3441);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     id="g3082"
+     transform="matrix(-1,0,0,1,31.497734,0.69779711)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3410"
+       d="m 16.997627,5.8023097 9,9.0000003 h -9 z m 2,5.0000003 v 2 h 2 z" />
+  </g>
+</svg>

--- a/mimes/24/application-vnd.oasis.opendocument.graphics-template.svg
+++ b/mimes/24/application-vnd.oasis.opendocument.graphics-template.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/mimes/24/application-vnd.oasis.opendocument.presentation-template.svg
+++ b/mimes/24/application-vnd.oasis.opendocument.presentation-template.svg
@@ -1,0 +1,1 @@
+x-office-presentation-template.svg

--- a/mimes/24/application-vnd.oasis.opendocument.presentation.svg
+++ b/mimes/24/application-vnd.oasis.opendocument.presentation.svg
@@ -1,0 +1,1 @@
+x-office-presentation.svg

--- a/mimes/24/application-vnd.oasis.opendocument.spreadsheet-template.svg
+++ b/mimes/24/application-vnd.oasis.opendocument.spreadsheet-template.svg
@@ -1,0 +1,1 @@
+x-office-spreadsheet-template.svg

--- a/mimes/24/application-vnd.oasis.opendocument.text-template.svg
+++ b/mimes/24/application-vnd.oasis.opendocument.text-template.svg
@@ -1,0 +1,1 @@
+x-office-document-template.svg

--- a/mimes/24/application-vnd.openofficeorg.extension.svg
+++ b/mimes/24/application-vnd.openofficeorg.extension.svg
@@ -1,0 +1,1 @@
+extension.svg

--- a/mimes/24/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
+++ b/mimes/24/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/24/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
+++ b/mimes/24/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/24/application-vnd.openxmlformats-officedocument.presentationml.template.svg
+++ b/mimes/24/application-vnd.openxmlformats-officedocument.presentationml.template.svg
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3828"
+   height="24"
+   width="24"
+   version="1.1"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.presentationml.template.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1319"
+     inkscape:window-height="980"
+     id="namedview38"
+     showgrid="true"
+     inkscape:zoom="55.625733"
+     inkscape:cx="12.20339"
+     inkscape:cy="10.561817"
+     inkscape:window-x="-49"
+     inkscape:window-y="157"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4274" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.526306"
+       x2="23.99999"
+       y1="6.4736748"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3">
+      <stop
+         id="stop3750-1-0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3"
+       id="radialGradient3441"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-7.6630149e-8,3.5405486,-3.8355631,-1.0627773e-7,89.480521,-32.283476)"
+       cx="5.6491151"
+       cy="9.9571075"
+       fx="5.118885"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       cx="6.5633106"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
+       id="radialGradient3029"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.0140392,-4.9279572,0,61.062437,-35.389667)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
+      <stop
+         id="stop3750-1-0-7"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7-4"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8-5"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6-2"
+         style="stop-color:#ac441f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3044"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01472605,0,0,0.0095356,21.208141,18.688026)" />
+    <linearGradient
+       x1="33.876614"
+       y1="19.948324"
+       x2="44.118835"
+       y2="30.190546"
+       id="linearGradient3391"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.61754391,-0.65185192,0,33.55926,-4.7561431)" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="22"
+     x="3.5000007"
+     height="2"
+     width="16.999998" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none"
+     id="path4160-3"
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
+  <path
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-3-1"
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
+  <path
+     inkscape:connector-curvature="0"
+     d="M 12,6.8 6,8 6,16.8 12,18 Z m 1,1.2 0,0.8 4.5,0 0,5.2 0.7,0 0,-5.2 0,-0.8 -0.6,0 z m 0,1.2 0,0.8625 C 13.128066,10.02947 13.46162,10 13.6,10 l 0,1.6 1.6,0 c 0,0.883656 -0.716344,1.6 -1.6,1.6 -0.13838,0 -0.471934,-0.02947 -0.6,-0.0625 L 13,14 l 3,0 0,0.5 -3,0 0,1 3,0 0,0.508978 -3,0 0,1.00225 4,0 L 17,9.2 Z m 1,0.4 c 0.883656,0 1.6,0.716344 1.6,1.6 l -1.6,0 z m -4.8141604,0.9 c 0.4008164,0.0068 0.604332,0.08649 0.7750002,0.25 0.2226242,0.213286 0.3151522,0.493702 0.3125002,0.9875 -0.0044,0.8105 -0.487556,1.3125 -1.25,1.3125 l -0.2875004,0 -0.024998,0.65 -0.012502,0.6625 -0.3,-0.025 -0.3818367,-0.0125 0,-1.8875 0,-1.8875 0.6943369,-0.0375 C 8.8955476,10.50202 9.0522316,10.49772 9.1858396,10.5 Z m -0.4624996,0.675 0,0.575 c 0,0.315639 0.028598,0.591101 0.050002,0.6125 0.062528,0.06253 0.2363117,0.05179 0.45,-0.0375 0.2593037,-0.108344 0.37704,-0.446923 0.2749997,-0.7875 C 9.4231037,11.28638 9.256324,11.175 8.93584,11.175 Z"
+     id="path3065"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="cccccccccccccccccccscccccccccccccccccsscsccccccccscscsssc" />
+  <g
+     id="g4198"
+     transform="translate(-1.0849469e-4,4.9581543e-4)">
+    <path
+       d="m 12.333333,22.18431 c 0,0 0,2.315662 0,2.315662 C 11.574979,24.504372 10.5,23.981149 10.5,23.341991 c 0,-0.639157 0.846268,-1.157681 1.833333,-1.157681 z"
+       id="path2883-9"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="M 21.499999,13 10.5,23.5 21.499999,23.500474 Z M 19.5,17.8 v 3.7 h -3.9 z"
+       id="path3410"
+       style="opacity:0.8;fill:url(#linearGradient3391);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/mimes/24/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
+++ b/mimes/24/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3828"
+   height="24"
+   width="24"
+   version="1.1"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview38"
+     showgrid="true"
+     inkscape:zoom="39.333333"
+     inkscape:cx="12.20339"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3828"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4278" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.526306"
+       x2="23.99999"
+       y1="6.4736748"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3">
+      <stop
+         id="stop3750-1-0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3"
+       id="radialGradient3441"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-7.6630149e-8,3.5405486,-3.8355631,-1.0627773e-7,89.48052,-32.283476)"
+       cx="5.6491151"
+       cy="9.9571075"
+       fx="5.118885"
+       fy="9.9571075"
+       r="12.671875" />
+    <radialGradient
+       xlink:href="#linearGradient3242-7-3-8-0-4-58"
+       id="radialGradient4777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.501195e-8,4.103576,-5.0378796,-1.8040853e-8,62.156945,-35.443688)"
+       cx="5.6155143"
+       cy="9.9571075"
+       fx="5.0852842"
+       fy="9.9571075"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58">
+      <stop
+         offset="0"
+         style="stop-color:#bdff69;stop-opacity:1;"
+         id="stop3244-5-8-5-6-4-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#8ed451;stop-opacity:1;"
+         id="stop3246-9-5-1-5-3-0" />
+      <stop
+         offset="0.66093999"
+         style="stop-color:#58aa30;stop-opacity:1;"
+         id="stop3248-7-2-0-7-5-35" />
+      <stop
+         offset="1"
+         style="stop-color:#2a6c1f;stop-opacity:1;"
+         id="stop3250-8-2-8-5-6-40" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3044"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01472605,0,0,0.0095356,21.208141,18.688026)" />
+    <linearGradient
+       x1="33.876614"
+       y1="19.948324"
+       x2="44.118835"
+       y2="30.190546"
+       id="linearGradient3391"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.61754391,-0.65185192,0,33.55926,-4.7561431)" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="22"
+     x="3.5000007"
+     height="2"
+     width="16.999998" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none"
+     id="path4160-3"
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
+  <path
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-3-1"
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3441);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 52,6.8007812 46,8 46,16.800781 52,18 52,6.8007812 Z M 53,8 l 0,1.2285156 3.75,0 0,0.4082032 -3.75,0 0,0.8183592 3.75,0 0,0.408203 -3.75,0 0,0.81836 3.75,0 0,0.410156 -3.75,0 0,0.816406 3.75,0 0,0.410156 -3.75,0 0,0.81836 3.75,0 0,0.408203 -3.75,0 0,0.818359 3.75,0 0,0.408203 -3.75,0 L 53,17 l 5,0 0,-9 -5,0 z m -2.71875,2.363281 0.339844,0 c 0.313618,0 0.332531,0.02299 0.296875,0.199219 -0.02123,0.10492 -0.198282,1.036636 -0.394531,2.074219 l -0.353516,1.888672 -0.365235,0 c -0.19848,0 -0.359477,-0.01373 -0.363281,-0.02539 -0.0038,-0.01166 -0.118023,-0.628874 -0.253906,-1.375 -0.135881,-0.74613 -0.265085,-1.30823 -0.287109,-1.238281 -0.02203,0.06995 -0.13616,0.684953 -0.251954,1.351562 l -0.210937,1.212891 -0.330078,-0.02734 -0.341797,-0.02344 -0.275391,-1.664063 c -0.153855,-0.909341 -0.299516,-1.751611 -0.320312,-1.875 -0.03441,-0.204143 -0.01199,-0.22964 0.230469,-0.261719 0.337832,-0.04469 0.351567,-0.0047 0.550781,1.462891 0.0851,0.627004 0.156424,1.149027 0.167969,1.162109 0.01154,0.01309 0.129833,-0.581482 0.261718,-1.3125 0.131887,-0.731018 0.28119,-1.350122 0.332032,-1.386718 0.146324,-0.105326 0.557429,-0.07959 0.595703,0.03711 0.01911,0.05829 0.137949,0.689239 0.253906,1.400391 0.194003,1.189803 0.331444,1.621978 0.332031,1.048828 2.27e-4,-0.22891 0.154892,-1.321107 0.308594,-2.199219 l 0.07813,-0.449219 z"
+     id="path3439"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4777);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 12,6.8 6,8 6,16.8 12,18 Z m 1,1.2067796 0,1.0070874 2.004237,0 0,0.9637904 -2.004237,0 0,0.5454546 2.004237,0 0,0.963791 -2.004237,0 0,0.520031 2.004237,0 0,0.996456 -2.004237,0 0,0.563636 2.004237,0 0,0.887519 -2.004237,0 L 13,15 l 2.004237,0 0,1.014638 -2.004237,0 0,0.996148 5,0 0,-9.0040064 z m 2.700693,1.0070874 1.299307,0 0,0.9637904 -1.299307,0 z m 0,1.509245 1.299307,0 0,0.963791 -1.299307,0 z m -5.664337,-0.337307 c 0.07265,-0.0014 0.112536,-0.0031 0.1125,0 -5.6e-5,0.0061 -0.2045756,0.471023 -0.4624996,1.025 l -0.475,1 0.475,1 c 0.257924,0.546548 0.4624996,1.014624 0.4624996,1.0375 0,0.04804 -0.3446476,0.04002 -0.6374996,-0.0125 -0.193848,-0.03476 -0.203536,-0.05652 -0.45,-0.675 -0.140452,-0.352458 -0.276348,-0.662847 -0.3,-0.6875 -0.02364,-0.02465 -0.160844,0.242429 -0.3,0.5875 -0.139156,0.345068 -0.268672,0.64176 -0.2875,0.6625 -0.01884,0.02076 -0.189936,0.02076 -0.3875,0 l -0.3625,-0.0375 0.4375,-0.925 0.4375,-0.925 -0.3875,-0.8875 c -0.212164,-0.489652 -0.3875,-0.92777 -0.3875,-0.962501 0,-0.03876 0.146492,-0.0625 0.375,-0.0625 l 0.375,0 0.2125,0.6 c 0.119432,0.328426 0.240424,0.613294 0.2625,0.6375 0.02208,0.0242 0.17074,-0.267805 0.325,-0.650001 l 0.275,-0.687499 0.4,-0.025 c 0.110264,-0.0052 0.214848,-0.01105 0.2874996,-0.0125 z m 5.664337,1.821129 1.299307,0 0,0.996456 -1.299307,0 z m 0,1.560092 1.299307,0 0,0.887519 -1.299307,0 z M 15.700693,15 17,15 l 0,1.014638 -1.299307,0 z"
+     id="path4881"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccscscsccccccsscccccccccccccccccccccc" />
+  <g
+     id="g4198"
+     transform="translate(-1.0849469e-4,4.9581543e-4)">
+    <path
+       d="m 12.333333,22.18431 c 0,0 0,2.315662 0,2.315662 C 11.574979,24.504372 10.5,23.981149 10.5,23.341991 c 0,-0.639157 0.846268,-1.157681 1.833333,-1.157681 z"
+       id="path2883-9"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="M 21.499999,13 10.5,23.5 21.499999,23.500474 Z M 19.5,17.8 v 3.7 h -3.9 z"
+       id="path3410"
+       style="opacity:0.8;fill:url(#linearGradient3391);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/mimes/24/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
+++ b/mimes/24/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg3828"
+   sodipodi:docname="application-msword (copy 1).svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview38"
+     showgrid="false"
+     inkscape:zoom="33.041667"
+     inkscape:cx="12.06053"
+     inkscape:cy="10.789407"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3828" />
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.4736748"
+       x2="23.99999"
+       y2="41.526306"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-1-0" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop3752-3-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop3754-1-8" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-1-6" />
+    </linearGradient>
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="5.118885"
+       cy="9.9571075"
+       cx="5.6491151"
+       gradientTransform="matrix(-7.6630149e-8,3.5405486,-3.8355631,-1.0627773e-7,49.480521,-32.283476)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3441"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3044"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01472605,0,0,0.0095356,21.208141,18.688026)" />
+    <linearGradient
+       x1="33.876614"
+       y1="19.948324"
+       x2="44.118835"
+       y2="30.190546"
+       id="linearGradient3391"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.61754391,-0.65185192,0,33.55926,-4.7561431)" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="16.999998"
+     height="2"
+     x="3.5000007"
+     y="22"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z"
+     id="path4160-3"
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none" />
+  <path
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z"
+     id="path4160-3-1"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     id="path3439"
+     d="M 12 6.8007812 L 6 8 L 6 16.800781 L 12 18 L 12 6.8007812 z M 13 8 L 13 9.2285156 L 16.75 9.2285156 L 16.75 9.6367188 L 13 9.6367188 L 13 10.455078 L 16.75 10.455078 L 16.75 10.863281 L 13 10.863281 L 13 11.681641 L 16.75 11.681641 L 16.75 12.091797 L 13 12.091797 L 13 12.908203 L 16.75 12.908203 L 16.75 13.318359 L 13 13.318359 L 13 14.136719 L 16.75 14.136719 L 16.75 14.544922 L 13 14.544922 L 13 15.363281 L 16.75 15.363281 L 16.75 15.771484 L 13 15.771484 L 13 17 L 18 17 L 18 8 L 13 8 z M 10.28125 10.363281 L 10.621094 10.363281 C 10.934712 10.363281 10.953625 10.386271 10.917969 10.5625 C 10.896739 10.66742 10.719687 11.599136 10.523438 12.636719 L 10.169922 14.525391 L 9.8046875 14.525391 C 9.6062072 14.525391 9.4452099 14.51166 9.4414062 14.5 C 9.437556 14.48834 9.323383 13.871126 9.1875 13.125 C 9.0516187 12.37887 8.9224145 11.81677 8.9003906 11.886719 C 8.8783632 11.956669 8.7642307 12.571672 8.6484375 13.238281 L 8.4375 14.451172 L 8.1074219 14.423828 L 7.765625 14.400391 L 7.4902344 12.736328 C 7.3363794 11.826987 7.1907177 10.984717 7.1699219 10.861328 C 7.1355159 10.657185 7.1579277 10.631688 7.4003906 10.599609 C 7.7382228 10.554919 7.7519582 10.594909 7.9511719 12.0625 C 8.0362739 12.689504 8.1075956 13.211527 8.1191406 13.224609 C 8.1306806 13.237699 8.2489745 12.643127 8.3808594 11.912109 C 8.5127456 11.181091 8.662049 10.561987 8.7128906 10.525391 C 8.8592151 10.420065 9.2703197 10.4458 9.3085938 10.5625 C 9.3277078 10.62079 9.4465431 11.251739 9.5625 11.962891 C 9.7565028 13.152694 9.8939436 13.584869 9.8945312 13.011719 C 9.8947578 12.782809 10.049423 11.690612 10.203125 10.8125 L 10.28125 10.363281 z "
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3441);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     id="g4198"
+     transform="translate(-1.0849469e-4,4.9581543e-4)">
+    <path
+       d="m 12.333333,22.18431 c 0,0 0,2.315662 0,2.315662 C 11.574979,24.504372 10.5,23.981149 10.5,23.341991 c 0,-0.639157 0.846268,-1.157681 1.833333,-1.157681 z"
+       id="path2883-9"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="M 21.499999,13 10.5,23.5 21.499999,23.500474 Z M 19.5,17.8 v 3.7 h -3.9 z"
+       id="path3410"
+       style="opacity:0.8;fill:url(#linearGradient3391);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/mimes/32/application-vnd.oasis.opendocument.graphics-template.svg
+++ b/mimes/32/application-vnd.oasis.opendocument.graphics-template.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/mimes/32/application-vnd.oasis.opendocument.presentation-template.svg
+++ b/mimes/32/application-vnd.oasis.opendocument.presentation-template.svg
@@ -1,0 +1,1 @@
+x-office-presentation-template.svg

--- a/mimes/32/application-vnd.oasis.opendocument.presentation.svg
+++ b/mimes/32/application-vnd.oasis.opendocument.presentation.svg
@@ -1,0 +1,1 @@
+x-office-presentation.svg

--- a/mimes/32/application-vnd.oasis.opendocument.spreadsheet-template.svg
+++ b/mimes/32/application-vnd.oasis.opendocument.spreadsheet-template.svg
@@ -1,0 +1,1 @@
+x-office-spreadsheet-template.svg

--- a/mimes/32/application-vnd.oasis.opendocument.text-template.svg
+++ b/mimes/32/application-vnd.oasis.opendocument.text-template.svg
@@ -1,0 +1,1 @@
+x-office-document-template.svg

--- a/mimes/32/application-vnd.openofficeorg.extension.svg
+++ b/mimes/32/application-vnd.openofficeorg.extension.svg
@@ -1,0 +1,1 @@
+extension.svg

--- a/mimes/32/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
+++ b/mimes/32/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/32/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
+++ b/mimes/32/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/32/application-vnd.openxmlformats-officedocument.presentationml.template.svg
+++ b/mimes/32/application-vnd.openxmlformats-officedocument.presentationml.template.svg
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg3182"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.presentationml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview49"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="16.080706"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3182"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99999994" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.1851754"
+       x2="23.99999"
+       y2="41.814808"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <radialGradient
+       gradientTransform="matrix(0,5.4038149,-6.6046736,0,142.06621,-52.987684)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3242-4"
+       id="radialGradient3988-4"
+       fy="9.9941158"
+       fx="8.276144"
+       r="12.671875"
+       cy="9.9941158"
+       cx="8.276144" />
+    <linearGradient
+       id="linearGradient3242-4">
+      <stop
+         offset="0"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         id="stop3244-7" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         id="stop3246-1" />
+      <stop
+         offset="0.66093999"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop3248-5" />
+      <stop
+         offset="1"
+         style="stop-color:#690b2c;stop-opacity:1"
+         id="stop3250-7" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,5.3759454,-6.5706096,0,81.416581,-48.004018)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       id="radialGradient3029"
+       fy="9.9571075"
+       fx="6.0330806"
+       r="12.671875"
+       cy="9.9571075"
+       cx="6.5633106" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         id="stop3750-1-0-7" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         id="stop3752-3-7-4" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         id="stop3754-1-8-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ac441f;stop-opacity:1"
+         id="stop3756-1-6-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,-1,-16.999999,48.999999)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273"
+       y2="18.12406"
+       x2="38.972309"
+       y1="32.537422"
+       x1="42.783993" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         offset="0"
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         id="stop3414" />
+      <stop
+         offset="1"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         id="stop3416" />
+    </linearGradient>
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       id="linearGradient3428">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3430" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3432" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="22.100021"
+     height="2"
+     x="4.9499893"
+     y="29"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z"
+     id="path4160-3"
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
+  <path
+     d="M 77,8.5000001 68,10.107143 68,21.892857 77,23.5 Z m 1.816667,2.1428569 c -0.170607,0.0017 -0.343939,0.01015 -0.516667,0.01674 l -0.366667,0.01674 0,1.356027 0,1.356027 -0.06667,0.03348 c 0.531627,0.06704 1.782304,0.04693 2.616666,-0.03348 C 82.7279,13.172119 84.142696,12.552662 83.9,11.898437 83.627716,11.164459 81.375774,10.620906 78.816667,10.642857 Z M 84,12.882813 83.8,13.117188 c -0.263492,0.318187 -0.990899,0.568596 -1.883333,0.765626 -0.551416,0.121738 -1.147144,0.16782 -2.516667,0.200892 l -1.466667,0.03348 0,0.744419 0,1.037946 1.416667,-0.05022 c 1.386317,-0.03297 1.926936,-0.0807 2.55,-0.217634 0.899039,-0.197593 1.599458,-0.481437 1.866667,-0.770089 L 83.95,14.660714 83.98333,13.572545 Z m -12.120621,0.945842 0.533333,0 c 0.444235,0 0.549952,0.02083 0.583333,0.133928 0.02219,0.07519 0.332864,1.229353 0.7,2.561384 0.367136,1.332031 0.681403,2.45745 0.7,2.511161 0.02464,0.07114 -0.09268,0.104939 -0.416666,0.100446 -0.24463,-0.0034 -0.482912,-0.02957 -0.533334,-0.05022 -0.0504,-0.02065 -0.141632,-0.299714 -0.216666,-0.619419 l -0.15,-0.569197 -0.7,0 -0.716667,0 -0.116667,0.518973 -0.1,0.535715 -0.5,0.01674 -0.483333,0.01674 0.03333,-0.133929 c 0.02341,-0.07734 0.297712,-1.059152 0.6,-2.176339 0.302288,-1.117187 0.602614,-2.201869 0.666667,-2.427455 z m 0.5,1.205357 c -0.02192,0.0061 -0.124272,0.345054 -0.233334,0.78683 -0.116325,0.47123 -0.227509,0.912528 -0.25,0.987724 -0.036,0.120334 0.02558,0.180573 0.466667,0.150669 l 0.5,0 -0.233333,-0.920759 c -0.125371,-0.504882 -0.237936,-0.962922 -0.25,-1.004464 z M 84,15.347342 c -0.237288,0 -0.233333,0.251116 -0.233333,0.251116 -0.608457,0.661848 -2.572125,1.078102 -4.983334,1.0542 l -0.8,-0.01674 -0.03333,0.619663 -0.01667,1.004465 0.133333,0.05022 c 0.291413,0.08836 2.738665,-0.02429 3.433333,-0.15067 0.969736,-0.176426 1.858324,-0.477872 2.183333,-0.753348 L 83.95,17.171875 83.98333,16.066964 Z m 0,2.383015 -0.233333,0.284598 C 83.198549,18.672429 81.452362,19.060181 79,19.069642 l -1.066666,0 0,0.663617 0,1.021205 0.08333,0.03348 c 0.844061,0.06 1.151274,0.04652 2.183333,-0.03348 1.746543,-0.135379 3.080135,-0.491715 3.516667,-0.954241 L 83.95,19.549107 l 0.03333,-1.08817 z"
+     id="path4255"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3988-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3065"
+     d="M 17,8.5 8,10.107143 8,21.892857 17,23.5 Z m 1,1.8 0,0.7 6,0 0,7.142857 0.7,0 0,-7.142857 0,-0.7 -0.7,0 z m -0.06667,1.728581 0,1.155133 c 0.170755,-0.04423 0.282159,-0.08371 0.466666,-0.08371 l 0,2.214291 2.200001,0 c 0,1.183467 -0.955126,2.071423 -2.133335,2.071423 -0.184507,0 -0.362577,-0.03947 -0.533332,-0.08371 l 0,1.197992 3.733333,0 0,0.5 -3.733333,0 0,1 3.733333,0 0,0.5 -3.733333,0 0,1.171428 5.066666,0 0,-9.642857 z m 1.06667,0.535714 c 1.178207,0 2.133333,0.95939 2.133333,2.142857 l -2.133333,0 z m -6.266671,0.891062 c 0.534422,0.0092 0.805776,0.115831 1.033334,0.334821 0.296832,0.285652 0.420202,0.661209 0.416666,1.322545 -0.0058,1.085491 -0.650074,1.757813 -1.666666,1.757813 l -0.383334,0 -0.03333,0.870535 -0.01667,0.887277 -0.4,-0.03348 -0.416666,-0.01674 0,-2.527902 0,-2.527902 L 12.1,13.472098 c 0.246277,-0.01403 0.455189,-0.01979 0.633333,-0.01674 z m -0.616666,0.904018 0,0.770089 c 0,0.422731 0.03813,0.791654 0.06667,0.820313 0.08337,0.08374 0.315083,0.06935 0.6,-0.05022 0.345739,-0.145104 0.50272,-0.598558 0.366667,-1.054688 -0.100315,-0.336321 -0.322688,-0.485491 -0.75,-0.485491 z" />
+  <g
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-3.358753,-3.6595092)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3410"
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/mimes/32/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
+++ b/mimes/32/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3182"
+   height="32"
+   width="32"
+   version="1.1"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview42"
+     showgrid="false"
+     inkscape:zoom="49.5625"
+     inkscape:cx="21.86349"
+     inkscape:cy="22.80931"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3182"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="0.99999994"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.814808"
+       x2="23.99999"
+       y1="6.1851754"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="5.0852842"
+       cy="9.9571075"
+       cx="5.6155143"
+       gradientTransform="matrix(-2.0015933e-8,5.4714347,-6.7171728,-2.4054471e-8,82.875925,-48.791584)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4777"
+       xlink:href="#linearGradient3242-7-3-8-0-4-58" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58">
+      <stop
+         id="stop3244-5-8-5-6-4-3"
+         style="stop-color:#bdff69;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0"
+         style="stop-color:#8ed451;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35"
+         style="stop-color:#58aa30;stop-opacity:1;"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40"
+         style="stop-color:#2a6c1f;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="42.783993"
+       y1="32.537422"
+       x2="38.972309"
+       y2="18.12406"
+       id="linearGradient3273"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-16.999999,48.999999)" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       id="linearGradient3428">
+      <stop
+         id="stop3430"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3432"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="29"
+     x="4.9499893"
+     height="2"
+     width="22.100021" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z" />
+  <path
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline"
+     id="path4160-3"
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z" />
+  <path
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z"
+     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     id="path4881"
+     d="m 17,8.0333332 -9,1.5999999 0,11.7333339 9,1.6 z M 18,10 l 0,1 2,0 0,1 -2,0 0,1 2,0 0,1 -2,0 0,1 2,0 0,1 -2,0 0,1 2,0 0,1 -2,0 0,1 2,0 0,1 -2,0 0,1 6,0 0,-11 z m 3,1 1.933333,0 0,1 L 21,12 Z m 0,2 1.933333,0 0,1 L 21,14 Z m -6.783333,-0.316667 c 0.09686,-0.0019 0.150048,-0.004 0.15,0 -7.5e-5,0.0081 -0.272768,0.628032 -0.616667,1.366667 L 13.116667,15.383333 13.75,16.716667 c 0.343899,0.72873 0.616667,1.352832 0.616667,1.383333 0,0.06405 -0.459531,0.05336 -0.85,-0.01667 -0.258464,-0.04635 -0.271382,-0.07536 -0.6,-0.9 -0.18727,-0.469944 -0.368464,-0.883796 -0.4,-0.916667 -0.03152,-0.03287 -0.214459,0.323239 -0.4,0.783334 -0.185542,0.46009 -0.35823,0.855679 -0.383334,0.883333 -0.02512,0.02768 -0.253248,0.02768 -0.516666,0 l -0.483334,-0.05 L 11.316667,16.65 11.9,15.416667 11.383333,14.233333 C 11.100448,13.580465 10.866667,12.996308 10.866667,12.95 c 0,-0.05169 0.28456,0.13211 0.5,-0.08333 l 0.5,0 0.283333,0.8 c 0.159243,0.437902 0.320565,0.817726 0.35,0.85 0.02944,0.03227 0.227653,-0.357074 0.433333,-0.866667 L 13.3,12.733333 13.833333,12.7 c 0.147019,-0.007 0.286464,-0.01472 0.383334,-0.01667 z M 21,15 l 1.933333,0 0,1 L 21,16 Z m 0,2 1.933333,0 0,1 L 21,18 Z m 0,2 1.933333,0 0,1 L 21,20 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4777);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-3.358753,-3.6595092)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3410"
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/mimes/32/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
+++ b/mimes/32/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3182"
+   height="32"
+   width="32"
+   version="1.1"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview42"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="16.080706"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3182"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="0.99999994"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.814808"
+       x2="23.99999"
+       y1="6.1851754"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-1-0" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop3752-3-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop3754-1-8" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-1-6" />
+    </linearGradient>
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="5.118885"
+       cy="9.9571075"
+       cx="5.6491151"
+       gradientTransform="matrix(-1.1494524e-7,4.7418365,-5.7533456,-1.4233716e-7,73.220792,-44.844372)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4249"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3" />
+    <linearGradient
+       x1="42.783993"
+       y1="32.537422"
+       x2="38.972309"
+       y2="18.12406"
+       id="linearGradient3273"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-16.999999,48.999999)" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#fcfcfc;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       id="linearGradient3428">
+      <stop
+         id="stop3430"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3432"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="29"
+     x="4.9499893"
+     height="2"
+     width="22.100021" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z" />
+  <path
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline"
+     id="path4160-3"
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z" />
+  <path
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z"
+     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     id="path4247"
+     d="M 17,8 8,9.6074219 8,21.392578 17,23 Z m 1,2 0,1 5,0 0,1 -5,0 0,1 5,0 0,1 -5,0 0,1 5,0 0,1 -5,0 0,1 5,0 0,1 -5,0 0,1 5,0 0,1 -5,0 0,1 6,0 0,-11 z m -3.578125,2.771484 0.509766,0 c 0.470425,0 0.500748,0.03155 0.447265,0.267578 -0.03185,0.140524 -0.299376,1.389671 -0.59375,2.779297 l -0.53125,2.527344 -0.546875,0 c -0.297719,0 -0.539216,-0.01758 -0.544922,-0.0332 -0.0057,-0.01562 -0.177036,-0.842514 -0.380859,-1.841797 -0.203823,-0.999282 -0.396649,-1.751885 -0.429688,-1.658203 -0.03303,0.09368 -0.205218,0.91776 -0.378906,1.810547 l -0.316406,1.623047 -0.496094,-0.03516 -0.513672,-0.03125 -0.412109,-2.228516 c -0.230784,-1.217876 -0.4492762,-2.346468 -0.4804688,-2.511719 -0.051607,-0.273408 -0.016046,-0.306647 0.3476558,-0.349609 0.506748,-0.05986 0.529304,-0.0065 0.828126,1.958984 0.127658,0.839741 0.228776,1.53912 0.246093,1.556641 0.01732,0.01752 0.20061,-0.778763 0.398438,-1.757813 0.19783,-0.979049 0.417878,-1.810362 0.49414,-1.859375 0.21949,-0.14106 0.837121,-0.105517 0.894532,0.05078 0.02868,0.07807 0.206924,0.922559 0.380859,1.875 0.291006,1.593497 0.497165,2.173865 0.498047,1.40625 3.38e-4,-0.306578 0.230385,-1.771214 0.460937,-2.947265 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4249);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-3.358753,-3.6595092)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3410"
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/mimes/32/text-x-generic-template-rtl.svg
+++ b/mimes/32/text-x-generic-template-rtl.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3182"
    height="32"
    width="32"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="text-x-generic-template-rtl.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview51"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="16.080706"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g3297"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3184">
     <linearGradient
@@ -147,7 +172,7 @@
          id="stop3108-5" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1,0,0,-1,-16.999999,48.999999)"
+       gradientTransform="matrix(1,0,0,-1,-17.000835,49.001881)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3412"
        id="linearGradient3273"
@@ -195,6 +220,42 @@
        x2="22.004084"
        y1="47.813133"
        x1="22.004084" />
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       x1="42.783993"
+       y1="32.537422"
+       x2="38.972309"
+       y2="18.12406"
+       id="linearGradient3273-3"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-16.999999,48.999999)" />
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
   </defs>
   <metadata
      id="metadata3187">
@@ -204,7 +265,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -240,14 +301,23 @@
      id="path3475"
      style="fill:none;stroke:url(#linearGradient3084-3);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     id="g3297">
-    <path
-       style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410"
-       d="m 13.5,30.5 15,-15 v 15 z m 6.999999,-3.000001 h 5 V 22.5 Z" />
-    <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3166);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 15.713203,29.538323 27.558515,17.693011 v 11.845312 z" />
+     id="g3297"
+     transform="matrix(1.1530242,0,0,1.1527031,-2.3585522,-3.6599597)"
+     style="stroke-width:0.867405">
+    <g
+       id="g3297-1"
+       style="stroke-width:0.867405"
+       transform="translate(-0.86745868,3.9083651e-4)">
+      <path
+         style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3410"
+         d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+         sodipodi:nodetypes="cccccccc" />
+      <path
+         style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3424-2"
+         d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+         sodipodi:nodetypes="cccc" />
+    </g>
   </g>
 </svg>

--- a/mimes/32/text-x-generic-template.svg
+++ b/mimes/32/text-x-generic-template.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3182"
    height="32"
    width="32"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="text-x-generic-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview51"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="16.080706"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3182"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3184">
     <linearGradient
@@ -195,6 +220,33 @@
          style="stop-color:#ffffff;stop-opacity:0"
          id="stop3432" />
     </linearGradient>
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
   </defs>
   <metadata
      id="metadata3187">
@@ -204,7 +256,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -240,14 +292,18 @@
      id="path3475"
      style="fill:none;stroke:url(#linearGradient3084);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     id="g3297">
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-3.358753,-3.6595092)">
     <path
-       style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3410"
-       d="m 13.5,30.5 15,-15 v 15 z m 6.999999,-3.000001 h 5 V 22.5 Z" />
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3166);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 15.713203,29.538323 27.558515,17.693011 v 11.845312 z" />
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
   </g>
 </svg>

--- a/mimes/32/text-x-gettext-translation-template.svg
+++ b/mimes/32/text-x-gettext-translation-template.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="32"
    height="32"
-   id="svg3182">
+   id="svg3182"
+   sodipodi:docname="text-x-gettext-translation-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview57"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="16.080706"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3182"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3184">
     <linearGradient
@@ -215,6 +240,33 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
   </defs>
   <metadata
      id="metadata3187">
@@ -271,12 +323,19 @@
      id="path1020"
      d="m 18.46875,9.0000125 -2.235352,6.0000005 h 1.029297 l 0.620117,-1.799805 h 2.216797 l 0.62793,1.799805 h 1.040039 L 19.53125,9.0000125 Z M 19,9.990247 19.894531,12.599622 H 18.08789 Z"
      style="color:#000000;font-variation-settings:normal;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-  <path
-     style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path3410"
-     d="m 13.5,30.5 15,-15 v 15 z m 6.999999,-3.000001 h 5 V 22.5 Z" />
-  <path
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient3182);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path3424"
-     d="M 15.713203,29.538323 27.558515,17.693011 v 11.845312 z" />
+  <g
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-3.358753,-3.6595092)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3410"
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
+  </g>
 </svg>

--- a/mimes/32/x-office-document-template-rtl.svg
+++ b/mimes/32/x-office-document-template-rtl.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="32"
    height="32"
-   id="svg3182">
+   id="svg3182"
+   sodipodi:docname="x-office-document-template-rtl.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="958"
+     inkscape:window-height="1028"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="13.279273"
+     inkscape:cx="20.560915"
+     inkscape:cy="5.8368035"
+     inkscape:window-x="960"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3182"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3184">
     <linearGradient
@@ -224,6 +249,33 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
   </defs>
   <metadata
      id="metadata3187">
@@ -233,7 +285,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -282,14 +334,18 @@
      id="rect6741-1-5"
      style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <g
-     id="g3297">
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-3.358753,-3.6595092)">
     <path
-       style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3410"
-       d="m 13.5,30.5 15,-15 v 15 z m 6.999999,-3.000001 h 5 V 22.5 Z" />
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 15.713203,29.538323 27.558515,17.693011 v 11.845312 z" />
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
   </g>
 </svg>

--- a/mimes/32/x-office-document-template.svg
+++ b/mimes/32/x-office-document-template.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="32"
    height="32"
-   id="svg3182">
+   id="svg3182"
+   sodipodi:docname="x-office-document-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="17.52299"
+     inkscape:cx="20.270754"
+     inkscape:cy="13.688041"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3182"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3184">
     <linearGradient
@@ -202,7 +227,7 @@
        id="linearGradient3270"
        xlink:href="#linearGradient3428"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99749995,0,0,-0.99749995,-16.923748,48.896056)" />
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
     <linearGradient
        id="linearGradient3428">
       <stop
@@ -214,6 +239,24 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
   </defs>
   <metadata
      id="metadata3187">
@@ -223,7 +266,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -274,14 +317,18 @@
        d="m 8.4999998,28.5 h -3 V 1.4999997 h 3" />
   </g>
   <g
-     id="g3297">
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-3.358753,-3.6595092)">
     <path
-       style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3410"
-       d="m 13.5,30.5 15,-15 v 15 z m 6.999999,-3.000001 h 5 V 22.5 Z" />
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 15.713203,29.538323 27.558515,17.693011 v 11.845312 z" />
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
   </g>
 </svg>

--- a/mimes/32/x-office-drawing-template.svg
+++ b/mimes/32/x-office-drawing-template.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3182"
    height="32"
    width="32"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="x-office-drawing-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview58"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="16.080706"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3182"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3184">
     <linearGradient
@@ -195,6 +220,33 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
   </defs>
   <metadata
      id="metadata3187">
@@ -277,14 +329,18 @@
        width="2" />
   </g>
   <g
-     id="g3297">
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-3.358753,-3.6595092)">
     <path
-       style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3410"
-       d="m 13.5,30.5 15,-15 0,15 -15,0 z m 6.999999,-3.000001 5,0 0,-4.999999 -5,4.999999 z" />
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3322);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="m 15.713203,29.538323 11.845312,-11.845312 0,11.845312 -11.845312,0 z" />
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
   </g>
 </svg>

--- a/mimes/32/x-office-presentation-template-rtl.svg
+++ b/mimes/32/x-office-presentation-template-rtl.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3828"
    height="32"
    width="32"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="x-office-presentation-template-rtl.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview100"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="16.080706"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3828"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3830">
     <linearGradient
@@ -379,6 +404,42 @@
        xlink:href="#linearGradient3211-8-8-9"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.99749995,0,0,-0.99749995,-13.923748,48.896056)" />
+    <linearGradient
+       x1="42.783993"
+       y1="32.537422"
+       x2="38.972309"
+       y2="18.12406"
+       id="linearGradient3273-3"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-16.999999,48.999999)" />
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3211-8-8-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3211-8-8-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
   </defs>
   <metadata
      id="metadata3833">
@@ -388,7 +449,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -491,12 +552,19 @@
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient911);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3962"
      d="m 3,19.003569 c 0,2.601413 1.892038,5.088408 4.398956,5.78238 C 7.457536,24.775789 9,19.003569 9,19.003569 Z" />
-  <path
-     style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path3410"
-     d="m 16.5,30.5 15,-15 v 15 z m 6.999999,-3.000001 h 5 V 22.5 Z" />
-  <path
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient3148);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path3424"
-     d="M 18.713203,29.538323 30.558515,17.693011 v 11.845312 z" />
+  <g
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-2.358753,-3.6595092)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3410"
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
+  </g>
 </svg>

--- a/mimes/32/x-office-presentation-template.svg
+++ b/mimes/32/x-office-presentation-template.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3828"
    height="32"
    width="32"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="x-office-presentation-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview98"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="16.080706"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3828"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3830">
     <linearGradient
@@ -351,6 +376,42 @@
        xlink:href="#linearGradient3211-8-8-9"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.99749995,0,0,-0.99749995,-13.923748,48.896056)" />
+    <linearGradient
+       x1="42.783993"
+       y1="32.537422"
+       x2="38.972309"
+       y2="18.12406"
+       id="linearGradient3273-3"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-16.999999,48.999999)" />
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3211-8-8-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3211-8-8-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
   </defs>
   <metadata
      id="metadata3833">
@@ -360,7 +421,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -464,12 +525,23 @@
        id="path3962"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient911);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none" />
   </g>
-  <path
-     style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path3410"
-     d="m 16.5,30.5 15,-15 v 15 z m 6.999999,-3.000001 h 5 V 22.5 Z" />
-  <path
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient3148);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path3424"
-     d="M 18.713203,29.538323 30.558515,17.693011 v 11.845312 z" />
+  <g
+     id="g3297"
+     transform="matrix(1.1530242,0,0,1.1527031,-2.3585522,-3.6599597)"
+     style="stroke-width:0.867405" />
+  <g
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-2.358753,-3.6595092)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3410"
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
+  </g>
 </svg>

--- a/mimes/32/x-office-spreadsheet-template.svg
+++ b/mimes/32/x-office-spreadsheet-template.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3182"
    height="32"
    width="32"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="x-office-spreadsheet-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview51"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="16.080706"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3182"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3184">
     <linearGradient
@@ -184,7 +209,34 @@
        id="radialGradient3199"
        xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,21.957523,24.873276)" />
+    <linearGradient
+       x1="40.105618"
+       y1="31.65719"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073538,0,0,-1.0076224,-17.291345,49.188702)" />
+    <linearGradient
+       gradientTransform="matrix(0.99999342,0,0,-1.0469474,-16.999821,49.868294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3412"
+       id="linearGradient3273-3-3"
+       y2="18.12406"
+       x2="38.972309"
+       y1="37.04594"
+       x1="43.806984" />
+    <linearGradient
+       x1="41.34964"
+       y1="34.796535"
+       x2="33.811069"
+       y2="18.353575"
+       id="linearGradient3270-7-2"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0073359,0,0,-1.064242,-17.290822,50.287481)" />
   </defs>
   <metadata
      id="metadata3187">
@@ -237,19 +289,19 @@
      d="M 8.4999999,8.5 H 23.5 v 12 H 8.4999999 Z m 14.8636371,3 H 8.7272726"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:#206b00;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect3580-7" />
-  <path
-     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
-     id="path2883-5"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3199);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <g
-     id="g3297">
+     id="g3297-1"
+     style="stroke-width:0.867405"
+     transform="matrix(1.1530242,0,0,1.1527031,-3.358753,-3.6595092)">
     <path
-       d="m 13.5,30.5 15,-15 0,15 -15,0 z m 6.999999,-3.000001 5,0 0,-4.999999 -5,4.999999 z"
+       style="opacity:0.8;fill:url(#linearGradient3273-3-3);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:0.867402;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3410"
-       style="opacity:0.8;fill:url(#linearGradient3273);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       d="M 11.765388,30.502024 29.365091,12.897241 v 17.604783 z m 8.059674,-3.470167 h 6.070693 v -6.072696 z"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="m 15.713203,29.538323 11.845312,-11.845312 0,11.845312 -11.845312,0 z"
-       id="path3424"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3182);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3270-7-2);stroke-width:0.867405;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3424-2"
+       d="M 13.933599,29.634535 28.497644,15.066056 v 14.568479 z"
+       sodipodi:nodetypes="cccc" />
   </g>
 </svg>

--- a/mimes/48/application-vnd.oasis.opendocument.graphics-template.svg
+++ b/mimes/48/application-vnd.oasis.opendocument.graphics-template.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/mimes/48/application-vnd.oasis.opendocument.presentation-template.svg
+++ b/mimes/48/application-vnd.oasis.opendocument.presentation-template.svg
@@ -1,0 +1,1 @@
+x-office-presentation-template.svg

--- a/mimes/48/application-vnd.oasis.opendocument.presentation.svg
+++ b/mimes/48/application-vnd.oasis.opendocument.presentation.svg
@@ -1,0 +1,1 @@
+x-office-presentation.svg

--- a/mimes/48/application-vnd.oasis.opendocument.spreadsheet-template.svg
+++ b/mimes/48/application-vnd.oasis.opendocument.spreadsheet-template.svg
@@ -1,0 +1,1 @@
+x-office-spreadsheet-template.svg

--- a/mimes/48/application-vnd.oasis.opendocument.text-template.svg
+++ b/mimes/48/application-vnd.oasis.opendocument.text-template.svg
@@ -1,0 +1,1 @@
+x-office-document-template.svg

--- a/mimes/48/application-vnd.openofficeorg.extension.svg
+++ b/mimes/48/application-vnd.openofficeorg.extension.svg
@@ -1,0 +1,1 @@
+extension.svg

--- a/mimes/48/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
+++ b/mimes/48/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/48/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
+++ b/mimes/48/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/48/application-vnd.openxmlformats-officedocument.presentationml.template.svg
+++ b/mimes/48/application-vnd.openxmlformats-officedocument.presentationml.template.svg
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3901"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.presentationml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview42"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="24.121059"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3405" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3407" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3409" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3411" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3403"
+       id="linearGradient3106"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       x1="23.99999"
+       y1="5.9404659"
+       x2="23.99999"
+       y2="42.110645" />
+    <linearGradient
+       xlink:href="#linearGradient3600"
+       id="linearGradient3109"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3112"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3118"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3170"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <radialGradient
+       gradientTransform="matrix(0,7.3590719,-9.0345882,0,113.9478,-64.38106)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       id="radialGradient3029"
+       fy="9.9571075"
+       fx="6.0330806"
+       r="12.671875"
+       cy="9.9571075"
+       cx="6.5633106" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         id="stop3750-1-0-7" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         id="stop3752-3-7-4" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         id="stop3754-1-8-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ac441f;stop-opacity:1"
+         id="stop3756-1-6-2" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
+    <linearGradient
+       id="linearGradient3428">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3430" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3432" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="42.429947"
+     x="7.7378473"
+     height="3.5700529"
+     width="32.508301" />
+  <path
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z" />
+  <path
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+  <path
+     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline"
+     id="path4160"
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3065"
+     d="m 25,12.966667 -12,2.2 L 13,31.3 25,33.5 Z M 26.2,15.9 l 0,0.733333 8.066667,0 0,9.533334 0.733333,0 0,-9.533334 0,-0.733333 -0.733333,0 z m 0,1.466667 0,1.58125 c 0.234788,-0.06055 0.479636,-0.114584 0.733333,-0.114584 l 0,2.933334 2.933334,0 C 29.866667,23.386702 28.553369,24.7 26.933333,24.7 26.679636,24.7 26.434788,24.64597 26.2,24.585417 l 0,0.847916 5.133333,0 0,0.733334 -5.133333,0 0,1.466666 5.133333,0 0,0.733334 -5.133333,0 0,2.2 7.333333,0 0,-13.2 z M 27.666667,18.1 C 29.286702,18.1 30.6,19.413298 30.6,21.033333 l -2.933333,0 z m -8.463419,1.65 c 0.73483,0.01255 1.107942,0.15856 1.420834,0.458333 0.408144,0.391025 0.577778,0.905121 0.572916,1.810417 -0.008,1.485916 -0.893852,2.40625 -2.291666,2.40625 l -0.527084,0 -0.04583,1.191667 -0.02292,1.214583 -0.55,-0.04583 -0.700034,-0.02292 0,-3.460417 0,-3.460416 1.272951,-0.06875 c 0.338631,-0.01921 0.625885,-0.0271 0.870833,-0.02292 z m -0.847916,1.2375 0,1.054167 c 0,0.578671 0.05243,1.083685 0.09167,1.122916 0.114634,0.114631 0.433238,0.09494 0.825,-0.06875 0.47539,-0.19863 0.69124,-0.819358 0.504166,-1.44375 C 19.638232,21.191697 19.332469,20.9875 18.744915,20.9875 Z" />
+  <g
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/mimes/48/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
+++ b/mimes/48/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3901"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview42"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="24.121059"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3405" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3407" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3409" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3411" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3403"
+       id="linearGradient3106"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       x1="23.99999"
+       y1="5.9404659"
+       x2="23.99999"
+       y2="42.110645" />
+    <linearGradient
+       xlink:href="#linearGradient3600"
+       id="linearGradient3109"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3112"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3118"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3170"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="5.0852842"
+       cy="9.9571075"
+       cx="5.6155143"
+       gradientTransform="matrix(-2.7521908e-8,7.5232227,-9.2361126,-3.3074898e-8,115.9544,-64.480095)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4777"
+       xlink:href="#linearGradient3242-7-3-8-0-4-58" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58">
+      <stop
+         id="stop3244-5-8-5-6-4-3"
+         style="stop-color:#bdff69;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0"
+         style="stop-color:#8ed451;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35"
+         style="stop-color:#58aa30;stop-opacity:1;"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40"
+         style="stop-color:#2a6c1f;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
+    <linearGradient
+       id="linearGradient3428">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3430" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3432" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="42.429947"
+     x="7.7378473"
+     height="3.5700529"
+     width="32.508301" />
+  <path
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z" />
+  <path
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+  <path
+     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline"
+     id="path4160"
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z" />
+  <path
+     id="path4881"
+     d="m 25,12.966667 -12,2.2 L 13,31.3 25,33.5 Z M 26,14.433333 26,16 l 3,0 0,2 -3,0 0,1 3,0 0,2 -3,0 0,1 3,0 0,1.966667 -3,0 L 26,25 l 3,0 0,2 -3,0 0,1 3,0 0,2 -3,0 0,1.5 9,0 0,-17.066667 z M 30,16 l 3.533333,0 0,2 L 30,18 Z m 0,3 3.533333,0 0,2 L 30,21 Z m -8.66781,0.360417 c 0.133188,-0.0026 0.206316,-0.0056 0.20625,0 -1.03e-4,0.01113 -0.375056,0.863543 -0.847917,1.879166 l -0.870833,1.833334 0.870833,1.833333 c 0.472861,1.002005 0.847917,1.860144 0.847917,1.902083 0,0.08807 -0.631855,0.07337 -1.16875,-0.02292 -0.355388,-0.06373 -0.37315,-0.10362 -0.825,-1.2375 -0.257496,-0.646173 -0.506638,-1.21522 -0.55,-1.260417 -0.04334,-0.04519 -0.294881,0.444454 -0.55,1.077083 -0.25512,0.632625 -0.492566,1.17656 -0.527084,1.214584 -0.03454,0.03806 -0.348216,0.03806 -0.710416,0 l -0.664584,-0.06875 0.802084,-1.695834 0.802083,-1.695833 -0.710417,-1.627083 c -0.388967,-0.897695 -0.710416,-1.700911 -0.710416,-1.764584 0,-0.07107 0.268568,-0.114583 0.6875,-0.114583 l 0.6875,0 0.389583,1.1 c 0.218959,0.602115 0.440777,1.124373 0.48125,1.16875 0.04048,0.04437 0.313023,-0.490976 0.595833,-1.191667 l 0.504167,-1.260416 0.733333,-0.04583 c 0.202151,-0.0096 0.393888,-0.02025 0.527084,-0.02292 z M 30,22 l 3.533333,0 0,1.966667 -3.533333,0 z m 0,3 3.533333,0 0,2 L 30,27 Z m 0,3 3.533333,0 0,2 L 30,30 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4777);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/mimes/48/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
+++ b/mimes/48/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
@@ -1,0 +1,378 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3901"
+   height="48"
+   width="48"
+   version="1.1"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview42"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="24.121059"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g3138"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.110645"
+       x2="23.99999"
+       y1="5.9404659"
+       x1="23.99999"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3112"
+       xlink:href="#linearGradient5060" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3115"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3118"
+       xlink:href="#linearGradient5048" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-1-0" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop3752-3-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop3754-1-8" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-1-6" />
+    </linearGradient>
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="5.118885"
+       cy="9.9571075"
+       cx="5.6491151"
+       gradientTransform="matrix(-1.5324784e-7,6.4910062,-7.6705026,-1.9484253e-7,99.953972,-58.68638)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4200"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
+    <linearGradient
+       id="linearGradient3428">
+      <stop
+         id="stop3430"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3432"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="32.508301"
+     height="3.5700529"
+     x="7.7378473"
+     y="42.429947"
+     id="rect2879"
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
+     id="path2881"
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
+     id="path2883"
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z"
+     id="path4160"
+     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z"
+     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     id="path4198"
+     d="M 25 12.966797 L 13 15.166016 L 13 31.300781 L 25 33.5 L 25 12.966797 z M 26 15.166016 L 26 17.367188 L 32.75 17.367188 L 32.75 18.099609 L 26 18.099609 L 26 19.566406 L 32.75 19.566406 L 32.75 20.300781 L 26 20.300781 L 26 21.767578 L 32.75 21.767578 L 32.75 22.5 L 26 22.5 L 26 23.966797 L 32.75 23.966797 L 32.75 24.699219 L 26 24.699219 L 26 26.166016 L 32.75 26.166016 L 32.75 26.900391 L 26 26.900391 L 26 28.367188 L 32.75 28.367188 L 32.75 29.099609 L 26 29.099609 L 26 31.300781 L 35 31.300781 L 35 15.166016 L 26 15.166016 z M 21.560547 19.498047 L 22.242188 19.498047 C 22.86937 19.498047 22.909195 19.542137 22.837891 19.865234 C 22.795441 20.057594 22.437389 21.765735 22.044922 23.667969 L 21.337891 27.128906 L 20.609375 27.128906 C 20.212449 27.128906 19.89042 27.105354 19.882812 27.083984 C 19.875212 27.062614 19.646742 25.930399 19.375 24.5625 C 19.103258 23.194602 18.844827 22.164729 18.800781 22.292969 C 18.756731 22.421209 18.526488 23.547413 18.294922 24.769531 L 17.875 26.992188 L 17.212891 26.945312 L 16.529297 26.900391 L 15.978516 23.851562 C 15.67083 22.184435 15.379478 20.640273 15.337891 20.414062 C 15.269091 20.0398 15.315894 19.992405 15.800781 19.933594 C 16.476391 19.851654 16.505903 19.924594 16.904297 22.615234 C 17.074496 23.764741 17.21324 24.72211 17.236328 24.746094 C 17.259418 24.770084 17.499922 23.680044 17.763672 22.339844 C 18.027422 20.999643 18.324105 19.862014 18.425781 19.794922 C 18.718406 19.60183 19.540645 19.651271 19.617188 19.865234 C 19.655417 19.972101 19.893105 21.127862 20.125 22.431641 C 20.512975 24.612947 20.785933 25.406243 20.787109 24.355469 C 20.78756 23.9358 21.096917 21.932138 21.404297 20.322266 L 21.560547 19.498047 z "
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4200);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/mimes/48/text-x-generic-template-rtl.svg
+++ b/mimes/48/text-x-generic-template-rtl.svg
@@ -6,10 +6,34 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="48"
    height="48"
-   id="svg3901">
+   id="svg3901"
+   sodipodi:docname="text-x-generic-template-rtl.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="24.121059"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3901" />
   <defs
      id="defs3903">
     <linearGradient
@@ -205,6 +229,73 @@
        x2="22.004084"
        y1="47.813133"
        x1="22.004084" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata3906">
@@ -250,43 +341,67 @@
      id="path3475"
      style="fill:none;stroke:url(#linearGradient3052-2);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     id="g3896"
-     transform="translate(-2.0000012,-2.1881345e-7)">
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
     <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2883-9"
-       d="m 40.246148,42.353179 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
     <path
-       style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410"
-       d="m 24.500001,45.5 20.000001,-20.000001 0,20.000001 -20.000001,0 z m 9.333333,-4.000001 6.666667,0 0,-6.666666 -6.666667,6.666666 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="m 27.450938,44.217765 15.79375,-15.793751 0,15.793751 -15.79375,0 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3082"
-       d="M 29.5,44.346154 29.5,45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3854"
-       d="M 34.5,44.346154 34.5,45.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3856"
-       d="M 39.5,44.346154 39.5,45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3858"
-       d="m 44.50049,35.423077 -1.00049,0" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3860"
-       d="m 44.50049,40.423077 -1.00049,0" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3862"
-       d="m 44.50049,30.423077 -1.00049,0" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/mimes/48/text-x-generic-template.svg
+++ b/mimes/48/text-x-generic-template.svg
@@ -6,10 +6,34 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3901"
    height="48"
    width="48"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="text-x-generic-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="24.121059"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3901" />
   <defs
      id="defs3903">
     <linearGradient
@@ -205,6 +229,73 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata3906">
@@ -250,43 +341,67 @@
      id="path3475"
      style="fill:none;stroke:url(#linearGradient3052);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     transform="translate(-2.0000012,-2.1881345e-7)"
-     id="g3896">
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
     <path
-       d="m 40.246148,42.353179 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
-       id="path2883-9"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
     <path
-       d="m 24.500001,45.5 20.000001,-20.000001 0,20.000001 -20.000001,0 z m 9.333333,-4.000001 6.666667,0 0,-6.666666 -6.666667,6.666666 z"
-       id="path3410"
-       style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
     <path
-       d="m 27.450938,44.217765 15.79375,-15.793751 0,15.793751 -15.79375,0 z"
-       id="path3424"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
     <path
-       d="M 29.5,44.346154 29.5,45.5"
-       id="path3082"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="M 34.5,44.346154 34.5,45.5"
-       id="path3854"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="M 39.5,44.346154 39.5,45.5"
-       id="path3856"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="m 44.50049,35.423077 -1.00049,0"
-       id="path3858"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 44.50049,40.423077 -1.00049,0"
-       id="path3860"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 44.50049,30.423077 -1.00049,0"
-       id="path3862"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/mimes/48/text-x-gettext-translation-template.svg
+++ b/mimes/48/text-x-gettext-translation-template.svg
@@ -6,10 +6,34 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3901"
    height="48"
    width="48"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="text-x-gettext-translation-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview64"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="24.121059"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3901" />
   <defs
      id="defs3903">
     <linearGradient
@@ -215,6 +239,73 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata3906">
@@ -272,40 +363,67 @@
      d="m 28.291016,13 -2.980469,8 h 1.372395 l 0.826823,-2.39974 h 2.95573 L 31.302735,21 h 1.386718 l -2.981771,-8 z m 0.708333,1.320312 1.192708,3.479168 h -2.408854 z"
      style="color:#000000;font-variation-settings:normal;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
   <g
-     style="opacity:1"
-     id="g3896"
-     transform="translate(-2.0000012)">
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
     <path
-       style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410"
-       d="M 24.500001,45.5 44.500002,25.499999 V 45.5 Z m 9.333333,-4.000001 h 6.666667 v -6.666666 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 27.450938,44.217765 43.244688,28.424014 V 44.217765 Z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3082"
-       d="M 29.5,44.346154 V 45.5" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3854"
-       d="M 34.5,44.346154 V 45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3856"
-       d="M 39.5,44.346154 V 45.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3858"
-       d="M 44.50049,35.423077 H 43.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3860"
-       d="M 44.50049,40.423077 H 43.5" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3862"
-       d="M 44.50049,30.423077 H 43.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/mimes/48/x-office-document-template-rtl.svg
+++ b/mimes/48/x-office-document-template-rtl.svg
@@ -13,7 +13,7 @@
    width="48"
    version="1.1"
    sodipodi:docname="x-office-document-template-rtl.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,17 +23,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="3200"
-     inkscape:window-height="1674"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
      id="namedview67"
      showgrid="false"
-     inkscape:zoom="29.166667"
-     inkscape:cx="24"
-     inkscape:cy="24"
+     inkscape:zoom="20.623948"
+     inkscape:cx="35.440737"
+     inkscape:cy="39.380339"
      inkscape:window-x="0"
-     inkscape:window-y="60"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3901" />
+     inkscape:current-layer="g3138"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3903">
     <linearGradient
@@ -258,6 +259,73 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata3906">
@@ -316,43 +384,67 @@
      id="path4160-6"
      style="display:inline;opacity:0.5;fill:none;stroke:#0d52bf;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <g
-     id="g3896"
-     transform="translate(-2.0000012)">
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
     <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2883-3"
-       d="m 40.246148,42.353179 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
     <path
-       style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410"
-       d="M 24.500001,45.5 44.500002,25.499999 V 45.5 Z m 9.333333,-4.000001 h 6.666667 v -6.666666 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 27.450938,44.217765 43.244688,28.424014 V 44.217765 Z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3082"
-       d="M 29.5,44.346154 V 45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3854"
-       d="M 34.5,44.346154 V 45.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3856"
-       d="M 39.5,44.346154 V 45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3858"
-       d="M 44.50049,35.423077 H 43.5" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3860"
-       d="M 44.50049,40.423077 H 43.5" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3862"
-       d="M 44.50049,30.423077 H 43.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/mimes/48/x-office-document-template.svg
+++ b/mimes/48/x-office-document-template.svg
@@ -13,7 +13,7 @@
    width="48"
    version="1.1"
    sodipodi:docname="x-office-document-template.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,17 +23,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="3200"
-     inkscape:window-height="1674"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
      id="namedview67"
      showgrid="false"
-     inkscape:zoom="29.166667"
-     inkscape:cx="24"
-     inkscape:cy="24"
+     inkscape:zoom="20.623948"
+     inkscape:cx="31.444503"
+     inkscape:cy="38.431896"
      inkscape:window-x="0"
-     inkscape:window-y="60"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3901" />
+     inkscape:current-layer="g3138"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3903">
     <linearGradient
@@ -258,6 +259,120 @@
        y1="5.9404659"
        x2="23.99999"
        y2="42.110645" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.89962666,0.93506368,0,-81.62938,-32.204086)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157-51"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.89962666,0.93506368,0,-33.629364,44.798864)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161-7"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661"
+       gradientTransform="matrix(1.0133332,0,0,0.89962576,-0.0436346,3.8658836)" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.4100631,-5.3070628,0,309.7614,-121.83734)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,0,0,2.0008421,236.50002,-127.60767)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata3906">
@@ -324,43 +439,67 @@
      id="path4160-6"
      style="display:inline;opacity:0.5;fill:none;stroke:#0d52bf;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <g
-     id="g3896"
-     transform="translate(-2.0000012)">
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24978)"
+     id="g3138"
+     style="stroke-width:1.32201">
     <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2883-3"
-       d="m 40.246148,42.353179 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
     <path
-       style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410"
-       d="M 24.500001,45.5 44.500002,25.499999 V 45.5 Z m 9.333333,-4.000001 h 6.666667 v -6.666666 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 27.450938,44.217765 43.244688,28.424014 V 44.217765 Z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3082"
-       d="M 29.5,44.346154 V 45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3854"
-       d="M 34.5,44.346154 V 45.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3856"
-       d="M 39.5,44.346154 V 45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3858"
-       d="M 44.50049,35.423077 H 43.5" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3860"
-       d="M 44.50049,40.423077 H 43.5" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3862"
-       d="M 44.50049,30.423077 H 43.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/mimes/48/x-office-drawing-template.svg
+++ b/mimes/48/x-office-drawing-template.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3901"
    height="48"
    width="48"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="x-office-drawing-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview62"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="24.121059"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g3138"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3903">
     <linearGradient
@@ -205,6 +230,73 @@
          style="stop-color:#ffffff;stop-opacity:0"
          id="stop3432" />
     </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata3906">
@@ -214,7 +306,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -262,43 +354,67 @@
      id="rect3569"
      style="fill:#ea541a;fill-opacity:1;stroke:none" />
   <g
-     id="g3896"
-     transform="translate(-2.0000012)">
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
     <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2883-9"
-       d="m 40.246148,42.353179 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
     <path
-       style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410"
-       d="M 24.500001,45.5 44.500002,25.499999 V 45.5 Z m 9.333333,-4.000001 h 6.666667 v -6.666666 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 27.450938,44.217765 43.244688,28.424014 V 44.217765 Z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3082"
-       d="M 29.5,44.346154 V 45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3854"
-       d="M 34.5,44.346154 V 45.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3856"
-       d="M 39.5,44.346154 V 45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3858"
-       d="M 44.50049,35.423077 H 43.5" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3860"
-       d="M 44.50049,40.423077 H 43.5" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3862"
-       d="M 44.50049,30.423077 H 43.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/mimes/48/x-office-presentation-template-rtl.svg
+++ b/mimes/48/x-office-presentation-template-rtl.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="48"
    height="48"
-   id="svg4954">
+   id="svg4954"
+   sodipodi:docname="x-office-presentation-template-rtl.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview107"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="15.102144"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g3138"
+     inkscape:document-rotation="0" />
   <defs
      id="defs4956">
     <linearGradient
@@ -379,6 +404,73 @@
        xlink:href="#linearGradient3211-8-8-0-0-9"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.33,0,0,-1.33,-13.064999,106.02808)" />
+    <radialGradient
+       xlink:href="#linearGradient5060-2"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060-2"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060-2"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048-9"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata4959">
@@ -388,7 +480,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -498,43 +590,67 @@
      id="path3962"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1060);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <g
-     id="g4286"
-     transform="translate(-3.0027871,-36)">
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
     <g
-       transform="translate(2.9999998,36)"
-       id="g4242">
-      <path
-         style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3410"
-         d="m 24.502894,45.5 20,-20.000001 V 45.5 Z m 9.33044,-4.000001 h 6.666667 v -6.666666 z" />
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
     </g>
     <path
-       d="M 29.888625,80.5 46.499907,63.908389 46.500093,80.5 Z"
-       id="path3424"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
     <path
-       d="m 32.5,80.5 v 1"
-       id="path3082"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
     <path
-       d="m 37.5,80.5 v 1"
-       id="path3854"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="m 42.5,80.5 v 1"
-       id="path3856"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="M 47.50049,71.5 H 46.5"
-       id="path3858"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="M 47.50049,76.5 H 46.5"
-       id="path3860"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="M 47.50049,66.5 H 46.5"
-       id="path3862"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/mimes/48/x-office-presentation-template.svg
+++ b/mimes/48/x-office-presentation-template.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="48"
    height="48"
-   id="svg4954">
+   id="svg4954"
+   sodipodi:docname="x-office-presentation-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview104"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="24.121059"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g3138"
+     inkscape:document-rotation="0" />
   <defs
      id="defs4956">
     <linearGradient
@@ -351,6 +376,73 @@
        xlink:href="#linearGradient3211-8-8-0-0-9"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.33,0,0,-1.33,-13.064999,106.02808)" />
+    <radialGradient
+       xlink:href="#linearGradient5060-2"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060-2"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060-2"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048-9"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata4959">
@@ -360,7 +452,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -466,43 +558,67 @@
      id="path3962"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1060);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none" />
   <g
-     id="g4286"
-     transform="translate(-3.0027871,-36)">
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
     <g
-       transform="translate(2.9999998,36)"
-       id="g4242">
-      <path
-         style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3410"
-         d="m 24.502894,45.5 20,-20.000001 V 45.5 Z m 9.33044,-4.000001 h 6.666667 v -6.666666 z" />
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
     </g>
     <path
-       d="M 29.888625,80.5 46.499907,63.908389 46.500093,80.5 Z"
-       id="path3424"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
     <path
-       d="m 32.5,80.5 v 1"
-       id="path3082"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
     <path
-       d="m 37.5,80.5 v 1"
-       id="path3854"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="m 42.5,80.5 v 1"
-       id="path3856"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="M 47.50049,71.5 H 46.5"
-       id="path3858"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="M 47.50049,76.5 H 46.5"
-       id="path3860"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="M 47.50049,66.5 H 46.5"
-       id="path3862"
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/mimes/48/x-office-spreadsheet-template.svg
+++ b/mimes/48/x-office-spreadsheet-template.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg4112"
    height="48"
    width="48"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="x-office-spreadsheet-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="16.520833"
+     inkscape:cx="24.121059"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g3138"
+     inkscape:document-rotation="0" />
   <defs
      id="defs4114">
     <linearGradient
@@ -207,6 +232,73 @@
        r="117.14286"
        cy="486.64789"
        cx="605.71429" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412-6"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7071087,-2.656681,0,169.15523,921.6163)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412-6">
+      <stop
+         id="stop3414-0"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416-6"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3428"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.96875457,0,0,0.96859829,130.2627,922.49185)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
   </defs>
   <metadata
      id="metadata4117">
@@ -260,43 +352,67 @@
      id="path2883"
      d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
   <g
-     id="g3896"
-     transform="translate(-2.000001,0)">
+     transform="matrix(0.75642387,0,0,0.75642387,-11.165806,-744.24979)"
+     id="g3138"
+     style="stroke-width:1.32201">
     <path
-       style="opacity:0.3;fill:url(#radialGradient3907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2883-1"
-       d="m 40.246148,42.353179 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.32201;marker:none"
+       id="path2881-3"
+       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+    <g
+       style="opacity:0.2;stroke-width:1.77281"
+       id="g22150"
+       transform="matrix(-0.9639657,0,0,0.37771717,78.217793,1031.4981)">
+      <rect
+         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22120"
+         y="35"
+         x="0"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22134"
+         transform="scale(-1)"
+         y="-42"
+         x="-48"
+         height="7"
+         width="4" />
+      <rect
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none;stroke-width:1.77281"
+         id="rect22138"
+         y="35"
+         x="4"
+         height="7"
+         width="40" />
+    </g>
     <path
-       style="opacity:0.8;fill:url(#linearGradient3909);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="path3410"
-       d="m 24.500001,45.5 20.000001,-20.000001 0,20.000001 -20.000001,0 z m 9.333333,-4.000001 6.666667,0 0,-6.666666 -6.666667,6.666666 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       d="m 74.912808,1005.3317 -40.047477,40.0476 h 40.047477 z m -8.009491,18.6889 v 13.3492 h -13.51603 z" />
     <path
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3911);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="path3424"
-       d="m 27.450938,44.217765 15.79375,-15.793751 0,15.793751 -15.79375,0 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1.32201px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3934"
+       d="m 73.590556,1008.6365 c 0,0 0,35.4143 0,35.4143 0,0 -35.420089,0 -35.420089,0 0,0 35.420089,-35.4143 35.420089,-35.4143 z m -5.812527,13.1365 c 0,0 -16.468828,16.4662 -16.468828,16.4662 0,0 16.468828,0 16.468828,0 0,0 0,-16.4662 0,-16.4662 z" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3082"
-       d="M 29.5,44.346154 29.5,45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3091"
+       d="m 65.658697,1045.3792 v -2.644 m -6.16938,2.644 v -2.6126 m -6.169381,2.6126 v -2.644 m -6.16938,2.644 v -2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3854"
-       d="M 34.5,44.346154 34.5,45.5" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1176"
+       d="m 66.980709,1044.0572 v -1.322 m -6.16938,1.322 v -1.3063 m -6.169381,1.3063 v -1.322 m -6.16938,1.322 v -1.322"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3856"
-       d="M 39.5,44.346154 39.5,45.5" />
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1178"
+       d="m 72.268748,1017.617 h 2.644 m -2.644,6.1694 h 2.644 m -2.644,6.1693 h 2.6126 m -2.6126,6.1694 h 2.644"
+       sodipodi:nodetypes="cccccccc" />
     <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3858"
-       d="m 44.50049,35.423077 -1.00049,0" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3860"
-       d="m 44.50049,40.423077 -1.00049,0" />
-    <path
-       style="opacity:0.6;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3862"
-       d="m 44.50049,30.423077 -1.00049,0" />
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.32201;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1180"
+       d="m 72.268738,1016.295 h 1.322 m -1.322,6.1693 h 1.322 m -1.322,6.1695 h 1.3063 m -1.3063,6.1693 h 1.322"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/mimes/64/application-vnd.oasis.opendocument.graphics-template.svg
+++ b/mimes/64/application-vnd.oasis.opendocument.graphics-template.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/mimes/64/application-vnd.oasis.opendocument.presentation-template.svg
+++ b/mimes/64/application-vnd.oasis.opendocument.presentation-template.svg
@@ -1,0 +1,1 @@
+x-office-presentation-template.svg

--- a/mimes/64/application-vnd.oasis.opendocument.presentation.svg
+++ b/mimes/64/application-vnd.oasis.opendocument.presentation.svg
@@ -1,0 +1,1 @@
+x-office-presentation.svg

--- a/mimes/64/application-vnd.oasis.opendocument.spreadsheet-template.svg
+++ b/mimes/64/application-vnd.oasis.opendocument.spreadsheet-template.svg
@@ -1,0 +1,1 @@
+x-office-spreadsheet-template.svg

--- a/mimes/64/application-vnd.oasis.opendocument.text-template.svg
+++ b/mimes/64/application-vnd.oasis.opendocument.text-template.svg
@@ -1,0 +1,1 @@
+x-office-document-template.svg

--- a/mimes/64/application-vnd.openofficeorg.extension.svg
+++ b/mimes/64/application-vnd.openofficeorg.extension.svg
@@ -1,0 +1,1 @@
+extension.svg

--- a/mimes/64/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
+++ b/mimes/64/application-vnd.openxmlformats-officedocument.presentationml.presentation.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/64/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
+++ b/mimes/64/application-vnd.openxmlformats-officedocument.presentationml.slideshow.svg
@@ -1,1 +1,1 @@
-x-office-presentation.svg
+application-vnd.ms-powerpoint.svg

--- a/mimes/64/application-vnd.openxmlformats-officedocument.presentationml.template.svg
+++ b/mimes/64/application-vnd.openxmlformats-officedocument.presentationml.template.svg
@@ -1,0 +1,454 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg3844"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.presentationml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview42"
+     showgrid="false"
+     inkscape:zoom="12.390625"
+     inkscape:cx="32.161412"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3844"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs3846">
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3033"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="5.8641062"
+       x2="23.99999"
+       y2="42.175503"
+       id="linearGradient3093"
+       xlink:href="#linearGradient3977-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         id="stop3979-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983-5"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985-6"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3096"
+       xlink:href="#linearGradient3600-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)" />
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3153"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3156"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3842"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)" />
+    <radialGradient
+       cx="6.5633106"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.0330806"
+       fy="9.9571075"
+       id="radialGradient3029"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,10.035098,-12.319893,0,154.65609,-88.47417)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3">
+      <stop
+         id="stop3750-1-0-7"
+         style="stop-color:#ffcd7d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-7-4"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-1-8-5"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-1-6-2"
+         style="stop-color:#ac441f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,169.84848,922.24617)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient6240"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,133.21779,919.36222)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
+    <linearGradient
+       id="linearGradient6240">
+      <stop
+         id="stop6242"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6244"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient6240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
+  </defs>
+  <metadata
+     id="metadata3849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect2879"
+     y="57.000004"
+     x="9.8999996"
+     height="5"
+     width="44.199997" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2881"
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2883"
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none"
+     id="path4160-6"
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1-8"
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z" />
+  <path
+     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-6-1"
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z" />
+  <path
+     d="m 34,17 -17,3 0,22 17,3 0,-28 z m 1,4 0,1 11,0 0,13 1,0 0,-13 0,-1 -1,0 -11,0 z m 0,2 0,2.15625 C 35.320165,25.073685 35.654049,25 36,25 l 0,4 4,0 c 0,2.209139 -1.790861,4 -4,4 -0.345951,0 -0.679835,-0.07368 -1,-0.15625 L 35,34 l 7,0 0,1 -7,0 0,2 7,0 0,1 -7,0 0,3 10,0 0,-18 -10,0 z m 2,1 c 2.209139,0 4,1.790861 4,4 l -4,0 0,-4 z m -11.125,2.25 c 1.00204,0.01711 1.51083,0.216218 1.9375,0.625 0.55656,0.533216 0.78788,1.234256 0.78125,2.46875 -0.0109,2.026249 -1.21889,3.28125 -3.125,3.28125 l -0.71875,0 -0.0625,1.625 -0.03125,1.65625 -0.75,-0.0625 -0.78125,-0.03125 0,-4.71875 0,-4.71875 1.5625,-0.09375 C 25.14927,26.25506 25.54098,26.2443 25.875,26.25 Z m -1.15625,1.6875 0,1.4375 c 0,0.789097 0.07149,1.477753 0.125,1.53125 0.15632,0.156315 0.59078,0.12946 1.125,-0.09375 0.64826,-0.27086 0.9426,-1.117307 0.6875,-1.96875 C 26.46816,28.215951 26.05121,27.9375 25.25,27.9375 l -0.53125,0 z"
+     id="path3065"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
+    <g
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
+       id="g22150"
+       style="opacity:0.3">
+      <rect
+         width="2.9094534"
+         height="7"
+         x="1.0905465"
+         y="35"
+         id="rect22120"
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
+      <rect
+         width="4"
+         height="7"
+         x="-48"
+         y="-42"
+         transform="scale(-1)"
+         id="rect22134"
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
+      <rect
+         width="40"
+         height="7"
+         x="4"
+         y="35"
+         id="rect22138"
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
+    </g>
+    <path
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
+       id="path2993"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
+    <path
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
+       id="path3934"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
+  </g>
+</svg>

--- a/mimes/64/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
+++ b/mimes/64/application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg
@@ -1,0 +1,405 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3844"
+   height="64"
+   width="64"
+   version="1.1"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.spreadsheetml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview42"
+     showgrid="false"
+     inkscape:zoom="12.390625"
+     inkscape:cx="32.161412"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3844" />
+  <defs
+     id="defs3846">
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3033"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4"
+       id="linearGradient3093"
+       y2="42.175503"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9"
+       id="linearGradient3096"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9571075"
+       fx="5.0852842"
+       cy="9.9571075"
+       cx="5.6155143"
+       gradientTransform="matrix(-3.7529874e-8,10.25894,-12.594699,-4.5102133e-8,157.39236,-88.609224)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4777"
+       xlink:href="#linearGradient3242-7-3-8-0-4-58" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58">
+      <stop
+         id="stop3244-5-8-5-6-4-3"
+         style="stop-color:#bdff69;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0"
+         style="stop-color:#8ed451;stop-opacity:1;"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35"
+         style="stop-color:#58aa30;stop-opacity:1;"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40"
+         style="stop-color:#2a6c1f;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661"
+       id="linearGradient3485"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient3211-8-8-0-0-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
+    <linearGradient
+       id="linearGradient3211-8-8-0-0-9">
+      <stop
+         id="stop3213-0-0-8-1-1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3215-1-8-0-6-4"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="44.199997"
+     height="5"
+     x="9.8999996"
+     y="57.000004"
+     id="rect2879"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z"
+     id="path2881"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z"
+     id="path2883"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
+     id="path4160-6"
+     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none" />
+  <path
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z"
+     id="rect6741-1-8"
+     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     id="path4881"
+     d="m 34,17 -17,3 0,22 17,3 z m 1,2 0,2 4,0 0,3 -4,0 0,1 4,0 0,3 -4,0 0,1 4,0 0,3 -4,0 0,1 4,0 0,3 -4,0 0,1 4,0 0,3 -4,0 0,2 12,0 0,-23 z m 5,2 5,0 0,3 -5,0 z m 0,4 5,0 0,3 -5,0 z m -11.34375,0.71875 c 0.18162,-0.0036 0.28134,-0.0076 0.28125,0 -1.4e-4,0.01518 -0.51144,1.177559 -1.15625,2.5625 l -1.1875,2.5 1.1875,2.5 c 0.64481,1.36637 1.15625,2.53656 1.15625,2.59375 0,0.12009 -0.86162,0.10005 -1.59375,-0.03125 -0.48462,-0.0869 -0.50884,-0.1413 -1.125,-1.6875 -0.35113,-0.881145 -0.69087,-1.657118 -0.75,-1.71875 -0.0591,-0.06163 -0.40211,0.606073 -0.75,1.46875 -0.34789,0.86267 -0.67168,1.604399 -0.71875,1.65625 -0.0471,0.0519 -0.47484,0.0519 -0.96875,0 L 22.125,35.46875 23.21875,33.15625 24.3125,30.84375 23.34375,28.625 C 22.81334,27.400871 22.375,26.305577 22.375,26.21875 c 0,-0.09692 0.36623,-0.15625 0.9375,-0.15625 l 0.9375,0 0.53125,1.5 c 0.29858,0.821066 0.60106,1.533236 0.65625,1.59375 0.0552,0.06051 0.42685,-0.669513 0.8125,-1.625 l 0.6875,-1.71875 1,-0.0625 c 0.27566,-0.01311 0.53712,-0.02761 0.71875,-0.03125 z M 40,29 l 5,0 0,3 -5,0 z m 0,4 5,0 0,3 -5,0 z m 0,4 5,0 0,3 -5,0 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4777);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <g
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
+    <g
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
+       id="g22150"
+       style="opacity:0.3">
+      <rect
+         width="2.9094534"
+         height="7"
+         x="1.0905465"
+         y="35"
+         id="rect22120"
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
+      <rect
+         width="4"
+         height="7"
+         x="-48"
+         y="-42"
+         transform="scale(-1)"
+         id="rect22134"
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
+      <rect
+         width="40"
+         height="7"
+         x="4"
+         y="35"
+         id="rect22138"
+         style="fill:url(#linearGradient3485);fill-opacity:1;stroke:none" />
+    </g>
+    <path
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
+       id="path2993"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
+    <path
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
+       id="path3934"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
+  </g>
+</svg>

--- a/mimes/64/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
+++ b/mimes/64/application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg
@@ -1,0 +1,454 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg3844"
+   height="64"
+   width="64"
+   version="1.1"
+   sodipodi:docname="application-vnd.openxmlformats-officedocument.wordprocessingml.template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview42"
+     showgrid="false"
+     inkscape:zoom="12.390625"
+     inkscape:cx="32.161412"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3844"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs3846">
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3033"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4"
+       id="linearGradient3093"
+       y2="42.175503"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9"
+       id="linearGradient3096"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-2.1710338e-7,8.8513721,-10.866659,-2.6569437e-7,140.18608,-80.708701)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3"
+       id="radialGradient3107"
+       fy="9.9571075"
+       fx="5.118885"
+       r="12.671875"
+       cy="9.9571075"
+       cx="5.6491151" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop3750-1-0" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop3752-3-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop3754-1-8" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop3756-1-6" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016195,0,0,0.02225161,48.013776,1032.7998)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-41.10259,45.50001)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)"
+       cx="7"
+       cy="39.464806"
+       fx="7"
+       fy="39.464806"
+       r="3.5" />
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient3161"
+       gradientUnits="userSpaceOnUse"
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661" />
+    <linearGradient
+       xlink:href="#linearGradient3412"
+       id="linearGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,169.84848,922.24617)"
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642" />
+    <linearGradient
+       id="linearGradient3412">
+      <stop
+         id="stop3414"
+         style="stop-color:#f0f0f1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3416"
+         style="stop-color:#cbcdd9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient6240"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,133.21779,919.36222)"
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607" />
+    <linearGradient
+       id="linearGradient6240">
+      <stop
+         id="stop6242"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6244"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient6240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
+  </defs>
+  <metadata
+     id="metadata3849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="44.199997"
+     height="5"
+     x="9.8999996"
+     y="57.000004"
+     id="rect2879"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z"
+     id="path2881"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z"
+     id="path2883"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
+     id="path4160-6"
+     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none" />
+  <path
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z"
+     id="rect6741-1-8"
+     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3107);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect3139"
+     d="m 34,17 -17,3 0,22 17,3 0,-28 z m 1,3 0,3 9,0 0,1 -9,0 0,2 9,0 0,1 -9,0 0,2 9,0 0,1 -9,0 0,2 9,0 0,1 -9,0 0,2 9,0 0,1 -9,0 0,2 9,0 0,1 -9,0 0,3 12,0 0,-22 -12,0 z m -5.875,5.90625 0.96875,0 c 0.888516,0 0.944766,0.05941 0.84375,0.5 -0.06014,0.26231 -0.569,2.593544 -1.125,5.1875 l -1,4.71875 -1.03125,0 c -0.562318,0 -1.020474,-0.03336 -1.03125,-0.0625 -0.01077,-0.02915 -0.333778,-1.572184 -0.71875,-3.4375 -0.384971,-1.865317 -0.750099,-3.268623 -0.8125,-3.09375 -0.0624,0.174874 -0.390694,1.708476 -0.71875,3.375 L 23.90625,36.125 22.96875,36.0625 22,36 21.21875,31.84375 C 20.782857,29.570395 20.371416,27.46472 20.3125,27.15625 20.21502,26.645893 20.28181,26.580196 20.96875,26.5 c 0.957124,-0.111739 0.998102,-0.01291 1.5625,3.65625 0.241118,1.56751 0.436041,2.873544 0.46875,2.90625 0.03271,0.03271 0.37635,-1.453704 0.75,-3.28125 0.37365,-1.827546 0.793459,-3.377261 0.9375,-3.46875 0.414556,-0.263308 1.579064,-0.19802 1.6875,0.09375 0.05416,0.145728 0.390228,1.72212 0.71875,3.5 0.549637,2.974508 0.935834,4.057874 0.9375,2.625 6.38e-4,-0.572275 0.43954,-3.304718 0.875,-5.5 l 0.21875,-1.125 z" />
+  <g
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
+    <g
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
+       id="g22150"
+       style="opacity:0.3">
+      <rect
+         width="2.9094534"
+         height="7"
+         x="1.0905465"
+         y="35"
+         id="rect22120"
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
+      <rect
+         width="4"
+         height="7"
+         x="-48"
+         y="-42"
+         transform="scale(-1)"
+         id="rect22134"
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
+      <rect
+         width="40"
+         height="7"
+         x="4"
+         y="35"
+         id="rect22138"
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
+    </g>
+    <path
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
+       id="path2993"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
+    <path
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
+       id="path3934"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
+  </g>
+</svg>

--- a/mimes/64/text-x-generic-template-rtl.svg
+++ b/mimes/64/text-x-generic-template-rtl.svg
@@ -6,10 +6,34 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3130"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="text-x-generic-template-rtl.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview76"
+     showgrid="false"
+     inkscape:zoom="12.390625"
+     inkscape:cx="30.728749"
+     inkscape:cy="29.57424"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3130" />
   <defs
      id="defs3132">
     <linearGradient
@@ -270,6 +294,55 @@
        xlink:href="#linearGradient3104-5"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-1.3428566,0,0,1.3407401,66.316046,-4.2520303)" />
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient6240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
   </defs>
   <metadata
      id="metadata3135">
@@ -315,70 +388,94 @@
      id="path3475"
      d="m 48.882558,11.5 -3.147321,0 z m -3.608928,0 -2.937498,0 z m -3.399105,0 -2.601785,0 z m -3.021428,0 -1.133035,0 z m -1.594642,0 -2.517856,0 z m -3.021427,0 -6.630355,0 z m -7.049997,0 -5.077677,0 z m -5.49732,0 -1.552678,0 z m 27.192847,3 -4.90982,0 z m -5.455355,0 -2.349999,0 z m -2.769642,0 -1.175,0 z m -1.636607,0 -2.140177,0 z m -2.601784,0 -2.182142,0 z m -2.601785,0 -3.483034,0 z m -3.944641,0 -4.532141,0 z m -4.951784,0 -3.021427,0 z m -3.44107,0 -0.755357,0 z m 27.402668,2.97905 -4.154463,0 z m -4.574106,0 -6.798211,0 z m -7.217854,0 -3.315177,0 z m -3.73482,0 -3.105356,0 z m -3.524998,0 -2.643749,0 z m -3.063392,0 -4.154463,0.0419 z m -4.532141,0.0419 -6.756247,0 z M 48.882558,20.5 l -5.749105,0 z m -6.210712,0 -6.210712,0 z m -6.630355,0 -2.475892,0 z m -2.895534,0 -5.833034,0 z m -6.210712,0 -3.986606,0 z m -4.448212,0 -1.594643,0 z m -2.014285,0 -0.88125,0 z m -1.342857,0 -2.475892,0 z m 29.752667,3 -2.140178,0 z m -2.811606,0 -7.931247,0 z m 2.811606,5 -3.147321,0 z m -3.608928,0 -2.895534,0 z m -3.399105,0 -2.601785,0 z m -3.021428,0 -1.133035,0 z m -1.594642,0 -2.517856,0 z m -3.021427,0 -6.58839,0 z m -7.049997,0 -5.035713,0 z m -5.455355,0 -1.594643,0 z m -2.014285,0 -3.776784,0 z m 29.165167,3 -5.287498,0 z m -5.707141,0 -5.665176,0 z m -6.084819,0 -2.182142,0 z m -2.601785,0 -5.329462,0 z m -5.749104,0 -6.714283,0 z m -7.17589,0 -2.475892,0 z m 27.318739,3 -5.749105,0 z m -6.210712,0 -6.210712,0 z m -6.630355,0 -2.475892,0 z m -2.895534,0 -5.833034,0 z m -6.210712,0 -3.986606,0 z m -4.448212,0 -1.594643,0 z m -2.014285,0 -0.88125,0 z m -1.342857,0 -2.475892,0 z m 29.752667,3 -4.90982,0 z m -5.455355,0 -2.349999,0 z m -2.769642,0 -1.175,0 z m -1.636607,0 -2.140177,0 z m -2.601784,0 -2.182142,0 z m -2.601785,0 -3.483034,0 z m -3.944641,0 -4.532141,0 z m -4.951784,0 -3.021427,0 z m -3.44107,0 -0.755357,0 z m 27.402668,4.979055 -4.154463,0 z m -4.574106,0 -6.798211,0 z m -7.217854,0 -3.315177,0 z m -3.73482,0 -3.105356,0 z m -3.524998,0 -2.643749,0 z m -3.063392,0 -4.154463,0.04189 z m -4.532141,0.04189 -6.756247,0 z M 48.882558,45.5 l -4.90982,0 z m -5.455355,0 -2.349999,0 z m -2.769642,0 -1.175,0 z m -1.636607,0 -2.140177,0 z m -2.601784,0 -2.182142,0 z m -2.601785,0 -3.483034,0 z m -3.944641,0 -4.532141,0 z m -4.951784,0 -3.021427,0 z m -3.44107,0 -0.755357,0 z m 27.402668,3 -5.20357,0 z m -5.665177,0 -1.636606,0 z m -2.056249,0 -3.73482,0 z m -4.154462,0 -5.49732,0 z m -5.958927,0 -3.73482,0 z m -4.112498,0 -0.797321,0 z m -1.216964,0 -4.741962,0 z m -5.245533,0 -2.475892,0 z m 28.40981,3 -5.20357,0 z m -5.665177,0 -2.349999,0 z m -2.769641,0 -3.692856,0 z m -4.112499,0 -3.986605,0 z m -4.448212,0 -1.594642,0 z m -2.014285,0 -0.88125,0 z m -1.342857,0 -2.475892,0 z" />
   <g
-     id="g3138"
-     transform="translate(-15.217778,-983.36214)">
-    <path
-       style="opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2881-3"
-       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
     <g
-       style="opacity:0.3"
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
        id="g22150"
-       transform="matrix(-0.916667,0,0,0.714282,78.217794,1017.3623)">
+       style="opacity:0.3">
       <rect
-         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none"
+         width="2.9094534"
+         height="7"
+         x="1.0905465"
+         y="35"
          id="rect22120"
-         y="35"
-         x="0"
-         height="7"
-         width="4" />
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
       <rect
-         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none"
-         id="rect22134"
-         transform="scale(-1,-1)"
-         y="-42"
+         width="4"
+         height="7"
          x="-48"
-         height="7"
-         width="4" />
+         y="-42"
+         transform="scale(-1)"
+         id="rect22134"
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
       <rect
-         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none"
-         id="rect22138"
-         y="35"
-         x="4"
+         width="40"
          height="7"
-         width="40" />
+         x="4"
+         y="35"
+         id="rect22138"
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
     </g>
     <path
-       style="opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
        id="path2993"
-       d="m 75.717796,1005.8622 -39.999999,40 39.999999,0 0,-40 z m -7.999996,18.6666 0,13.3334 -13.500006,0 13.500006,-13.3334 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
     <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3101"
-       d="m 70.717794,1044.8622 0,-1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3103"
-       d="m 64.717794,1044.8622 0,-1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3105"
-       d="m 58.717794,1044.8622 0,-0.9881" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3107"
-       d="m 52.717794,1044.8622 0,-1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3109"
-       d="m 46.717794,1044.8622 0,-1" />
-    <path
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3091"
-       d="m 69.717794,1045.8622 0,-2 m -6,2 0,-2 m -6,2 0,-1.9762 m -6,1.9762 0,-2 m -6,2 0,-2" />
-    <path
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3150);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
        id="path3934"
-       d="m 74.717794,1008.2997 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
   </g>
 </svg>

--- a/mimes/64/text-x-generic-template.svg
+++ b/mimes/64/text-x-generic-template.svg
@@ -6,10 +6,34 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="64"
    height="64"
-   id="svg3130">
+   id="svg3130"
+   sodipodi:docname="text-x-generic-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview77"
+     showgrid="false"
+     inkscape:zoom="17.52299"
+     inkscape:cx="59.02416"
+     inkscape:cy="45.673008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4309" />
   <defs
      id="defs3132">
     <linearGradient
@@ -270,6 +294,63 @@
        xlink:href="#linearGradient6240"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-1,0,0,1,133.21779,919.36222)" />
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="18.142136"
+       y1="35"
+       x2="18.142136"
+       y2="42.040661"
+       id="linearGradient3485"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient6240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
   </defs>
   <metadata
      id="metadata3135">
@@ -318,70 +399,94 @@
        style="fill:none;stroke:url(#linearGradient3072);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
   <g
-     transform="translate(-15.217778,-983.36214)"
-     id="g3138">
-    <path
-       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z"
-       id="path2881-3"
-       style="opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
     <g
-       transform="matrix(-0.916667,0,0,0.714282,78.217794,1017.3623)"
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
        id="g22150"
        style="opacity:0.3">
       <rect
-         width="4"
+         width="2.9094534"
          height="7"
-         x="0"
+         x="1.0905465"
          y="35"
          id="rect22120"
-         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none" />
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
       <rect
          width="4"
          height="7"
          x="-48"
          y="-42"
-         transform="scale(-1,-1)"
+         transform="scale(-1)"
          id="rect22134"
-         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none" />
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
       <rect
          width="40"
          height="7"
          x="4"
          y="35"
          id="rect22138"
-         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
+         style="fill:url(#linearGradient3485);fill-opacity:1;stroke:none" />
     </g>
     <path
-       d="m 75.717796,1005.8622 -39.999999,40 39.999999,0 0,-40 z m -7.999996,18.6666 0,13.3334 -13.500006,0 13.500006,-13.3334 z"
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
        id="path2993"
-       style="opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
     <path
-       d="m 70.717794,1044.8622 0,-1"
-       id="path3101"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 64.717794,1044.8622 0,-1"
-       id="path3103"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 58.717794,1044.8622 0,-0.9881"
-       id="path3105"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 52.717794,1044.8622 0,-1"
-       id="path3107"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 46.717794,1044.8622 0,-1"
-       id="path3109"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 69.717794,1045.8622 0,-2 m -6,2 0,-2 m -6,2 0,-1.9762 m -6,1.9762 0,-2 m -6,2 0,-2"
-       id="path3091"
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 74.717794,1008.2997 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
        id="path3934"
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3150);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
   </g>
 </svg>

--- a/mimes/64/text-x-gettext-translation-template.svg
+++ b/mimes/64/text-x-gettext-translation-template.svg
@@ -6,10 +6,34 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3844"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="text-x-gettext-translation-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview73"
+     showgrid="false"
+     inkscape:zoom="12.390625"
+     inkscape:cx="32.161412"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3844" />
   <defs
      id="defs3846">
     <linearGradient
@@ -251,6 +275,55 @@
          style="stop-color:#ffffff;stop-opacity:0"
          id="stop6244" />
     </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient6240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
   </defs>
   <metadata
      id="metadata3849">
@@ -260,7 +333,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -308,70 +381,94 @@
      d="M 36.9375 18 L 32.466797 30 L 34.525391 30 L 35.765625 26.400391 L 40.199219 26.400391 L 41.455078 30 L 43.535156 30 L 39.0625 18 L 36.9375 18 z M 38 19.980469 L 39.789062 25.199219 L 36.175781 25.199219 L 38 19.980469 z "
      id="path1020" />
   <g
-     id="g3138"
-     transform="translate(-15.217778,-983.36214)">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2881-3"
-       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
     <g
-       style="opacity:0.3"
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
        id="g22150"
-       transform="matrix(-0.916667,0,0,0.714282,78.217794,1017.3623)">
+       style="opacity:0.3">
       <rect
-         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none"
+         width="2.9094534"
+         height="7"
+         x="1.0905465"
+         y="35"
          id="rect22120"
-         y="35"
-         x="0"
-         height="7"
-         width="4" />
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
       <rect
-         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none"
-         id="rect22134"
-         transform="scale(-1)"
-         y="-42"
+         width="4"
+         height="7"
          x="-48"
-         height="7"
-         width="4" />
+         y="-42"
+         transform="scale(-1)"
+         id="rect22134"
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
       <rect
-         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none"
-         id="rect22138"
-         y="35"
-         x="4"
+         width="40"
          height="7"
-         width="40" />
+         x="4"
+         y="35"
+         id="rect22138"
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
     </g>
     <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
        id="path2993"
-       d="m 75.717796,1005.8622 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 54.217794 Z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
     <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3101"
-       d="m 70.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3103"
-       d="m 64.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3105"
-       d="m 58.717794,1044.8622 v -0.9881" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3107"
-       d="m 52.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3109"
-       d="m 46.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3091"
-       d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3150);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
        id="path3934"
-       d="m 74.717794,1008.2997 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
   </g>
 </svg>

--- a/mimes/64/x-office-document-template-rtl.svg
+++ b/mimes/64/x-office-document-template-rtl.svg
@@ -13,7 +13,7 @@
    height="64"
    id="svg3844"
    sodipodi:docname="x-office-document-template-rtl.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,17 +23,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="3200"
-     inkscape:window-height="1674"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
      id="namedview82"
      showgrid="false"
      inkscape:zoom="21.875"
      inkscape:cx="32"
      inkscape:cy="32"
      inkscape:window-x="0"
-     inkscape:window-y="60"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3844" />
+     inkscape:current-layer="svg3844"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3846">
     <linearGradient
@@ -314,6 +315,55 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient6240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
   </defs>
   <metadata
      id="metadata3849">
@@ -380,70 +430,94 @@
      id="path4530-6"
      d="m 49,59.50002 h 6.5 V 0.5 l -6.5,4.1e-7" />
   <g
-     transform="translate(-15.217778,-983.36214)"
-     id="g3138">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2881-3"
-       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
     <g
-       style="opacity:0.3"
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
        id="g22150"
-       transform="matrix(-0.916667,0,0,0.714282,78.217794,1017.3623)">
+       style="opacity:0.3">
       <rect
-         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none"
+         width="2.9094534"
+         height="7"
+         x="1.0905465"
+         y="35"
          id="rect22120"
-         y="35"
-         x="0"
-         height="7"
-         width="4" />
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
       <rect
-         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none"
-         id="rect22134"
-         transform="scale(-1)"
-         y="-42"
+         width="4"
+         height="7"
          x="-48"
-         height="7"
-         width="4" />
+         y="-42"
+         transform="scale(-1)"
+         id="rect22134"
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
       <rect
-         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none"
-         id="rect22138"
-         y="35"
-         x="4"
+         width="40"
          height="7"
-         width="40" />
+         x="4"
+         y="35"
+         id="rect22138"
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
     </g>
     <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
        id="path2993"
-       d="m 75.717796,1005.8622 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 54.217794 Z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
     <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3101"
-       d="m 70.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3103"
-       d="m 64.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3105"
-       d="m 58.717794,1044.8622 v -0.9881" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3107"
-       d="m 52.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3109"
-       d="m 46.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3091"
-       d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
        id="path3934"
-       d="m 74.717794,1008.2997 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
   </g>
 </svg>

--- a/mimes/64/x-office-document-template.svg
+++ b/mimes/64/x-office-document-template.svg
@@ -13,7 +13,7 @@
    height="64"
    id="svg3844"
    sodipodi:docname="x-office-document-template.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,17 +23,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="3200"
-     inkscape:window-height="1674"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
      id="namedview82"
      showgrid="false"
      inkscape:zoom="21.875"
      inkscape:cx="32"
      inkscape:cy="32"
      inkscape:window-x="0"
-     inkscape:window-y="60"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3844" />
+     inkscape:current-layer="svg3844"
+     inkscape:document-rotation="0" />
   <defs
      id="defs3846">
     <linearGradient
@@ -313,6 +314,55 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient6240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
   </defs>
   <metadata
      id="metadata3849">
@@ -378,70 +428,94 @@
      id="path4530-6"
      d="M 15,59.50002 H 8.5 V 0.5 l 6.5,4.1e-7" />
   <g
-     transform="translate(-15.217778,-983.36214)"
-     id="g3138">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2881-3"
-       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z" />
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
     <g
-       style="opacity:0.3"
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
        id="g22150"
-       transform="matrix(-0.916667,0,0,0.714282,78.217794,1017.3623)">
+       style="opacity:0.3">
       <rect
-         style="fill:url(#radialGradient3157);fill-opacity:1;stroke:none"
+         width="2.9094534"
+         height="7"
+         x="1.0905465"
+         y="35"
          id="rect22120"
-         y="35"
-         x="0"
-         height="7"
-         width="4" />
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
       <rect
-         style="fill:url(#radialGradient3159);fill-opacity:1;stroke:none"
-         id="rect22134"
-         transform="scale(-1)"
-         y="-42"
+         width="4"
+         height="7"
          x="-48"
-         height="7"
-         width="4" />
+         y="-42"
+         transform="scale(-1)"
+         id="rect22134"
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
       <rect
-         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none"
-         id="rect22138"
-         y="35"
-         x="4"
+         width="40"
          height="7"
-         width="40" />
+         x="4"
+         y="35"
+         id="rect22138"
+         style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
     </g>
     <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
        id="path2993"
-       d="m 75.717796,1005.8622 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 54.217794 Z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
     <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3101"
-       d="m 70.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3103"
-       d="m 64.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3105"
-       d="m 58.717794,1044.8622 v -0.9881" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3107"
-       d="m 52.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3109"
-       d="m 46.717794,1044.8622 v -1" />
-    <path
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3091"
-       d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3165);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
        id="path3934"
-       d="m 74.717794,1008.2997 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
   </g>
 </svg>

--- a/mimes/64/x-office-drawing-template.svg
+++ b/mimes/64/x-office-drawing-template.svg
@@ -6,10 +6,34 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3844"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="x-office-drawing-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview69"
+     showgrid="false"
+     inkscape:zoom="12.390625"
+     inkscape:cx="32.161412"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3844" />
   <defs
      id="defs3846">
     <linearGradient
@@ -233,6 +257,55 @@
          style="stop-color:#ffffff;stop-opacity:0"
          id="stop6244" />
     </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient6240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
   </defs>
   <metadata
      id="metadata3849">
@@ -290,31 +363,27 @@
      id="rect3569"
      d="m 27,29 4,0 0,4 -4,0 z m 16,-7 4,0 0,4 -4,0 z m -26,22 4,0 0,4 -4,0 z" />
   <g
-     id="g3138"
-     transform="translate(-15.217778,-983.36214)">
-    <path
-       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z"
-       id="path2881-3"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
     <g
-       transform="matrix(-0.916667,0,0,0.714282,78.217794,1017.3623)"
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
        id="g22150"
        style="opacity:0.3">
       <rect
-         width="4"
+         width="2.9094534"
          height="7"
-         x="0"
+         x="1.0905465"
          y="35"
          id="rect22120"
-         style="fill:url(#radialGradient3157);fill-opacity:1.0;stroke:none" />
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
       <rect
          width="4"
          height="7"
          x="-48"
          y="-42"
-         transform="scale(-1,-1)"
+         transform="scale(-1)"
          id="rect22134"
-         style="fill:url(#radialGradient3159);fill-opacity:1.0;stroke:none" />
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
       <rect
          width="40"
          height="7"
@@ -324,36 +393,64 @@
          style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
     </g>
     <path
-       d="m 75.717796,1005.8622 -39.999999,40 39.999999,0 0,-40 z m -7.999996,18.6666 0,13.3334 -13.500006,0 13.500006,-13.3334 z"
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
        id="path2993"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
     <path
-       d="m 70.717794,1044.8622 0,-1"
-       id="path3101"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 64.717794,1044.8622 0,-1"
-       id="path3103"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 58.717794,1044.8622 0,-0.9881"
-       id="path3105"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 52.717794,1044.8622 0,-1"
-       id="path3107"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 46.717794,1044.8622 0,-1"
-       id="path3109"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 69.717794,1045.8622 0,-2 m -6,2 0,-2 m -6,2 0,-1.9762 m -6,1.9762 0,-2 m -6,2 0,-2"
-       id="path3091"
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 74.717794,1008.2997 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
        id="path3934"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3238);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
   </g>
 </svg>

--- a/mimes/64/x-office-spreadsheet-template.svg
+++ b/mimes/64/x-office-spreadsheet-template.svg
@@ -6,10 +6,34 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg3844"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="x-office-spreadsheet-template.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview64"
+     showgrid="false"
+     inkscape:zoom="12.390625"
+     inkscape:cx="32.161412"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3844" />
   <defs
      id="defs3846">
     <linearGradient
@@ -213,6 +237,55 @@
          style="stop-color:#ffffff;stop-opacity:0"
          id="stop6244" />
     </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3481"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,0.83127159,0,-28.805972,45.50001)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <radialGradient
+       cx="7"
+       cy="39.464806"
+       r="3.5"
+       fx="7"
+       fy="39.464806"
+       id="radialGradient3483"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.000001,1.142856,0,-89.10259,-31.49999)" />
+    <linearGradient
+       x1="30.739399"
+       y1="35.285313"
+       x2="45.902721"
+       y2="50.73642"
+       id="linearGradient3487"
+       xlink:href="#linearGradient3412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.7038931,-2.6535314,0,156.6307,-61.11597)" />
+    <linearGradient
+       x1="75.779678"
+       y1="86"
+       x2="75.779678"
+       y2="127.03607"
+       id="linearGradient3489"
+       xlink:href="#linearGradient6240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,120.00001,-63.99992)" />
   </defs>
   <metadata
      id="metadata3849">
@@ -266,31 +339,27 @@
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:#206b00;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect3580" />
   <g
-     id="g3138"
-     transform="translate(-15.217778,-983.36214)">
-    <path
-       d="m 72.217794,1040.9585 c 0,0 0,5.4036 0,5.4036 2.068242,0.01 5,-1.2107 5,-2.7022 0,-1.4915 -2.308,-2.7014 -5,-2.7014 z"
-       id="path2881-3"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     transform="translate(0,4.6802525e-5)"
+     id="g4309">
     <g
-       transform="matrix(-0.916667,0,0,0.714282,78.217794,1017.3623)"
+       transform="matrix(-0.916667,0,0,0.714282,65.000016,34.00016)"
        id="g22150"
        style="opacity:0.3">
       <rect
-         width="4"
+         width="2.9094534"
          height="7"
-         x="0"
+         x="1.0905465"
          y="35"
          id="rect22120"
-         style="fill:url(#radialGradient3157);fill-opacity:1.0;stroke:none" />
+         style="fill:url(#radialGradient3481);fill-opacity:1;stroke:none" />
       <rect
          width="4"
          height="7"
          x="-48"
          y="-42"
-         transform="scale(-1,-1)"
+         transform="scale(-1)"
          id="rect22134"
-         style="fill:url(#radialGradient3159);fill-opacity:1.0;stroke:none" />
+         style="fill:url(#radialGradient3483);fill-opacity:1;stroke:none" />
       <rect
          width="40"
          height="7"
@@ -300,36 +369,64 @@
          style="fill:url(#linearGradient3161);fill-opacity:1;stroke:none" />
     </g>
     <path
-       d="m 75.717796,1005.8622 -39.999999,40 39.999999,0 0,-40 z m -7.999996,18.6666 0,13.3334 -13.500006,0 13.500006,-13.3334 z"
+       d="m 62.500018,22.50006 -39.999999,40 h 39.999999 z m -7.999996,18.6666 v 13.3334 H 41.000016 Z"
        id="path2993"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3163);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:url(#linearGradient3487);fill-opacity:1;fill-rule:evenodd;stroke:#83899a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <g
+       transform="translate(-13.217778,-983.36214)"
+       id="g4259">
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3101"
+         d="m 70.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3103"
+         d="m 64.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3105"
+         d="m 58.717794,1044.8622 v -0.9881" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3107"
+         d="m 52.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3109"
+         d="m 46.717794,1044.8622 v -1" />
+      <path
+         style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3091"
+         d="m 69.717794,1045.8622 v -2 m -6,2 v -2 m -6,2 v -1.9762 m -6,1.9762 v -2 m -6,2 v -2" />
+    </g>
     <path
-       d="m 70.717794,1044.8622 0,-1"
-       id="path3101"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 64.717794,1044.8622 0,-1"
-       id="path3103"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 58.717794,1044.8622 0,-0.9881"
-       id="path3105"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 52.717794,1044.8622 0,-1"
-       id="path3107"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 46.717794,1044.8622 0,-1"
-       id="path3109"
-       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 69.717794,1045.8622 0,-2 m -6,2 0,-2 m -6,2 0,-1.9762 m -6,1.9762 0,-2 m -6,2 0,-2"
-       id="path3091"
-       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1.00000012px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       d="m 74.717794,1008.2997 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
+       d="m 61.500016,24.93756 c 0,0 0,36.5625 0,36.5625 0,0 -36.5625,0 -36.5625,0 0,0 36.5625,-36.5625 36.5625,-36.5625 z m -6,13.5625 c 0,0 -17,17 -17,17 0,0 17,0 17,0 0,0 0,-17 0,-17 z"
        id="path3934"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3238);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3489);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4269"
+       d="m 61.50002,33.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4271"
+       d="m 61.50002,39.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4273"
+       d="m 61.49402,45.49995 h -0.9881" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4275"
+       d="m 61.50002,51.49995 h -1" />
+    <path
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4277"
+       d="m 61.50002,57.49995 h -1" />
+    <path
+       style="opacity:0.75;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4279"
+       d="m 62.50002,32.5 h -2.0119 m 2.0119,6 h -2.0119 m 2.0119,6 h -1.9881 m 1.9881,6 h -2.0119 m 2.0119,6 h -2.0119" />
   </g>
 </svg>


### PR DESCRIPTION
These are proposed updates to the elementary-xfce icon theme.
Pushing them upstream if the changes are wanted.

Made template icons for opendocument and openxmlformats icons.
Fixed incorrectly symlinked opendocument icons.
Fixed incorrectly symlinked openxmlformat icons.
Added some symlinks for missing opendocument icons.
Added symlink for opendocument plugin (to extension icon).
Remade template triangle/set square ruler at 32px and 48px to match other sizes.
Applied new ruler to other text mime icons (text, gettext, etc).