### PR TITLE
Use rounded arrow on download folder

### DIFF
--- a/places/128/folder-download-open.svg
+++ b/places/128/folder-download-open.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    height="128"
    id="svg11300"
    style="display:inline;enable-background:new"
    version="1.0"
    viewBox="0 0 128 128"
-   width="128">
+   width="128"
+   sodipodi:docname="folder-download-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview46"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.15625"
+     inkscape:cx="62.51928"
+     inkscape:cy="96.822622"
+     inkscape:window-width="1396"
+     inkscape:window-height="992"
+     inkscape:window-x="340"
+     inkscape:window-y="118"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata154">
     <rdf:RDF>
@@ -216,11 +238,13 @@
      id="path4234"
      d="M 2.53891,59.641217 7,115.49995 c 0,0 0,1 1,1 h 112 c 1,0 1,-1 1,-1 l 4.5,-56.000003 c 0.15378,-1.59495 0,-2 -1,-2 H 4.04143 c -1.04143,0 -1.80961,-0.22529 -1.50252,2.14127 z" />
   <path
-     d="m 64,70.999939 c -13.2548,0 -24,8.95431 -24,20 0,11.045701 10.7452,20.000001 24,20.000001 13.2548,0 24,-8.9543 24,-20.000001 0,-11.04569 -10.7452,-20 -24,-20 z m 0,5 c 9.9411,0 18,6.71573 18,15 0,8.28427 -8.0589,15.000001 -18,15.000001 -9.9411,0 -18,-6.715731 -18,-15.000001 0,-8.28427 8.0589,-15 18,-15 z m -3,5 v 10 H 52 L 64,100.99994 76,90.999939 h -9 v -10 z"
-     id="path12695"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.10000038;marker:none;enable-background:accumulate" />
+     id="path1850"
+     style="color:#000000;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:0.912871;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 64,71 C 50.745166,71 40,79.954305 40,91.000001 40.000001,102.0457 50.745167,111 64,111 77.254833,111 87.999999,102.0457 88,91.000001 88,79.954305 77.254834,71 64,71 Z m 0,5 c 9.941125,0 18,6.715729 18,15.000001 C 81.999999,99.284272 73.941125,106 64,106 54.058875,106 46.000001,99.284272 46,91.000001 46,82.715729 54.058875,76 64,76 Z m -2,6.000334 c -0.554,0 -1,0.371666 -1,0.833333 v 9.166459 h -5.5 c -1.314567,0.0012 -1.991677,1.31071 -1.089844,2.107748 l 8.5,6.499876 c 0.591849,0.52142 1.587839,0.52142 2.179688,0 l 8.5,-6.499876 C 74.491677,93.310836 73.814567,92.001313 72.5,92.000126 H 67 v -9.166459 c 0,-0.461668 -0.446,-0.833333 -1,-0.833333 z"
+     sodipodi:nodetypes="ssssssssssssccccccccsss" />
   <path
-     d="m 64,69.999939 c -13.2548,0 -24,8.95431 -24,20 0,11.045701 10.7452,20.000001 24,20.000001 13.2548,0 24,-8.9543 24,-20.000001 0,-11.04569 -10.7452,-20 -24,-20 z m 0,5 c 9.9411,0 18,6.71573 18,15 0,8.28427 -8.0589,15.000001 -18,15.000001 -9.9411,0 -18,-6.715731 -18,-15.000001 0,-8.28427 8.0589,-15 18,-15 z m -3,5 v 10 h -9 l 12,10 12,-10 h -9 v -10 z"
-     id="path2991-3-3-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922" />
+     id="path897"
+     style="color:#000000;opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:0.912871;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 64,70 C 50.745166,70 40,78.954305 40,90.000001 40.000001,101.0457 50.745167,110 64,110 77.254833,110 87.999999,101.0457 88,90.000001 88,78.954305 77.254834,70 64,70 Z m 0,5 c 9.941125,0 18,6.715729 18,15.000001 C 81.999999,98.284272 73.941125,105 64,105 54.058875,105 46.000001,98.284272 46,90.000001 46,81.715729 54.058875,75 64,75 Z m -2,6.000334 c -0.554,0 -1,0.371666 -1,0.833333 v 9.166459 h -5.5 c -1.314567,0.0012 -1.991677,1.31071 -1.089844,2.107748 l 8.5,6.499875 c 0.591849,0.521421 1.587839,0.521421 2.179688,0 l 8.5,-6.499875 C 74.491677,92.310836 73.814567,91.001313 72.5,91.000126 H 67 v -9.166459 c 0,-0.461668 -0.446,-0.833333 -1,-0.833333 z"
+     sodipodi:nodetypes="ssssssssssssccccccccsss" />
 </svg>

