### PR TITLE
Use rounder edges in template and download folders

### DIFF
--- a/places/128/folder-download-open.svg
+++ b/places/128/folder-download-open.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    height="128"
    id="svg11300"
    style="display:inline;enable-background:new"
    version="1.0"
    viewBox="0 0 128 128"
-   width="128">
+   width="128"
+   sodipodi:docname="folder-download-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview46"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.15625"
+     inkscape:cx="63.25964"
+     inkscape:cy="96.822622"
+     inkscape:window-width="1396"
+     inkscape:window-height="992"
+     inkscape:window-x="384"
+     inkscape:window-y="805"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata154">
     <rdf:RDF>
@@ -216,11 +238,13 @@
      id="path4234"
      d="M 2.53891,59.641217 7,115.49995 c 0,0 0,1 1,1 h 112 c 1,0 1,-1 1,-1 l 4.5,-56.000003 c 0.15378,-1.59495 0,-2 -1,-2 H 4.04143 c -1.04143,0 -1.80961,-0.22529 -1.50252,2.14127 z" />
   <path
-     d="m 64,70.999939 c -13.2548,0 -24,8.95431 -24,20 0,11.045701 10.7452,20.000001 24,20.000001 13.2548,0 24,-8.9543 24,-20.000001 0,-11.04569 -10.7452,-20 -24,-20 z m 0,5 c 9.9411,0 18,6.71573 18,15 0,8.28427 -8.0589,15.000001 -18,15.000001 -9.9411,0 -18,-6.715731 -18,-15.000001 0,-8.28427 8.0589,-15 18,-15 z m -3,5 v 10 H 52 L 64,100.99994 76,90.999939 h -9 v -10 z"
-     id="path12695"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.10000038;marker:none;enable-background:accumulate" />
+     id="path1340"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.498039;marker:none;enable-background:accumulate"
+     d="m 64,71 c -13.2548,0 -24,8.95431 -24,20 0,11.0457 10.7452,20 24,20 13.2548,0 24,-8.9543 24,-20 C 88,79.95431 77.2548,71 64,71 Z m 0,5 c 9.9411,0 18,6.71573 18,15 0,8.28427 -8.0589,15 -18,15 -9.9411,0 -18,-6.71573 -18,-15 0,-8.28427 8.0589,-15 18,-15 z m -2.322266,6 C 61.290744,81.999959 61,83.065648 61,82.677734 V 83 92.00018 H 55.199219 C 54.46054,92.00018 54,92.593533 54,93.332211 c 0,0.398118 0.174293,0.756096 0.449219,1 l 8.636719,6.304329 c 0.238796,0.22544 0.559736,0.36328 0.914062,0.36328 0.354324,0 0.675265,-0.13784 0.914062,-0.36328 l 8.636719,-6.304329 C 73.825706,94.088308 74,93.730329 74,93.332211 74,92.593533 73.716623,92.17933 73,92.00018 H 67 V 83 82.679688 C 67,82.291775 66.709254,82.000042 66.322266,82 Z"
+     sodipodi:nodetypes="sssssssssscsccssccsccscccscc" />
   <path
-     d="m 64,69.999939 c -13.2548,0 -24,8.95431 -24,20 0,11.045701 10.7452,20.000001 24,20.000001 13.2548,0 24,-8.9543 24,-20.000001 0,-11.04569 -10.7452,-20 -24,-20 z m 0,5 c 9.9411,0 18,6.71573 18,15 0,8.28427 -8.0589,15.000001 -18,15.000001 -9.9411,0 -18,-6.715731 -18,-15.000001 0,-8.28427 8.0589,-15 18,-15 z m -3,5 v 10 h -9 l 12,10 12,-10 h -9 v -10 z"
      id="path2991-3-3-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;vector-effect:none;fill:#7e5514;fill-opacity:0.971119;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.498039;marker:none;enable-background:accumulate"
+     d="m 64,70 c -13.2548,0 -24,8.95431 -24,20 0,11.0457 10.7452,20 24,20 13.2548,0 24,-8.9543 24,-20 C 88,78.95431 77.2548,70 64,70 Z m 0,5 c 9.9411,0 18,6.71573 18,15 0,8.28427 -8.0589,15 -18,15 -9.9411,0 -18,-6.71573 -18,-15 0,-8.28427 8.0589,-15 18,-15 z m -2.322266,6 C 61.290744,80.999959 61,82.065648 61,81.677734 V 82 91.00018 H 55.199219 C 54.46054,91.00018 54,91.593533 54,92.332211 c 0,0.398118 0.174293,0.756096 0.449219,1 l 8.636719,6.304328 C 63.324734,99.86198 63.645674,99.99982 64,99.99982 c 0.354324,0 0.675265,-0.13784 0.914062,-0.363281 l 8.636719,-6.304328 C 73.825706,93.088308 74,92.730329 74,92.332211 74,91.593533 73.716623,91.17933 73,91.00018 H 67 V 82 81.679688 C 67,81.291775 66.709254,81.000042 66.322266,81 Z"
+     sodipodi:nodetypes="sssssssssscsccssccsccscccscc" />
 </svg>

