### PR TITLE
Add extension mimetype at 128px

### DIFF
--- a/mimes/128/application-vnd.openofficeorg.extension.svg
+++ b/mimes/128/application-vnd.openofficeorg.extension.svg
@@ -1,0 +1,1 @@
+extension.svg

--- a/mimes/128/extension.svg
+++ b/mimes/128/extension.svg
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3783"
+   height="128"
+   width="128"
+   version="1.0"
+   sodipodi:docname="extension.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     width="128px"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="74.069435"
+     inkscape:cy="80.079842"
+     inkscape:window-width="1396"
+     inkscape:window-height="955"
+     inkscape:window-x="145"
+     inkscape:window-y="775"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3783" />
+  <metadata
+     id="metadata43">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3785">
+    <linearGradient
+       id="linearGradient4345">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4347" />
+      <stop
+         offset="0.28695652"
+         style="stop-color:#ffffff;stop-opacity:0.04575163"
+         id="stop4349" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4353" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4327">
+      <stop
+         id="stop4329"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0" />
+      <stop
+         offset="0.02222222"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4335" />
+      <stop
+         offset="0.06666667"
+         style="stop-color:#ffffff;stop-opacity:0.92941176;"
+         id="stop4333" />
+      <stop
+         id="stop4339"
+         style="stop-color:#ffffff;stop-opacity:0.29411766"
+         offset="0.12083333" />
+      <stop
+         id="stop4337"
+         style="stop-color:#ffffff;stop-opacity:0.16993465"
+         offset="0.93478262" />
+      <stop
+         id="stop4331"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3704" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3710" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3706" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3690" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3692" />
+    </linearGradient>
+    <radialGradient
+       r="2.5"
+       fy="43.5"
+       fx="4.9929786"
+       cy="43.5"
+       cx="4.9929786"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2470"
+       xlink:href="#linearGradient3688" />
+    <radialGradient
+       r="2.5"
+       fy="43.5"
+       fx="4.9929786"
+       cy="43.5"
+       cx="4.9929786"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2472"
+       xlink:href="#linearGradient3688" />
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2474"
+       xlink:href="#linearGradient3702" />
+    <radialGradient
+       r="2.5"
+       fy="43.5"
+       fx="4.9929786"
+       cy="43.5"
+       cx="4.9929786"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2476"
+       xlink:href="#linearGradient3688" />
+    <radialGradient
+       r="2.5"
+       fy="43.5"
+       fx="4.9929786"
+       cy="43.5"
+       cx="4.9929786"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2478"
+       xlink:href="#linearGradient3688" />
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2480"
+       xlink:href="#linearGradient3702" />
+    <linearGradient
+       id="linearGradient3242-7-3-8-0-4-58-06">
+      <stop
+         id="stop3244-5-8-5-6-4-3-8"
+         style="stop-color:#cdf87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9-5-1-5-3-0-7"
+         style="stop-color:#a2e34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7-2-0-7-5-35-9"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8-2-8-5-6-40-4"
+         style="stop-color:#1d7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
+       id="radialGradient4210"
+       cx="10"
+       cy="9"
+       fx="10"
+       fy="9"
+       r="30"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-6.6949153,2.0083337e-8,0,-6.3597222,88.521187,71.783332)" />
+    <linearGradient
+       xlink:href="#linearGradient4327"
+       id="linearGradient4269"
+       x1="26"
+       y1="16"
+       x2="26"
+       y2="62"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0084746,0,0,2.0083333,1.4872882,-3.5291665)" />
+    <linearGradient
+       xlink:href="#linearGradient4364"
+       id="linearGradient4362"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.51595,0,0,1.5066991,-100.79406,43.585033)"
+       x1="107.05136"
+       y1="-23.105574"
+       x2="107.05136"
+       y2="-5.7774076" />
+    <linearGradient
+       id="linearGradient4364">
+      <stop
+         id="stop4366"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4368"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.40000001" />
+      <stop
+         id="stop4370"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.80000001" />
+      <stop
+         id="stop4372"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4345"
+       id="linearGradient4343"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.51595,0,0,1.5066991,-44.431237,97.810032)"
+       x1="107.05136"
+       y1="-24.93836"
+       x2="107.05136"
+       y2="-5.7774076" />
+  </defs>
+  <g
+     transform="matrix(1.1052632,0,0,1.1428571,50.973684,69.285716)"
+     id="g3761"
+     style="opacity:0.3;stroke-width:0.500143">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect3763"
+       style="fill:url(#radialGradient2470);fill-opacity:1;stroke:none;stroke-width:0.500143" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1)"
+       id="rect3765"
+       style="fill:url(#radialGradient2472);fill-opacity:1;stroke:none;stroke-width:0.500143" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3767"
+       style="fill:url(#linearGradient2474);fill-opacity:1;stroke:none;stroke-width:0.500143" />
+  </g>
+  <g
+     transform="matrix(1.1315789,0,0,1.1428571,-1.1578945,69.285716)"
+     id="g3550"
+     style="opacity:0.3;stroke-width:0.4974">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect3552"
+       style="fill:url(#radialGradient2476);fill-opacity:1;stroke:none;stroke-width:0.4974" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1)"
+       id="rect3554"
+       style="fill:url(#radialGradient2478);fill-opacity:1;stroke:none;stroke-width:0.4974" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3556"
+       style="fill:url(#linearGradient2480);fill-opacity:1;stroke:none;stroke-width:0.4974" />
+  </g>
+  <path
+     style="opacity:1;fill:url(#radialGradient4210);fill-opacity:1;stroke:#0f5a00;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.498039"
+     d="m 51.699153,3.3833335 c -8.319375,0 -15.063559,6.7437115 -15.063559,15.0624995 0.0054,5.39368 2.894645,10.372778 7.574929,13.054167 H 10.517627 c -2.2253899,0 -4.0169492,1.791432 -4.0169492,4.016666 v 29.78273 c 2.6815775,-4.679955 7.6610242,-7.568969 13.0550842,-7.574397 8.319375,0 15.06356,6.74371 15.06356,15.0625 0,8.318789 -6.744185,15.062499 -15.06356,15.062499 C 14.159264,87.842166 9.1792492,84.94832 6.5006778,80.263833 v 35.219827 c 0,2.22524 1.7915593,4.01667 4.0169492,4.01667 h 33.692896 c -4.680284,-2.68139 -7.5695,-7.66048 -7.574929,-13.05417 0,-8.318783 6.744184,-15.062493 15.063559,-15.062493 8.319375,0 15.06356,6.74371 15.06356,15.062493 -0.0078,5.39612 -2.901883,10.37579 -7.5867,13.05417 h 31.307191 c 2.22539,0 4.016949,-1.79143 4.016949,-4.01667 V 80.263833 c 2.678572,4.684487 7.658587,7.578319 13.055087,7.586165 8.31938,0 15.06356,-6.74371 15.06356,-15.062499 0,-8.31879 -6.74418,-15.0625 -15.06356,-15.0625 -5.39406,0.0054 -10.37351,2.894442 -13.055087,7.574397 V 35.516666 C 94.500153,33.291432 92.708594,31.5 90.483204,31.5 H 59.176013 c 4.684817,-2.678385 7.578852,-7.658049 7.5867,-13.054167 0,-8.318789 -6.744185,-15.0624995 -15.06356,-15.0624995 z"
+     id="rect4168"
+     sodipodi:nodetypes="sccssccsccssccsccssccsccssccs" />
+  <path
+     style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4269);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.498039"
+     d="M 45.677999,32.499985 H 10.117 c -1.1126949,0 -2.6083222,1.396171 -2.6083222,2.508788 V 61.795714 C 10.590483,59.168892 14.505763,56.722722 18.555287,56.716 c 9.428624,0 17.072035,6.643539 17.072035,16.071499 0,9.42796 -7.043698,16.070501 -16.472322,16.070501 -4.04655,-1.53e-4 -8.5612,-2.437675 -11.6463221,-5.056 v 32.19 c 0,1.11262 1.4956273,2.50833 2.6083221,2.50833 h 30.59 c -3.122485,-3.66281 -5.073278,-7.49709 -5.08,-11.54633 0,-9.427949 6.918414,-16.570332 16.072153,-16.570332 9.071088,0 16.071847,7.142383 16.071847,16.570332 -1.52e-4,4.04627 -1.980805,7.92339 -5.056,11.54633 h 28.276223 c 1.112695,0 2.509162,-1.39571 2.508923,-2.50833 V 78.808 h 1.513077 0.004 c 2.026495,4.863245 7.277117,8.032379 12.546007,8.034 7.1839,0 14.05555,-6.00028 14.05555,-14.054501 0,-7.911135 -6.33396,-14.054499 -14.05555,-14.054499 -5.26702,0.0054 -10.513931,3.175767 -12.538122,8.03795 -0.0043,-2.6e-5 -0.0075,-0.0039 -0.01177,-0.0039 H 93.500146 V 35.508773 c 0,-1.985113 -1.735477,-3.008788 -3.008923,-3.008788 H 57.720675 L 57.623325,28.217227 45.678,28.357798 Z"
+     id="rect4214"
+     sodipodi:nodetypes="cssccsccssccsccssccccsccscsscccc" />
+  <path
+     id="path4335"
+     d="m 46.2,31.117 c -0.74554,0 -2.369326,-0.67666 -4.731833,-3.039 -2.362506,-2.36234 -3.823746,-6.026193 -3.823746,-9.631 0,-7.875024 6.362045,-14.053819 14.054732,-14.053819 7.768888,0 14.055544,6.325809 14.055544,13.953819 0,3.604807 -1.46124,7.36866 -3.823746,9.731 -2.362506,2.36234 -4.136529,3.113 -4.783951,3.113"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4362);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="csssssc" />
+  <path
+     id="circle4341"
+     d="m 95.0155,66.770628 c 0.246331,-0.919259 0.571493,-1.851439 2.934,-4.213779 2.36251,-2.36234 5.70813,-3.823477 10.1505,-3.823477 7.21013,0 13.6355,6.844509 13.6355,14.054127 0,7.209617 -6.8449,14.054501 -14.05503,14.054501 -3.60506,0 -7.36846,-1.46166 -9.73097,-3.824 -2.362507,-2.36234 -2.700352,-3.311958 -2.941,-4.21"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4343);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="csssssc" />
+  <path
+     style="opacity:0.2;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 7.6349575,84.074 C 14.999297,89.797435 24.710566,92.060622 33.245042,81.553"
+     id="path4355"
+     sodipodi:nodetypes="cc" />
+</svg>

--- a/mimes/128/libpeas-plugin.svg
+++ b/mimes/128/libpeas-plugin.svg
@@ -1,0 +1,1 @@
+extension.svg


### PR DESCRIPTION
Adds extension mimetype and related symlinks at 128px.

Addresses part of issue #548 