--- a/places/128/folder-download.svg
+++ b/places/128/folder-download.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg26392"
    height="128"
    width="128"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="folder-download.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-global="false"
+     inkscape:zoom="16"
+     inkscape:cx="66.0625"
+     inkscape:cy="74.34375"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg26392" />
   <defs
      id="defs26394">
     <linearGradient
@@ -183,7 +206,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -223,11 +245,11 @@
      id="path8263"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient5891);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     id="path2991-3-3-6-2"
-     d="M 64 56 C 50.745166 56 40 66.745166 40 80 C 40 93.254834 50.745166 104 64 104 C 77.254834 104 88 93.254834 88 80 C 88 66.745166 77.254834 56 64 56 z M 64 62 C 73.941124 62 82 70.058875 82 80 C 82 89.941124 73.941124 98 64 98 C 54.058874 98 46 89.941124 46 80 C 46 70.058875 54.058874 62 64 62 z M 61 68 L 61 80 L 52 80 L 64 92 L 76 80 L 67 80 L 67 68 L 61 68 z "
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.3;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="path5756"
+     style="color:#000000;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 64,56 A 24,24 0 0 0 40,80 24,24 0 0 0 64,104 24,24 0 0 0 88,80 24,24 0 0 0 64,56 Z m 0,6 A 18,18 0 0 1 82,80 18,18 0 0 1 64,98 18,18 0 0 1 46,80 18,18 0 0 1 64,62 Z m -2,6 c -0.554,0 -1,0.446 -1,1 v 11 h -5.5 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 l 8.5,9 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.5,-9 C 74.491677,81.572852 73.814567,80.001424 72.5,80 H 67 V 69 c 0,-0.554 -0.446,-1 -1,-1 z" />
   <path
-     id="path2991-3-3-6"
-     d="M 64 55 C 50.745166 55 40 65.745166 40 79 C 40 92.254834 50.745166 103 64 103 C 77.254834 103 88 92.254834 88 79 C 88 65.745166 77.254834 55 64 55 z M 64 61 C 73.941124 61 82 69.058874 82 79 C 82 88.941124 73.941124 97 64 97 C 54.058874 97 46 88.941124 46 79 C 46 69.058875 54.058874 61 64 61 z M 61 67 L 61 79 L 52 79 L 64 91 L 76 79 L 67 79 L 67 67 L 61 67 z "
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.6;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922" />
+     id="path897"
+     style="color:#000000;opacity:0.6;fill:#7e5514;stroke-linejoin:round;-inkscape-stroke:none;fill-opacity:0.97254902"
+     d="M 64 55 A 24 24 0 0 0 40 79 A 24 24 0 0 0 64 103 A 24 24 0 0 0 88 79 A 24 24 0 0 0 64 55 z M 64 61 A 18 18 0 0 1 82 79 A 18 18 0 0 1 64 97 A 18 18 0 0 1 46 79 A 18 18 0 0 1 64 61 z M 62 67 C 61.446 67 61 67.446 61 68 L 61 79 L 55.5 79 C 54.185433 79.0014 53.508323 80.572852 54.410156 81.529297 L 62.910156 90.529297 C 63.502005 91.155006 64.497995 91.155006 65.089844 90.529297 L 73.589844 81.529297 C 74.491677 80.572852 73.814567 79.001424 72.5 79 L 67 79 L 67 68 C 67 67.446 66.554 67 66 67 L 62 67 z " />
 </svg>

--- a/places/32/folder-download-open.svg
+++ b/places/32/folder-download-open.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    height="32"
    id="svg11300"
    style="display:inline;enable-background:new"
    version="1.0"
    viewBox="0 0 32.000961 32"
-   width="32.000961">
+   width="32.000961"
+   sodipodi:docname="folder-download-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview46"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="34.383067"
+     inkscape:cx="10.950158"
+     inkscape:cy="19.660841"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="0"
+     inkscape:window-y="44"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata154">
     <rdf:RDF>