--- a/places/128/folder-download.svg
+++ b/places/128/folder-download.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg26392"
    height="128"
    width="128"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="folder-download.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-global="false"
+     inkscape:zoom="24.3125"
+     inkscape:cx="62.478149"
+     inkscape:cy="77.120823"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg26392" />
   <defs
      id="defs26394">
     <linearGradient
@@ -183,7 +206,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -223,11 +245,13 @@
      id="path8263"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient5891);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     id="path2991-3-3-6-2"
-     d="M 64 56 C 50.745166 56 40 66.745166 40 80 C 40 93.254834 50.745166 104 64 104 C 77.254834 104 88 93.254834 88 80 C 88 66.745166 77.254834 56 64 56 z M 64 62 C 73.941124 62 82 70.058875 82 80 C 82 89.941124 73.941124 98 64 98 C 54.058874 98 46 89.941124 46 80 C 46 70.058875 54.058874 62 64 62 z M 61 68 L 61 80 L 52 80 L 64 92 L 76 80 L 67 80 L 67 68 L 61 68 z "
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.3;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="path4207"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.498039;marker:none;enable-background:accumulate"
+     d="M 64,56 C 50.745166,56 40,66.745166 40,80 40,93.254834 50.745166,104 64,104 77.254834,104 88,93.254834 88,80 88,66.745166 77.254834,56 64,56 Z m 0,6 c 9.941124,0 18,8.058874 18,18 0,9.941124 -8.058876,18 -18,18 -9.941126,0 -18,-8.058876 -18,-18 0,-9.941125 8.058874,-18 18,-18 z m -2.322266,6 C 61.290744,67.999959 61,68.28982 61,68.677734 V 69 80 H 55.199219 C 54.46054,80 54,80.593353 54,81.332031 c 0,0.398118 0.174293,0.756096 0.449219,1 l 8.636719,9.304688 C 63.324734,91.862166 63.645674,92 64,92 c 0.354324,0 0.675265,-0.137835 0.914062,-0.363281 l 8.636719,-9.304688 C 73.825706,82.088128 74,81.730149 74,81.332031 74,80.593353 73.716623,80.17915 73,80 H 67 V 69 68.679688 C 67,68.291775 66.709254,68.000042 66.322266,68 Z"
+     sodipodi:nodetypes="sssssssssscsccssccsccscccscc" />
   <path
      id="path2991-3-3-6"
-     d="M 64 55 C 50.745166 55 40 65.745166 40 79 C 40 92.254834 50.745166 103 64 103 C 77.254834 103 88 92.254834 88 79 C 88 65.745166 77.254834 55 64 55 z M 64 61 C 73.941124 61 82 69.058874 82 79 C 82 88.941124 73.941124 97 64 97 C 54.058874 97 46 88.941124 46 79 C 46 69.058875 54.058874 61 64 61 z M 61 67 L 61 79 L 52 79 L 64 91 L 76 79 L 67 79 L 67 67 L 61 67 z "
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.6;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;vector-effect:none;fill:#7e5514;fill-opacity:0.971119;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.498039;marker:none;enable-background:accumulate"
+     d="M 64,55 C 50.745166,55 40,65.745166 40,79 40,92.254834 50.745166,103 64,103 77.254834,103 88,92.254834 88,79 88,65.745166 77.254834,55 64,55 Z m 0,6 c 9.941124,0 18,8.058874 18,18 0,9.941124 -8.058876,18 -18,18 -9.941126,0 -18,-8.058876 -18,-18 0,-9.941125 8.058874,-18 18,-18 z m -2.322266,6 C 61.290744,66.999959 61,67.28982 61,67.677734 V 68 79 H 55.199219 C 54.46054,79 54,79.593353 54,80.332031 c 0,0.398118 0.174293,0.756096 0.449219,1 l 8.636719,9.304688 C 63.324734,90.862166 63.645674,91 64,91 c 0.354324,0 0.675265,-0.137835 0.914062,-0.363281 l 8.636719,-9.304688 C 73.825706,81.088128 74,80.730149 74,80.332031 74,79.593353 73.716623,79.17915 73,79 H 67 V 68 67.679688 C 67,67.291775 66.709254,67.000042 66.322266,67 Z"
+     sodipodi:nodetypes="sssssssssscsccssccsccscccscc" />
 </svg>

