### PR TITLE
Add Vala mimetype at 16px

### DIFF
--- a/mimes/16/text-x-vala.svg
+++ b/mimes/16/text-x-vala.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="text-x-vala.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview24"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="2.65625"
+     inkscape:cy="4.25"
+     inkscape:window-width="1396"
+     inkscape:window-height="955"
+     inkscape:window-x="338"
+     inkscape:window-y="605"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="text4203" />
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.076912"
+       x2="23.99999"
+       y1="6.9230647"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="59.171429"
+       x2="37.611286"
+       y1="4.3999987"
+       x1="37.611286"
+       id="linearGradient857"
+       xlink:href="#linearGradient855" />
+    <linearGradient
+       id="linearGradient855">
+      <stop
+         id="stop851"
+         offset="0"
+         style="stop-color:#a56de2;stop-opacity:1" />
+      <stop
+         id="stop853"
+         offset="1"
+         style="stop-color:#7239b3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient855"
+       id="linearGradient863"
+       gradientUnits="userSpaceOnUse"
+       x1="37.611286"
+       y1="4.3999987"
+       x2="37.611286"
+       y2="59.171429"
+       gradientTransform="matrix(0.89999971,0,0,0.89999971,3.1000158,4.5125054)" />
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:url(#linearGradient3806);fill-opacity:1;stroke:none;display:inline"
+       id="path4160"
+       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect6741-1"
+       d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       id="path4160-8"
+       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z" />
+  </g>
+  <g
+     transform="matrix(0.38095237,0,0,0.38095237,-3.8095524,-4.190476)"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35px;line-height:125%;font-family:Lobster;-inkscape-font-specification:Lobster;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient857);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.39999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="text4203">
+    <path
+       d="M 28.375076,45.124992 27.063061,21.501048 c -0.760805,0.170488 -1.547973,0.703472 -2.147477,1.283053 -0.569037,0.550127 -0.946653,1.280997 -1.286016,1.996032 -0.306815,0.646456 -0.546332,1.335789 -0.662866,2.041806 -0.08299,0.502771 -0.07435,1.021893 -0.02026,1.528589 0.03997,0.374484 0.101993,0.756152 0.253101,1.101119 0.108201,0.247013 0.456663,0.667805 0.456663,0.667805 0,0 -0.858266,0.01081 -1.273946,-0.08001 -0.397329,-0.08681 -0.812195,-0.195792 -1.13864,-0.438364 -0.319059,-0.237084 -0.564503,-0.581129 -0.731326,-0.941931 -0.227059,-0.491081 -0.304012,-1.048476 -0.331981,-1.588786 -0.04171,-0.805852 0.02308,-1.633072 0.247821,-2.408074 0.244743,-0.843976 0.667809,-1.642285 1.174934,-2.359933 0.499406,-0.706726 1.126429,-1.328703 1.804276,-1.866655 0.544278,-0.431949 1.142546,-0.814935 1.788705,-1.070469 0.714343,-0.282499 1.488219,-0.407183 2.252004,-0.489182 1.394904,-0.149755 4.20876,0 4.20876,0 l 0.655765,18.373953 5.906735,-18.373953 h 3.9375 l -8.531735,26.248954 z"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient863);fill-opacity:1;fill-rule:nonzero;stroke-width:1.39998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path4171"
+       sodipodi:nodetypes="ccaaaaacaaaaaaaaacccccc" />
+  </g>
+</svg>


### PR DESCRIPTION
Fixes #836 

Hope I'm not bothering with too many PRs! Just trying to pick something off of the issue tracker every few days.

Using the screenshot in the issue above, I edited mine as the MainWindow.vala icon just to compare it to the current downscaled version.
![e-icon-vala-16px](https://user-images.githubusercontent.com/1984060/152159586-c4f09174-81a9-484f-abca-9caea2467da0.png)


Let me know if this needs any tweaking. Thanks!