@@ -216,11 +238,11 @@
      id="use8572"
      d="m 1.602042,15.5 1.265854,13 h 26.265163 l 1.26586,-13 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate"
-     id="path12758"
-     d="m 16.00048,19.125 c -2.76141,0 -5,1.79086 -5,4 0,2.20914 2.23859,4 5,4 2.76141,0 5,-1.79086 5,-4 0,-2.20914 -2.23859,-4 -5,-4 z m 0,0.72728 c 2.25936,0 4.09091,1.46524 4.09091,3.27272 0,1.80747 -1.83155,3.27273 -4.09091,3.27273 -2.25936,0 -4.09091,-1.46526 -4.09091,-3.27273 0,-1.80748 1.83155,-3.27272 4.09091,-3.27272 z m -0.45454,1.45454 V 23.125 h -1.81819 l 2.27273,1.81818 2.27273,-1.81818 h -1.81818 v -1.81818 z" />
+     id="path2484"
+     style="color:#000000;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:1.15442;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 16,17.75 c -3.313708,0 -6,2.238577 -6,5 0,2.761423 2.686292,5 6,5 3.313708,0 6,-2.238577 6,-5 0,-2.761423 -2.686292,-5 -6,-5 z M 16,19 c 2.485281,0 4.5,1.678933 4.5,3.75 0,2.071067 -2.014719,3.75 -4.5,3.75 -2.485281,0 -4.5,-1.678933 -4.5,-3.75 C 11.5,20.678933 13.514719,19 16,19 Z m -0.75,1 C 15.111467,20 15,20.08362 15,20.1875 V 23 h -1.416016 c -0.290949,-1.41e-4 -0.441846,0.259867 -0.24414,0.419922 l 2.416015,2 c 0.131956,0.107032 0.356327,0.107032 0.488282,0 l 2.416015,-2 C 18.857862,23.259867 18.706965,22.999859 18.416016,23 H 17 V 20.1875 C 17,20.083629 16.888534,20 16.75,20 Z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
-     id="rect3005-5-8-6-8-1"
-     d="m 16.00048,18.125 c -2.76141,0 -5,1.79086 -5,4 0,2.20914 2.23859,4 5,4 2.76141,0 5,-1.79086 5,-4 0,-2.20914 -2.23859,-4 -5,-4 z m 0,0.72728 c 2.25936,0 4.09091,1.46524 4.09091,3.27272 0,1.80747 -1.83155,3.27273 -4.09091,3.27273 -2.25936,0 -4.09091,-1.46526 -4.09091,-3.27273 0,-1.80748 1.83155,-3.27272 4.09091,-3.27272 z m -0.45454,1.45454 V 22.125 h -1.81819 l 2.27273,1.81818 2.27273,-1.81818 h -1.81818 v -1.81818 z" />
+     id="path885"
+     style="color:#000000;opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:1.15442;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 16 16.75 C 12.686292 16.75 10 18.988577 10 21.75 C 10 24.511423 12.686292 26.75 16 26.75 C 19.313708 26.75 22 24.511423 22 21.75 C 22 18.988577 19.313708 16.75 16 16.75 z M 16 18 C 18.485281 18 20.5 19.678933 20.5 21.75 C 20.5 23.821067 18.485281 25.5 16 25.5 C 13.514719 25.5 11.5 23.821067 11.5 21.75 C 11.5 19.678933 13.514719 18 16 18 z M 15.25 19 C 15.111467 19 15 19.08362 15 19.1875 L 15 22 L 13.583984 22 C 13.293035 21.999859 13.142138 22.259867 13.339844 22.419922 L 15.755859 24.419922 C 15.887815 24.526954 16.112186 24.526954 16.244141 24.419922 L 18.660156 22.419922 C 18.857862 22.259867 18.706965 21.999859 18.416016 22 L 17 22 L 17 19.1875 C 17 19.083629 16.888534 19 16.75 19 L 15.25 19 z " />
 </svg>

--- a/places/32/folder-download.svg
+++ b/places/32/folder-download.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg14288">
+   id="svg14288"
+   sodipodi:docname="folder-download.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.15625"
+     inkscape:cx="15.177378"
+     inkscape:cy="11.187661"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="125"
+     inkscape:window-y="32"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg14288" />
   <defs
      id="defs14290">
     <linearGradient