--- a/places/128/folder-templates-open.svg
+++ b/places/128/folder-templates-open.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    height="128"
    id="svg11300"
    style="display:inline;enable-background:new"
    version="1.0"
    viewBox="0 0 128 128"
-   width="128">
+   width="128"
+   sodipodi:docname="folder-templates-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview46"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.15625"
+     inkscape:cx="68.85347"
+     inkscape:cy="87.033419"
+     inkscape:window-width="1396"
+     inkscape:window-height="992"
+     inkscape:window-x="406"
+     inkscape:window-y="10"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata154">
     <rdf:RDF>
@@ -216,11 +238,13 @@
      id="path4234"
      d="M 2.53891,59.641217 7,115.49995 c 0,0 0,1 1,1 h 112 c 1,0 1,-1 1,-1 l 4.5,-56.000003 c 0.15378,-1.59495 0,-2 -1,-2 H 4.04143 c -1.04143,0 -1.80961,-0.22529 -1.50252,2.14127 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5;marker:none;enable-background:accumulate"
-     id="path15987"
-     d="m 86.5299,104.99994 h -47.981 v 0 0 l 52,-32.785631 z M 79.2038,86.841889 61.406,98.190669 h 16.3974 z" />
+     id="path1523"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="m 82,73 c -1.053804,8.6e-5 -2.108536,0.315748 -2.916016,0.94769 L 40.210938,104.37008 C 39.403534,105.00195 39.000188,105.82754 39,106.65217 39,107.95287 40.338,109 42,109 h 10 v -2 h 1 v 2 h 7 v -2 h 1 v 2 h 7 v -2 h 1 v 2 h 7 v -2 h 1 v 2 h 5 c 1.662,0 3,-1.04713 3,-2.34783 V 102 h -2 v -1 h 2 v -5 h -2 v -1 h 2 v -5 h -2 v -1 h 2 v -5 h -2 v -1 h 2 v -7.652174 c 0,-1.089803 -0.944402,-1.993675 -2.226562,-2.2607 C 82.519492,73.014508 82,73 82,73 Z m -6.050781,12.523268 c 0.145421,-0.0059 0.293468,0.01267 0.433593,0.05808 0.373561,0.121179 0.617162,0.406509 0.617188,0.722999 v 15.652173 c -5.5e-5,0.43221 -0.447781,0.78257 -1,0.78261 H 56.001953 c -0.890567,-2.8e-4 -1.336538,-0.8429 -0.707031,-1.33594 L 75.292969,85.751019 c 0.178746,-0.139895 0.413881,-0.218034 0.65625,-0.227751 z"
+     sodipodi:nodetypes="ccccsccccccccccccccccssccccccccccccccccsccccccccccc" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
-     id="path13642"
-     d="m 86.5299,103.99994 h -47.981 v 0 0 l 52,-32.785631 z M 79.2038,85.841889 61.406,97.190669 h 16.3974 z" />
+     id="rect3855-3"
+     style="opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="m 82,72 c -1.053804,8.6e-5 -2.108536,0.315748 -2.916016,0.94769 L 40.210938,103.37008 C 39.403534,104.00195 39.000188,104.82754 39,105.65217 39,106.95287 40.338,108 42,108 h 10 v -2 h 1 v 2 h 7 v -2 h 1 v 2 h 7 v -2 h 1 v 2 h 7 v -2 h 1 v 2 h 5 c 1.662,0 3,-1.04713 3,-2.34783 V 101 h -2 v -1 h 2 v -5 h -2 v -1 h 2 v -5 h -2 v -1 h 2 v -5 h -2 v -1 h 2 v -7.652174 c 0,-1.089803 -0.944402,-1.993675 -2.226562,-2.2607 C 82.519492,72.014508 82,72 82,72 Z m -6.050781,12.523268 c 0.145421,-0.0059 0.293468,0.01267 0.433593,0.05808 0.373561,0.121179 0.617162,0.406509 0.617188,0.722999 v 15.652173 c -5.5e-5,0.43221 -0.447781,0.78257 -1,0.78261 H 56.001953 c -0.890567,-2.8e-4 -1.336538,-0.8429 -0.707031,-1.33594 L 75.292969,84.751019 c 0.178746,-0.139895 0.413881,-0.218034 0.65625,-0.227751 z"
+     sodipodi:nodetypes="ccccsccccccccccccccccssccccccccccccccccsccccccccccc" />
 </svg>

--- a/places/128/folder-templates.svg
+++ b/places/128/folder-templates.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="128"
    height="128"
-   id="svg26392">
+   id="svg26392"
+   sodipodi:docname="folder-templates.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="15.999999"
+     inkscape:cx="67.125004"
+     inkscape:cy="88.687506"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg26392" />
   <defs
      id="defs26394">
     <linearGradient
@@ -183,7 +205,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -223,11 +244,11 @@
      id="path8263"
      d="m 6.2499966,40.500147 c -2.84882,0.29656 -1.40933,3.76689 -1.63989,5.72017 0.78584,22.54795 1.57466,45.09583 2.35864,67.643813 1.18868,2.48974 4.4300904,1.28205 6.6383204,1.57433 35.235146,0.0205 70.470294,0.0412 105.705433,0.0617 2.566,-0.16531 1.15721,-3.81803 1.65357,-5.65555 0.85465,-22.569493 2.54292,-67.571353 2.54292,-67.571353 0,-1.16209 -0.77992,-1.7731 -2.20738,-1.7731 -37.089309,0 -77.962299,0 -115.0516134,0 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5;marker:none;enable-background:accumulate"
-     id="path4048"
-     d="M 86.995444,58.515992 V 101 H 36.99544 Z m -9,18.484008 -17,15 h 17 z" />
+     id="path5117"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="m 82,58 c -1.053804,1.1e-4 -2.108536,0.403456 -2.916016,1.210938 L 40.210938,98.083984 C 39.403534,98.891386 39.000188,99.946297 39,101 c 0,1.662 1.338,3 3,3 h 10 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 5 c 1.662,0 3,-1.338 3,-3 v -5 h -3 v -1 h 3 v -7 h -3 v -1 h 3 v -7 h -3 v -1 h 3 v -7 h -3 v -1 h 3 V 61 C 85,59.607474 84.055598,58.452527 82.773438,58.111328 82.519492,58.018534 82,58 82,58 Z m -6.050781,16.001953 c 0.145421,-0.0075 0.293468,0.01618 0.433593,0.07422 C 76.756373,74.231008 76.999974,74.595596 77,75 v 20 c -5.5e-5,0.552262 -0.447781,0.999945 -1,1 H 56.001953 c -0.890567,-3.5e-4 -1.336538,-1.077036 -0.707031,-1.707031 l 19.998047,-20 c 0.178746,-0.178755 0.413881,-0.278598 0.65625,-0.291016 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.6;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
-     id="path181"
-     d="M 86.995444,57.515991 V 100 h -50 z m -9,18.484009 -17,15 h 17 z" />
+     id="rect3855"
+     style="opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="M 82 57 C 80.946196 57.00011 79.891464 57.403456 79.083984 58.210938 L 40.210938 97.083984 C 39.403534 97.891386 39.000188 98.946297 39 100 C 39 101.662 40.338 103 42 103 L 52 103 L 52 100 L 53 100 L 53 103 L 60 103 L 60 100 L 61 100 L 61 103 L 68 103 L 68 100 L 69 100 L 69 103 L 76 103 L 76 100 L 77 100 L 77 103 L 82 103 C 83.662 103 85 101.662 85 100 L 85 95 L 82 95 L 82 94 L 85 94 L 85 87 L 82 87 L 82 86 L 85 86 L 85 79 L 82 79 L 82 78 L 85 78 L 85 71 L 82 71 L 82 70 L 85 70 L 85 60 C 85 58.607474 84.055598 57.452527 82.773438 57.111328 C 82.519492 57.018534 82 57 82 57 z M 75.949219 73.001953 C 76.09464 72.994502 76.242687 73.018133 76.382812 73.076172 C 76.756373 73.231008 76.999974 73.595596 77 74 L 77 94 C 76.999945 94.552262 76.552219 94.999945 76 95 L 56.001953 95 C 55.111386 94.99965 54.665415 93.922964 55.294922 93.292969 L 75.292969 73.292969 C 75.471715 73.114214 75.70685 73.014371 75.949219 73.001953 z " />
 </svg>


### PR DESCRIPTION
Wasn't sure if anyone had started adding the new rounder arrow style to the `Download` folder so I started on it.

Then I got distracted by the `Templates` folder icon and wanted it to look more similar to the others with smoother edges.

Let me know if either of these look okay and I can start working on the other sizes.

Thanks!

Current on left, proposed on right
![folder-templates-final1](https://user-images.githubusercontent.com/1984060/154881961-7a88e345-d45a-4a68-a0ea-aa6c67680f8f.png)

![folder-download-final1](https://user-images.githubusercontent.com/1984060/154882039-757293f8-07e1-45ae-a03d-740225552aad.png)


Edit: I realized `folder-remote` could use the rounder arrow update. Let me know if you all want me to do this one too or if it's already been/being done somewhere.

![folder-recent-1a](https://user-images.githubusercontent.com/1984060/155018522-1d07da6c-f7db-4f16-b812-e7524edb1f22.png)


---

Downloads folder arrow should now match the new arrow style.

Ruler on the templates folder given rounded edges
to match rounded edges of other folder icons.
Added hatch marks for a more distinct silhouette
and more similar to ruler used in the mimetypes.