@@ -183,7 +205,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -223,11 +244,11 @@
      id="path3309"
      d="m 2.5001794,12.499999 0.62498,16 H 28.874329 l 0.62498,-16 z" />
   <path
-     id="path951-3"
-     d="m 16,17 c -2.761423,0 -5,2.238577 -5,5 0,2.761423 2.238577,5 5,5 2.761423,0 5,-2.238577 5,-5 0,-2.761423 -2.238577,-5 -5,-5 z m 0,1 c 2.209138,0 4,1.790862 4,4 0,2.209138 -1.790862,4 -4,4 -2.209138,0 -4,-1.790862 -4,-4 0,-2.209138 1.790862,-4 4,-4 z m -0.5,2 v 2 H 14 L 16,24.273438 18,22 h -1.599609 v -2 z"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal" />
+     id="path6505"
+     style="color:#000000;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:1.33294;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 16,16 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 6,6 0 0 0 6,-6 6,6 0 0 0 -6,-6 z m 0,1.5 A 4.5,4.5 0 0 1 20.5,22 4.5,4.5 0 0 1 16,26.5 4.5,4.5 0 0 1 11.5,22 4.5,4.5 0 0 1 16,17.5 Z M 15.25,19 C 15.111481,19 15,19.1115 15,19.25 V 22 h -1.416016 c -0.29092,-1.87e-4 -0.441826,0.347141 -0.24414,0.560547 l 2.416015,2.582031 c 0.131943,0.142708 0.35634,0.142708 0.488282,0 l 2.416015,-2.582031 C 18.857842,22.347141 18.706936,21.999813 18.416016,22 H 17 V 19.25 C 17,19.1115 16.88852,19 16.75,19 Z" />
   <path
-     id="path951"
-     d="M 16 16 C 13.238577 16 11 18.238577 11 21 C 11 23.761423 13.238577 26 16 26 C 18.761423 26 21 23.761423 21 21 C 21 18.238577 18.761423 16 16 16 z M 16 17 C 18.209138 17 20 18.790862 20 21 C 20 23.209138 18.209138 25 16 25 C 13.790862 25 12 23.209138 12 21 C 12 18.790862 13.790862 17 16 17 z M 15.5 19 L 15.5 21 L 14 21 L 16 23.273438 L 18 21 L 16.400391 21 L 16.400391 19 L 15.5 19 z "
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;vector-effect:none;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.9999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922;marker:none;enable-background:accumulate" />
+     id="path1063"
+     style="color:#000000;opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:1.33294;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 16 15 A 6 6 0 0 0 10 21 A 6 6 0 0 0 16 27 A 6 6 0 0 0 22 21 A 6 6 0 0 0 16 15 z M 16 16.5 A 4.5 4.5 0 0 1 20.5 21 A 4.5 4.5 0 0 1 16 25.5 A 4.5 4.5 0 0 1 11.5 21 A 4.5 4.5 0 0 1 16 16.5 z M 15.25 18 C 15.111481 18 15 18.1115 15 18.25 L 15 21 L 13.583984 21 C 13.293064 20.999813 13.142158 21.347141 13.339844 21.560547 L 15.755859 24.142578 C 15.887802 24.285286 16.112199 24.285286 16.244141 24.142578 L 18.660156 21.560547 C 18.857842 21.347141 18.706936 20.999813 18.416016 21 L 17 21 L 17 18.25 C 17 18.1115 16.88852 18 16.75 18 L 15.25 18 z " />
 </svg>

--- a/places/48/folder-download-open.svg
+++ b/places/48/folder-download-open.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48.055344"
    viewBox="0 0 48.055344 48"
    version="1.0"
    style="display:inline;enable-background:new"
    id="svg11300"
-   height="48">
+   height="48"
+   sodipodi:docname="folder-download-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview46"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="22.922045"
+     inkscape:cx="25.608536"
+     inkscape:cy="36.973141"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata154">
     <rdf:RDF>
@@ -216,11 +238,13 @@
      id="path3985"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient1369);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     id="path7559"
-     d="M 24 29 C 19.581722 29 16 31.686292 16 35 C 16 38.313709 19.581722 41 24 41 C 28.418278 41 32 38.313709 32 35 C 32 31.686292 28.418278 29 24 29 z M 24 30.5 C 27.313708 30.5 30 32.514719 30 35 C 30 37.485281 27.313708 39.5 24 39.5 C 20.686291 39.5 18 37.485281 18 35 C 18 32.514719 20.686291 30.5 24 30.5 z M 23 32 L 23 35 L 20 35 L 24 38 L 28 35 L 25 35 L 25 32 L 23 32 z "
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.3;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="path1840"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="m 24.027672,28 c -4.958713,0 -9,3.143223 -9,6.999999 0,3.856777 4.041287,7.000001 9,7.000001 4.958713,0 9,-3.143224 9,-7.000001 0,-3.856776 -4.041287,-6.999999 -9,-6.999999 z m 0,1.555555 c 3.877834,0 7,2.428352 7,5.444444 0,3.016094 -3.122166,5.444446 -7,5.444446 -3.877834,0 -7,-2.428352 -7,-5.444446 0,-3.016092 3.122166,-5.444444 7,-5.444444 z m -0.5,2.444001 c -0.277,0 -0.498763,0.173447 -0.5,0.388888 v 2.611555 h -2.375 c -0.548171,6.04e-4 -0.829901,0.510632 -0.453125,0.820314 l 3.375,2.761718 c 0.246423,0.201708 0.659827,0.201708 0.90625,0 l 3.375,-2.761718 c 0.376776,-0.309683 0.09505,-0.81971 -0.453125,-0.820314 h -2.375 v -2.611555 c 0,-0.215444 -0.223,-0.388888 -0.5,-0.388888 z"
+     sodipodi:nodetypes="ssssssssssscccccccccsss" />
   <path
-     id="path2991-3-3"
-     d="M 24 28 C 19.581722 28 16 30.686292 16 34 C 16 37.313709 19.581722 40 24 40 C 28.418278 40 32 37.313709 32 34 C 32 30.686292 28.418278 28 24 28 z M 24 29.5 C 27.313708 29.5 30 31.514719 30 34 C 30 36.485281 27.313708 38.5 24 38.5 C 20.686291 38.5 18 36.485281 18 34 C 18 31.514719 20.686291 29.5 24 29.5 z M 23 31 L 23 34 L 20 34 L 24 37 L 28 34 L 25 34 L 25 31 L 23 31 z "
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.6;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922" />
+     id="rect2153-3"
+     style="opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="m 24.027672,27 c -4.958713,0 -9,3.143223 -9,6.999999 0,3.856777 4.041287,7.000001 9,7.000001 4.958713,0 9,-3.143224 9,-7.000001 0,-3.856776 -4.041287,-6.999999 -9,-6.999999 z m 0,1.555555 c 3.877834,0 7,2.428352 7,5.444444 0,3.016094 -3.122166,5.444446 -7,5.444446 -3.877834,0 -7,-2.428352 -7,-5.444446 0,-3.016092 3.122166,-5.444444 7,-5.444444 z m -0.5,2.444001 c -0.277,0 -0.498763,0.173447 -0.5,0.388888 v 2.611555 h -2.375 c -0.548171,6.04e-4 -0.829901,0.510632 -0.453125,0.820314 l 3.375,2.761718 c 0.246423,0.201708 0.659827,0.201708 0.90625,0 l 3.375,-2.761718 c 0.376776,-0.309683 0.09505,-0.81971 -0.453125,-0.820314 h -2.375 v -2.611555 c 0,-0.215444 -0.223,-0.388888 -0.5,-0.388888 z"
+     sodipodi:nodetypes="ssssssssssscccccccccsss" />
 </svg>

--- a/places/48/folder-download.svg
+++ b/places/48/folder-download.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg18157">
+   id="svg18157"
+   sodipodi:docname="folder-download.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="15.887805"
+     inkscape:cy="29.654291"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg18157"
+     inkscape:snap-center="true" />
   <defs
      id="defs18159">
     <linearGradient
@@ -183,7 +206,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -223,11 +245,13 @@
      id="path4587-3-5"
      d="m 2.5221121,16.499999 c 0.016793,0.183202 0.022163,0.537823 0.03125,0.908598 0.023112,0.08973 0.025524,0.06151 0.03125,0.09735 0.011058,0.06921 0.027034,0.143566 0.03125,0.1947 0.0064,0.07761 -0.00668,0.179686 0,0.292049 0.013352,0.224726 0.045306,0.530459 0.0625,0.908598 0.034388,0.756279 0.078083,1.7745 0.125,3.017843 0.093834,2.486687 0.2030642,5.769016 0.3125,9.02108 0.2122959,6.308724 0.3945663,12.188203 0.40625,12.558123 0.1225025,0.0037 0.071108,0 0.25,0 H 44.490862 c 0.0124,-0.341463 0.253182,-6.673493 0.5,-13.401821 0.126691,-3.453636 0.245386,-6.941969 0.34375,-9.572728 0.04918,-1.31538 0.09434,-2.421026 0.125,-3.212543 0.01322,-0.341237 0.02246,-0.594976 0.03125,-0.811249 z" />
   <path
-     id="path2991-1-1-3"
-     d="m 23.984375,23 c -4.418278,0 -8,3.581722 -8,8 0,4.418278 3.581722,8 8,8 4.418278,0 8,-3.581722 8,-8 0,-4.418278 -3.581722,-8 -8,-8 z m 0,2 c 3.313708,0 6,2.686291 6,6 0,3.313708 -2.686292,6 -6,6 -3.313709,0 -6,-2.686292 -6,-6 0,-3.313709 2.686291,-6 6,-6 z m -1,2 v 4 h -3 l 4,4 4,-4 h -3 v -4 z"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.3;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="path870"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="m 24,22.25 c -4.958713,0 -9,4.041287 -9,9 0,4.958713 4.041287,9 9,9 4.958713,0 9,-4.041287 9,-9 0,-4.958713 -4.041287,-9 -9,-9 z m 0,2 c 3.877834,0 7,3.122166 7,7 0,3.877834 -3.122166,7 -7,7 -3.877834,0 -7,-3.122166 -7,-7 0,-3.877834 3.122166,-7 7,-7 z M 23.5,27 c -0.277,0 -0.498763,0.223003 -0.5,0.5 V 31 h -2.375 c -0.548171,7.76e-4 -0.829901,0.656527 -0.453125,1.054688 l 3.375,3.550781 c 0.246423,0.259338 0.659827,0.259338 0.90625,0 l 3.375,-3.550781 C 28.204901,31.656526 27.923171,31.000776 27.375,31 H 25 V 27.5 C 25,27.223 24.777,27 24.5,27 Z"
+     sodipodi:nodetypes="ssssssssssscccccccccsss" />
   <path
-     id="path2991-3-3"
-     d="m 23.984375,22 c -4.418278,0 -8,3.581722 -8,8 0,4.418278 3.581722,8 8,8 4.418278,0 8,-3.581722 8,-8 0,-4.418278 -3.581722,-8 -8,-8 z m 0,2 c 3.313708,0 6,2.686291 6,6 0,3.313708 -2.686292,6 -6,6 -3.313709,0 -6,-2.686292 -6,-6 0,-3.313709 2.686291,-6 6,-6 z m -1,2 v 4 h -3 l 4,4 4,-4 h -3 v -4 z"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.6;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922" />
+     id="rect2153"
+     style="opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="m 24,21.25 c -4.958713,0 -9,4.041287 -9,9 0,4.958713 4.041287,9 9,9 4.958713,0 9,-4.041287 9,-9 0,-4.958713 -4.041287,-9 -9,-9 z m 0,2 c 3.877834,0 7,3.122166 7,7 0,3.877834 -3.122166,7 -7,7 -3.877834,0 -7,-3.122166 -7,-7 0,-3.877834 3.122166,-7 7,-7 z M 23.5,26 c -0.277,0 -0.498763,0.223003 -0.5,0.5 V 30 h -2.375 c -0.548171,7.76e-4 -0.829901,0.656527 -0.453125,1.054688 l 3.375,3.550781 c 0.246423,0.259338 0.659827,0.259338 0.90625,0 l 3.375,-3.550781 C 28.204901,30.656526 27.923171,30.000776 27.375,30 H 25 V 26.5 C 25,26.223 24.777,26 24.5,26 Z"
+     sodipodi:nodetypes="ssssssssssscccccccccsss" />
 </svg>

--- a/places/64/folder-download-open.svg
+++ b/places/64/folder-download-open.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="64"
    height="64"
-   id="svg22774">
+   id="svg22774"
+   sodipodi:docname="folder-download-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview45"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.15625"
+     inkscape:cx="23.650386"
+     inkscape:cy="35.455013"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="-289"
+     inkscape:window-y="102"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg22774" />
   <defs
      id="defs22776">
     <linearGradient
@@ -172,7 +194,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -212,11 +233,11 @@
      id="path4183"
      d="m 1.472422,28.500092 2.9315,27.9845 55.13702,0.031 2.93148,-28.0155 z" />
   <path
-     d="m 32.00007,37 c -6.0751,0 -11,3.58172 -11,8 0,4.41828 4.9249,8 11,8 6.0751,0 11,-3.58172 11,-8 0,-4.41828 -4.9249,-8 -11,-8 z m 0,1.45455 c 4.9706,0 9,2.9305 9,6.54545 0,3.61495 -4.0294,6.54546 -9,6.54546 -4.9706,0 -9,-2.93051 -9,-6.54546 0,-3.61495 4.0294,-6.54545 9,-6.54545 z m -1,2.90909 V 45 h -4 l 5,3.63636 5,-3.63636 h -4 v -3.63636 z"
-     id="path9650"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate" />
+     id="path1252"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:2.78447;stroke-linejoin:round"
+     d="m 32,35 c -6.471246,0 -12,4.32113 -12,10 0,5.67887 5.528754,10 12,10 6.471246,0 12,-4.32113 12,-10 0,-5.67887 -5.528754,-10 -12,-10 z m 0,2.75 c 5.264794,0 9.25,3.401967 9.25,7.25 0,3.848033 -3.985206,7.25 -9.25,7.25 -5.264794,0 -9.25,-3.401967 -9.25,-7.25 0,-3.848033 3.985206,-7.25 9.25,-7.25 z M 31,40 c -0.554,0 -1,0.372318 -1,0.833984 V 45 h -2.673828 c -0.722903,6.33e-4 -1.095536,0.710803 -0.59961,1.142578 l 4.673829,4.0625 c 0.325472,0.282473 0.873746,0.282473 1.199218,0 l 4.673829,-4.0625 C 37.769374,45.710803 37.396734,45.000643 36.673828,45 H 34 V 40.833984 C 34,40.372318 33.554,40 33,40 Z" />
   <path
-     d="m 32.00007,36 c -6.0751,0 -11,3.58172 -11,8 0,4.41828 4.9249,8 11,8 6.0751,0 11,-3.58172 11,-8 0,-4.41828 -4.9249,-8 -11,-8 z m 0,1.45455 c 4.9706,0 9,2.9305 9,6.54545 0,3.61495 -4.0294,6.54546 -9,6.54546 -4.9706,0 -9,-2.93051 -9,-6.54546 0,-3.61495 4.0294,-6.54545 9,-6.54545 z m -1,2.90909 V 44 h -4 l 5,3.63636 5,-3.63636 h -4 v -3.63636 z"
-     id="rect3005-5-8-6-8"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922" />
+     id="path883-3"
+     style="opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:2.78447;stroke-linejoin:round"
+     d="M 32 34 C 25.528754 34 20 38.32113 20 44 C 20 49.67887 25.528754 54 32 54 C 38.471246 54 44 49.67887 44 44 C 44 38.32113 38.471246 34 32 34 z M 32 36.75 C 37.264794 36.75 41.25 40.151967 41.25 44 C 41.25 47.848033 37.264794 51.25 32 51.25 C 26.735206 51.25 22.75 47.848033 22.75 44 C 22.75 40.151967 26.735206 36.75 32 36.75 z M 31 39 C 30.446 39 30 39.372318 30 39.833984 L 30 44 L 27.326172 44 C 26.603269 44.000633 26.230636 44.710803 26.726562 45.142578 L 31.400391 49.205078 C 31.725863 49.487551 32.274137 49.487551 32.599609 49.205078 L 37.273438 45.142578 C 37.769374 44.710803 37.396734 44.000643 36.673828 44 L 34 44 L 34 39.833984 C 34 39.372318 33.554 39 33 39 L 31 39 z " />
 </svg>

--- a/places/64/folder-download.svg
+++ b/places/64/folder-download.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg22774"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="folder-download.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview45"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="25.698912"
+     inkscape:cy="41.940271"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="-327"
+     inkscape:window-y="69"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg22774"
+     inkscape:snap-global="false" />
   <defs
      id="defs22776">
     <linearGradient
@@ -172,7 +195,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -212,11 +234,11 @@
      d="m 3,21.5 c -0.277,0 -0.5134886,0.185576 -0.5,0.416016 l 2,34.167968 C 4.5134886,56.314424 4.723,56.5 5,56.5 h 54 c 0.277,0 0.486511,-0.185576 0.5,-0.416016 l 2,-34.167968 C 61.513489,21.685576 61.277,21.5 61,21.5 Z"
      style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient5962);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;font-variant-east_asian:normal" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate"
-     d="m 32,29 c -6.07513,0 -11,4.92487 -11,11 0,6.07513 4.92487,11 11,11 6.07513,0 11,-4.92487 11,-11 0,-6.07513 -4.92487,-11 -11,-11 z m 0,2 c 4.97056,0 9,4.02944 9,9 0,4.97056 -4.02944,9 -9,9 -4.97056,0 -9,-4.02944 -9,-9 0,-4.97056 4.02944,-9 9,-9 z m -1,4 v 5 h -4 l 5,5 5,-5 h -4 v -5 z"
-     id="rect3005-5-8-6-8-3" />
+     id="path2894"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:3.05023;stroke-linejoin:round"
+     d="M 32 29 C 25.388876 29 20 34.388876 20 41 C 20 47.611124 25.388876 53 32 53 C 38.611124 53 44 47.611124 44 41 C 44 34.388876 38.611124 29 32 29 z M 32 31.75 C 37.124915 31.75 41.25 35.875085 41.25 41 C 41.25 46.124915 37.124915 50.25 32 50.25 C 26.875085 50.25 22.75 46.124915 22.75 41 C 22.75 35.875085 26.875085 31.75 32 31.75 z M 31 35 C 30.446 35 30 35.446 30 36 L 30 41 L 27.326172 41 C 26.603269 41.000759 26.230636 41.852963 26.726562 42.371094 L 31.400391 47.246094 C 31.725863 47.585061 32.274137 47.585061 32.599609 47.246094 L 37.273438 42.371094 C 37.769374 41.852963 37.396734 41.000772 36.673828 41 L 34 41 L 34 36 C 34 35.446 33.554 35 33 35 L 31 35 z " />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e5514;fill-opacity:0.97111912;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.6;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
-     d="m 32,28 c -6.07513,0 -11,4.92487 -11,11 0,6.07513 4.92487,11 11,11 6.07513,0 11,-4.92487 11,-11 0,-6.07513 -4.92487,-11 -11,-11 z m 0,2 c 4.97056,0 9,4.02944 9,9 0,4.97056 -4.02944,9 -9,9 -4.97056,0 -9,-4.02944 -9,-9 0,-4.97056 4.02944,-9 9,-9 z m -1,4 v 5 h -4 l 5,5 5,-5 h -4 v -5 z"
-     id="rect3005-5-8-6-8" />
+     id="path883"
+     style="opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:3.05023;stroke-linejoin:round"
+     d="M 32 28 C 25.388876 28 20 33.388876 20 40 C 20 46.611124 25.388876 52 32 52 C 38.611124 52 44 46.611124 44 40 C 44 33.388876 38.611124 28 32 28 z M 32 30.75 C 37.124915 30.75 41.25 34.875085 41.25 40 C 41.25 45.124915 37.124915 49.25 32 49.25 C 26.875085 49.25 22.75 45.124915 22.75 40 C 22.75 34.875085 26.875085 30.75 32 30.75 z M 31 34 C 30.446 34 30 34.446 30 35 L 30 40 L 27.326172 40 C 26.603269 40.000759 26.230636 40.852963 26.726562 41.371094 L 31.400391 46.246094 C 31.725863 46.585061 32.274137 46.585061 32.599609 46.246094 L 37.273438 41.371094 C 37.769374 40.852963 37.396734 40.000772 36.673828 40 L 34 40 L 34 35 C 34 34.446 33.554 34 33 34 L 31 34 z " />
 </svg>


### PR DESCRIPTION
Updated the places folder-download folders to use the rounded arrow style. Tried to also make the smaller sizes a little more legible and consistent while I was at it.

---
Current:

![current-white](https://user-images.githubusercontent.com/1984060/159422568-bade5090-d4d8-41d4-b6a2-fa9f6dd44d49.png)


Proposed:

![proposed-final2-white](https://user-images.githubusercontent.com/1984060/159422593-b7816c4e-7d12-4e17-9710-844924242bf9.png)