### PR TITLE
Places: Use rounded corners for template symbol

### DIFF
--- a/places/128/folder-templates-open.svg
+++ b/places/128/folder-templates-open.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    height="128"
    id="svg11300"
    style="display:inline;enable-background:new"
    version="1.0"
    viewBox="0 0 128 128"
-   width="128">
+   width="128"
+   sodipodi:docname="folder-templates-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview46"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.5351066"
+     inkscape:cx="57.928842"
+     inkscape:cy="108.95665"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="469"
+     inkscape:window-y="79"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata154">
     <rdf:RDF>
@@ -216,11 +238,13 @@
      id="path4234"
      d="M 2.53891,59.641217 7,115.49995 c 0,0 0,1 1,1 h 112 c 1,0 1,-1 1,-1 l 4.5,-56.000003 c 0.15378,-1.59495 0,-2 -1,-2 H 4.04143 c -1.04143,0 -1.80961,-0.22529 -1.50252,2.14127 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5;marker:none;enable-background:accumulate"
-     id="path15987"
-     d="m 86.5299,104.99994 h -47.981 v 0 0 l 52,-32.785631 z M 79.2038,86.841889 61.406,98.190669 h 16.3974 z" />
+     id="path2476"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:0.99905306;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="m 83,71 c -1.053804,1.11e-4 -2.108536,0.403457 -2.916016,1.210938 L 41.210938,102.08399 c -0.807404,0.8074 -1.21075,1.86231 -1.210938,2.916 0,1.662 1.338,3 3,3 h 10 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 5 c 1.662,0 3,-1.338 3,-3 V 101 h -3 v -1 h 3 v -5 h -3 v -1 h 3 v -5 h -3 v -1 h 3 v -5 h -3 v -1 h 3 V 74 C 86,72.607474 85.055598,71.452528 83.773438,71.111328 83.519492,71.018539 83,71 83,71 Z m -6.050781,13.001976 c 0.145421,-0.0075 0.293468,0.01618 0.433593,0.07422 0.373561,0.154835 0.617162,0.519423 0.617188,0.923827 V 100 c -5.5e-5,0.55226 -0.447781,0.99995 -1,1 H 56.501516 c -0.890567,-3.5e-4 -1.336538,-1.07703 -0.707031,-1.707031 L 76.292969,84.292992 c 0.178746,-0.178754 0.413881,-0.278598 0.65625,-0.291016 z"
+     sodipodi:nodetypes="ccccsccccccccccccccccssccccccccccccccccsccccccccccc" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
-     id="path13642"
-     d="m 86.5299,103.99994 h -47.981 v 0 0 l 52,-32.785631 z M 79.2038,85.841889 61.406,97.190669 h 16.3974 z" />
+     id="rect3855"
+     style="opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="m 83,70 c -1.053804,1.11e-4 -2.108536,0.403457 -2.916016,1.210938 L 41.210938,101.08399 c -0.807404,0.8074 -1.21075,1.86231 -1.210938,2.916 0,1.662 1.338,3 3,3 h 10 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 5 c 1.662,0 3,-1.338 3,-3 V 100 h -3 v -1 h 3 v -5 h -3 v -1 h 3 v -5 h -3 v -1 h 3 v -5 h -3 v -1 h 3 V 73 C 86,71.607474 85.055598,70.452528 83.773438,70.111328 83.519492,70.018539 83,70 83,70 Z m -6.050781,13.001976 c 0.145421,-0.0075 0.293468,0.01618 0.433593,0.07422 0.373561,0.154835 0.617162,0.519423 0.617188,0.923827 V 99 c -5.5e-5,0.55226 -0.447781,0.99995 -1,1 H 56.501516 c -0.890567,-3.5e-4 -1.336538,-1.07703 -0.707031,-1.707031 L 76.292969,83.292992 c 0.178746,-0.178754 0.413881,-0.278598 0.65625,-0.291016 z"
+     sodipodi:nodetypes="ccccsccccccccccccccccssccccccccccccccccsccccccccccc" />
 </svg>

--- a/places/128/folder-templates.svg
+++ b/places/128/folder-templates.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="128"
    height="128"
-   id="svg26392">
+   id="svg26392"
+   sodipodi:docname="folder-templates.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="15.999999"
+     inkscape:cx="67.125004"
+     inkscape:cy="88.656256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg26392" />
   <defs
      id="defs26394">
     <linearGradient
@@ -183,7 +205,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -223,11 +244,11 @@
      id="path8263"
      d="m 6.2499966,40.500147 c -2.84882,0.29656 -1.40933,3.76689 -1.63989,5.72017 0.78584,22.54795 1.57466,45.09583 2.35864,67.643813 1.18868,2.48974 4.4300904,1.28205 6.6383204,1.57433 35.235146,0.0205 70.470294,0.0412 105.705433,0.0617 2.566,-0.16531 1.15721,-3.81803 1.65357,-5.65555 0.85465,-22.569493 2.54292,-67.571353 2.54292,-67.571353 0,-1.16209 -0.77992,-1.7731 -2.20738,-1.7731 -37.089309,0 -77.962299,0 -115.0516134,0 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5;marker:none;enable-background:accumulate"
-     id="path4048"
-     d="M 86.995444,58.515992 V 101 H 36.99544 Z m -9,18.484008 -17,15 h 17 z" />
+     id="path5117"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="m 82,58 c -1.053804,1.1e-4 -2.108536,0.403456 -2.916016,1.210938 L 40.210938,98.083984 C 39.403534,98.891386 39.000188,99.946297 39,101 c 0,1.662 1.338,3 3,3 h 10 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 7 v -3 h 1 v 3 h 5 c 1.662,0 3,-1.338 3,-3 v -5 h -3 v -1 h 3 v -7 h -3 v -1 h 3 v -7 h -3 v -1 h 3 v -7 h -3 v -1 h 3 V 61 C 85,59.607474 84.055598,58.452527 82.773438,58.111328 82.519492,58.018534 82,58 82,58 Z m -6.050781,16.001953 c 0.145421,-0.0075 0.293468,0.01618 0.433593,0.07422 C 76.756373,74.231008 76.999974,74.595596 77,75 v 20 c -5.5e-5,0.552262 -0.447781,0.999945 -1,1 H 56.001953 c -0.890567,-3.5e-4 -1.336538,-1.077036 -0.707031,-1.707031 l 19.998047,-20 c 0.178746,-0.178755 0.413881,-0.278598 0.65625,-0.291016 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.6;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
-     id="path181"
-     d="M 86.995444,57.515991 V 100 h -50 z m -9,18.484009 -17,15 h 17 z" />
+     id="rect3855"
+     style="opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="M 82 57 C 80.946196 57.00011 79.891464 57.403456 79.083984 58.210938 L 40.210938 97.083984 C 39.403534 97.891386 39.000188 98.946297 39 100 C 39 101.662 40.338 103 42 103 L 52 103 L 52 100 L 53 100 L 53 103 L 60 103 L 60 100 L 61 100 L 61 103 L 68 103 L 68 100 L 69 100 L 69 103 L 76 103 L 76 100 L 77 100 L 77 103 L 82 103 C 83.662 103 85 101.662 85 100 L 85 95 L 82 95 L 82 94 L 85 94 L 85 87 L 82 87 L 82 86 L 85 86 L 85 79 L 82 79 L 82 78 L 85 78 L 85 71 L 82 71 L 82 70 L 85 70 L 85 60 C 85 58.607474 84.055598 57.452527 82.773438 57.111328 C 82.519492 57.018534 82 57 82 57 z M 75.949219 73.001953 C 76.09464 72.994502 76.242687 73.018133 76.382812 73.076172 C 76.756373 73.231008 76.999974 73.595596 77 74 L 77 94 C 76.999945 94.552262 76.552219 94.999945 76 95 L 56.001953 95 C 55.111386 94.99965 54.665415 93.922964 55.294922 93.292969 L 75.292969 73.292969 C 75.471715 73.114214 75.70685 73.014371 75.949219 73.001953 z " />
 </svg>

--- a/places/16/folder-templates.svg
+++ b/places/16/folder-templates.svg
@@ -1,57 +1,81 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3182"
    height="16"
    width="16"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="folder-templates.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview18"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="-4.3125"
+     inkscape:cy="3.375"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="290"
+     inkscape:window-y="44"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs3184">
     <linearGradient
-       id="linearGradient3412">
+       inkscape:collect="always"
+       id="linearGradient3767">
       <stop
+         style="stop-color:#000000;stop-opacity:0.34999999"
          offset="0"
-         style="stop-color:#fcfcfc;stop-opacity:1"
-         id="stop3414" />
+         id="stop3763" />
       <stop
+         style="stop-color:#000000;stop-opacity:0.40000001"
          offset="1"
-         style="stop-color:#cbcdd9;stop-opacity:1"
-         id="stop3416" />
+         id="stop3765" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3428">
+       inkscape:collect="always"
+       id="linearGradient3169">
       <stop
+         style="stop-color:#f9fafa;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3430" />
+         id="stop3165" />
       <stop
+         style="stop-color:#e9ebed;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3432" />
+         id="stop3167" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-0.99749995,0,0,-0.99749995,45.982263,49.857733)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3428"
-       id="linearGradient3844"
-       y2="18.89035"
-       x2="35.452969"
-       y1="31.550577"
-       x1="35.452969" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient3169"
+       id="linearGradient3171"
+       x1="5.8110995"
+       y1="17.943918"
+       x2="5.8110995"
+       y2="29.547907"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       gradientTransform="matrix(-1,0,0,-1,45.999999,49.999999)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3412"
-       id="linearGradient3847"
-       y2="18.12406"
-       x2="38.972309"
-       y1="32.537422"
-       x1="42.783993" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient3767"
+       id="linearGradient3769"
+       x1="9.6883192"
+       y1="17.830683"
+       x2="9.6883192"
+       y2="30.050489"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata3187">
@@ -61,7 +85,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -69,20 +92,57 @@
      id="layer1"
      transform="matrix(-1,0,0,1,15.999929,-16)">
     <path
-       style="opacity:0.8;fill:url(#linearGradient3847);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3410"
-       d="m 15.5,31.5 -15,-15 0,15 15,0 z m -6.999999,-3.000001 -5,0 0,-4.999999 5,4.999999 z" />
-    <path
-       style="opacity:0.8;fill:none;stroke:url(#linearGradient3844);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3424"
-       d="M 13.093343,30.5 1.5,18.87516 1.5,30.5 Z" />
-    <path
-       style="opacity:0.2;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3851"
-       d="m 3,29.5 5.9793341,0" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410-8"
-       d="m 15.5,31.5 -15,-15 0,15 15,0 z m -6.999999,-3.000001 -5,0 0,-4.999999 5,4.999999 z" />
+       style="color:#000000;fill:url(#linearGradient3171);fill-opacity:1;stroke:url(#linearGradient3769);stroke-width:1;stroke-linejoin:round;stroke-opacity:0.99996656;-inkscape-stroke:none"
+       d="m 1.147991,16.579458 c -0.3921101,0.1625 -0.64775842,0.545137 -0.64778557,0.969559 v 12.901479 c 5.776e-5,0.579599 0.46993534,1.049443 1.04957667,1.049501 H 14.452196 c 0.934792,-3.67e-4 1.402851,-1.130351 0.742083,-1.791531 L 2.2918656,16.806987 C 1.9916702,16.506825 1.5402146,16.417026 1.147991,16.579458 Z M 3.499929,22 l 6.5,6.5 h -6.5 z"
+       id="path873"
+       sodipodi:nodetypes="cccccccccccc" />
+    <rect
+       style="opacity:0.3;fill:#000000;fill-opacity:1;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;paint-order:normal"
+       id="rect6725"
+       height="1"
+       x="-1.999929"
+       y="22"
+       transform="scale(-1,1)"
+       width="1" />
+    <rect
+       style="opacity:0.3;fill:#000000;fill-opacity:1;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;paint-order:normal"
+       id="rect6843"
+       width="1"
+       height="1"
+       x="-1.999929"
+       y="25"
+       transform="scale(-1,1)" />
+    <rect
+       style="opacity:0.3;fill:#000000;fill-opacity:1;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;paint-order:normal"
+       id="rect6845"
+       width="1"
+       height="1"
+       x="-1.999929"
+       y="28"
+       transform="scale(-1,1)" />
+    <rect
+       style="opacity:0.3;fill:#000000;fill-opacity:1;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;paint-order:normal"
+       id="rect6847"
+       width="1"
+       height="1"
+       x="30"
+       y="2.9999294"
+       transform="matrix(0,1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3;fill:#000000;fill-opacity:1;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;paint-order:normal"
+       id="rect6849"
+       width="1"
+       height="1"
+       x="30"
+       y="5.9999294"
+       transform="matrix(0,1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3;fill:#000000;fill-opacity:1;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;paint-order:normal"
+       id="rect6851"
+       width="1"
+       height="1"
+       x="30"
+       y="8.9999294"
+       transform="matrix(0,1,1,0,0,0)" />
   </g>
 </svg>

--- a/places/24/folder-templates.svg
+++ b/places/24/folder-templates.svg
@@ -1,17 +1,70 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg4006"
    height="24"
    width="24"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="folder-templates.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview47"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="10.40625"
+     inkscape:cy="19.9375"
+     inkscape:window-width="1317"
+     inkscape:window-height="1030"
+     inkscape:window-x="526"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true" />
   <defs
      id="defs4008">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1974">
+      <stop
+         style="stop-color:#0e141f;stop-opacity:0.30000001"
+         offset="0"
+         id="stop1970" />
+      <stop
+         style="stop-color:#0e141f;stop-opacity:0.40000001"
+         offset="1"
+         id="stop1972" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18425">
+      <stop
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1"
+         id="stop18421" />
+      <stop
+         offset="1"
+         style="stop-color:#e7e9ee;stop-opacity:1"
+         id="stop18423" />
+    </linearGradient>
     <linearGradient
        gradientTransform="matrix(-1.33,0,0,-1.33,62.809687,54.310312)"
        gradientUnits="userSpaceOnUse"
@@ -33,195 +86,128 @@
          id="stop3432" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(-1.3333334,0,0,-1.3333334,63.167156,54.166667)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3412"
-       id="linearGradient3057"
-       y2="18.12406"
-       x2="38.972309"
-       y1="32.537422"
-       x1="42.783993" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient18425"
+       id="linearGradient15930"
+       x1="8.8589869"
+       y1="10.078045"
+       x2="8.8589869"
+       y2="30"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient3412">
-      <stop
-         offset="0"
-         style="stop-color:#fcfcfc;stop-opacity:1"
-         id="stop3414" />
-      <stop
-         offset="1"
-         style="stop-color:#cbcdd9;stop-opacity:1"
-         id="stop3416" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(-0.02303995,0,0,0.01470022,20.639608,20.963253)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060-8"
-       id="radialGradient3060"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       id="linearGradient5060-8">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5062-8" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5064-6" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.72481893,10.98054)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5048-2-2"
-       id="linearGradient12979"
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715" />
-    <linearGradient
-       id="linearGradient5048-2-2">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5050-3-3" />
-      <stop
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5056-5-7" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5052-02-4" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761241,10.98055)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060-2-47"
-       id="radialGradient4968-3"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       id="linearGradient5060-2-47">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5062-2-8" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5064-2-5" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.23882,10.98055)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060-2-47"
-       id="radialGradient4004"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient1974"
+       id="linearGradient1976"
+       x1="13.72325"
+       y1="10.3655"
+       x2="13.72325"
+       y2="29.668238"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata4011">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
      id="layer1"
      transform="matrix(-1,0,0,1,23.999596,-8)">
-    <g
-       id="g3022"
-       transform="translate(-3.06e-5,15)">
-      <rect
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient12979);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         id="rect2879-7"
-         y="14"
-         x="3.5000305"
-         height="2"
-         width="16.999998" />
-      <path
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient4968-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         id="path2881-0"
-         d="m 3.5000311,14.00008 c 0,0 0,1.99989 0,1.99989 -0.62047,0.004 -1.5,-0.44808 -1.5,-1.00008 0,-0.552 0.6924,-0.99981 1.5,-0.99981 z" />
-      <path
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient4004);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         id="path2883-3"
-         d="m 20.50003,14.00008 c 0,0 0,1.99989 0,1.99989 0.62047,0.004 1.5,-0.44808 1.5,-1.00008 0,-0.552 -0.6924,-0.99981 -1.5,-0.99981 z" />
-    </g>
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3060);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path2883-1"
-       d="m 6.754342,26.353179 c 0,0 0,3.569856 0,3.569856 -1.1865,0.0067 -2.86838,-0.799823 -2.86838,-1.785158 0,-0.985333 1.324045,-1.784697 2.86838,-1.784698 z" />
-    <path
-       style="opacity:0.8;fill:url(#linearGradient3057);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3410"
-       d="M 22.500489,29.5 2.500488,9.499999 l 0,20.000001 20.000001,0 z m -9.333333,-4.000001 -6.666667,0 0,-6.666666 6.666667,6.666666 z" />
     <path
        style="opacity:0.8;fill:none;stroke:url(#linearGradient3054);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3424"
-       d="M 20,28.5 3.5,12 l 0,16.5 z" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3082"
-       d="m 11.50049,28.5 0,1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3854"
-       d="m 8.50049,28.5 0,1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3856"
-       d="m 5.50049,28.5 0,1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3858"
-       d="m 2.5,20.5 1.00049,0" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3860"
-       d="m 2.5,26.423077 1.00049,0" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3862"
-       d="m 2.5,17.5 1.00049,0" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3858-1"
-       d="m 2.5,23.423077 1.00049,0" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3858-8"
-       d="m 2.5,14.5 1.00049,0" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3410-4"
-       d="M 22.500489,29.5 2.500488,9.499999 l 0,20.000001 20.000001,0 z m -9.333333,-4.000001 -6.666667,0 0,-6.666666 6.666667,6.666666 z" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3082-2"
-       d="m 17.50049,28.5 0,1" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#83899a;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3854-2"
-       d="m 14.50049,28.5 0,1" />
+       d="M 21.599596,28.5 3.499596,10.4 3.5,28.5 Z"
+       sodipodi:nodetypes="cccc" />
     <path
        style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3424-1"
-       d="m 14.5,26.5 -8.5285714,0 z" />
+       d="m 14.999596,26.5 h -10 z"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="color:#000000;opacity:1;fill:url(#linearGradient15930);fill-opacity:1;stroke:url(#linearGradient1976);stroke-width:1;stroke-linejoin:round;stroke-opacity:1;-inkscape-stroke:none"
+       d="M 2.6162818,9.6374025 C 1.9424367,9.9169225 1.5001179,10.574904 1.499596,11.304962 v 17.388236 c 9.95e-5,0.997565 0.8108694,1.806225 1.8075725,1.806326 H 20.680387 c 1.673058,-6.57e-4 2.412228,-1.945479 1.276026,-3.083454 L 4.5831941,10.027832 C 4.0667378,9.5116245 3.290485,9.3575369 2.6162818,9.6374025 Z M 5.499596,17 l 9.5,9.5 h -9.5 z"
+       id="path12381"
+       sodipodi:nodetypes="cccccccccccc" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect20863"
+       width="1"
+       height="2"
+       x="-15"
+       y="28"
+       transform="scale(-1,1)" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect24840"
+       width="1"
+       height="2"
+       x="-11.999596"
+       y="28"
+       transform="scale(-1,1)" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect24842"
+       width="1"
+       height="2"
+       x="-8.9995956"
+       y="28"
+       transform="scale(-1,1)" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect24844"
+       width="1"
+       height="2"
+       x="-5.9995961"
+       y="28"
+       transform="scale(-1,1)" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect25364"
+       width="1"
+       height="2"
+       x="-27.000404"
+       y="-3.9995961"
+       transform="matrix(0,-1,-1,0,0,0)" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect25366"
+       width="1"
+       height="2"
+       x="-24"
+       y="-3.9995961"
+       transform="matrix(0,-1,-1,0,0,0)" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect25368"
+       width="1"
+       height="2"
+       x="-21"
+       y="-3.9995961"
+       transform="matrix(0,-1,-1,0,0,0)" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect25370"
+       width="1"
+       height="2"
+       x="-18"
+       y="-3.9995961"
+       transform="matrix(0,-1,-1,0,0,0)" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect26333"
+       width="1"
+       height="2"
+       x="-17.999596"
+       y="28"
+       transform="scale(-1,1)" />
+    <rect
+       style="opacity:0.3;fill:#0e141f;fill-opacity:1;stroke:none;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="rect26380"
+       width="1"
+       height="2"
+       x="-15"
+       y="-3.9995961"
+       transform="matrix(0,-1,-1,0,0,0)" />
   </g>
 </svg>

--- a/places/32/folder-templates-open.svg
+++ b/places/32/folder-templates-open.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="32.000961"
    viewBox="0 0 32.000961 32"
    version="1.0"
    style="display:inline;enable-background:new"
    id="svg11300"
-   height="32">
+   height="32"
+   sodipodi:docname="folder-templates-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview47"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="17.191534"
+     inkscape:cx="20.387943"
+     inkscape:cy="16.694264"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="332"
+     inkscape:window-y="737"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata154">
     <rdf:RDF>
@@ -216,16 +238,13 @@
      id="use8572"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient8576);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal"
-     id="path181-5-5"
-     d="M 21.41,19.257162 20.727142,27.585 H 9.2500003 Z m -1.838572,3.265477 -5.070393,3.396794 h 4.681821 z" />
-  <g
-     id="g122"
-     transform="matrix(0.93252875,0,0,0.770553,-24.919638,-0.05382385)"
-     style="stroke-width:1.17968929">
-    <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.6;vector-effect:none;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:1.17968917;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922;marker:none;enable-background:accumulate"
-       id="path181-5"
-       d="M 49.681726,23.763769 48.949462,34.571381 H 36.641914 Z m -1.971598,4.237836 -5.437251,4.408254 h 5.020565 z" />
-  </g>
+     id="path1464"
+     style="color:#000000;opacity:0.3;fill:#ffffff;fill-opacity:0.99941504;stroke-width:0.999995;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 20.949349,18.501005 c -0.231806,0.06211 -0.477517,0.113244 -0.65625,0.291992 l -9.498497,7.489528 c -0.629132,0.629644 -0.18398,1.716556 0.706055,1.717773 h 1.499473 v -1 h 1 v 1 h 2 v -1 h 1 v 1 h 2 v -1 h 1 v 1 h 0.999023 c 0.552562,4.65e-4 1.000923,-0.4503 1.000977,-1.002929 v -0.997071 h -1 v -1 h 1 v -1.000326 h -1 v -1 h 1 v -1.000456 h -1 v -1 h 1 V 19.500028 C 22.000104,19.095636 21.756476,18.731032 21.382942,18.5762 21.242827,18.51816 21.204371,18.501 20.949349,18.501 Z m -1.34375,3.172981 c 0.05462,-0.0029 0.110429,0.0065 0.163085,0.02832 0.140178,0.0581 0.231535,0.19494 0.231446,0.34668 v 3.576312 c -2.1e-5,0.207098 -0.167902,0.37498 -0.375,0.375 h -4.825196 c -0.334322,-1.3e-4 -0.501402,-0.404577 -0.264648,-0.640625 l 4.824219,-3.575336 c 0.07629,-0.05654 0.155053,-0.105571 0.246094,-0.110351 z"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccsc" />
+  <path
+     id="path1472"
+     style="color:#000000;opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:0.999995;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 20.949349,17.500519 c -0.231806,0.06211 -0.477517,0.113244 -0.65625,0.291992 l -9.498497,7.489528 c -0.629132,0.629644 -0.18398,1.716556 0.706055,1.717773 h 1.499473 v -1 h 1 v 1 h 2 v -1 h 1 v 1 h 2 v -1 h 1 v 1 h 0.999023 c 0.552562,4.65e-4 1.000923,-0.4503 1.000977,-1.002929 v -0.997071 h -1 v -1 h 1 v -1.000326 h -1 v -1 h 1 V 20.99903 h -1 v -1 h 1 v -1.499488 c -2.6e-5,-0.404392 -0.243654,-0.768996 -0.617188,-0.923828 -0.140115,-0.05804 -0.178571,-0.0752 -0.433593,-0.0752 z m -1.34375,3.172981 c 0.05462,-0.0029 0.110429,0.0065 0.163085,0.02832 0.140178,0.0581 0.231535,0.19494 0.231446,0.34668 v 3.576312 c -2.1e-5,0.207098 -0.167902,0.37498 -0.375,0.375 h -4.825196 c -0.334322,-1.3e-4 -0.501402,-0.404577 -0.264648,-0.640625 l 4.824219,-3.575336 c 0.07629,-0.05654 0.155053,-0.105571 0.246094,-0.110351 z"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccsc" />
 </svg>

--- a/places/32/folder-templates.svg
+++ b/places/32/folder-templates.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg14288">
+   id="svg14288"
+   sodipodi:docname="folder-templates.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview50"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="24.3125"
+     inkscape:cx="14.128535"
+     inkscape:cy="20.565553"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="-38"
+     inkscape:window-y="527"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg14288" />
   <defs
      id="defs14290">
     <linearGradient
@@ -183,7 +205,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -222,22 +243,14 @@
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient5926);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path3309"
      d="m 2.5001794,12.499999 0.62498,16 H 28.874329 l 0.62498,-16 z" />
-  <g
-     style="stroke-width:5.38274445;font-variant-east_asian:normal;opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     transform="matrix(0.93252875,0,0,0.92527378,-24.919638,-4.9879924)"
-     id="g122-6">
-    <path
-       d="m 49.242061,23.763769 v 2.345943 7.37684 1.084829 h -1.097504 -8.780033 -2.990699 l 2.27732,-1.912012 8.780034,-7.376839 z m -2.144706,4.593795 -4.824478,4.052295 h 4.824478 z"
-       id="path181-5-2"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.6;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5.38274445;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal" />
-  </g>
-  <g
-     style="stroke-width:1.07654893"
-     transform="matrix(0.93252875,0,0,0.92527378,-24.919638,-5.9879924)"
-     id="g122">
-    <path
-       d="m 49.242061,23.763769 v 2.345943 7.37684 1.084829 h -1.097504 -8.780033 -2.990699 l 2.27732,-1.912012 8.780034,-7.376839 z m -2.144706,4.593795 -4.824478,4.052295 h 4.824478 z"
-       id="path181-5"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.6;vector-effect:none;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:1.07654881;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922;marker:none;enable-background:accumulate" />
-  </g>
+  <path
+     id="path2192"
+     style="color:#000000;opacity:0.3;fill:#ffffff;fill-opacity:0.99721;stroke-width:0.999995;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 20.94935,15.501301 c -0.242353,0.01242 -0.477517,0.113244 -0.65625,0.291992 l -9.498497,9.488746 c -0.629133,0.629644 -0.183981,1.716556 0.706055,1.717773 h 1.499473 v -1 h 1 v 1 h 2 v -1 h 1 v 1 h 2 v -1 h 1 v 1 h 0.999023 c 0.552562,4.65e-4 1.000923,-0.4503 1.000977,-1.002929 v -0.997071 h -1 v -1 h 1 v -2 h -1 v -1 h 1 v -2 h -1 v -1 h 1 v -1.499488 c -2.6e-5,-0.404392 -0.243654,-0.768996 -0.617188,-0.923828 -0.140115,-0.05804 -0.288183,-0.08265 -0.433593,-0.0752 z m -1.34375,3.923316 c 0.05462,-0.0029 0.110429,0.0065 0.163085,0.02832 0.140178,0.0581 0.231535,0.194939 0.231446,0.346679 v 4.825196 c -2.1e-5,0.207098 -0.167902,0.37498 -0.375,0.375 h -4.825196 c -0.334322,-1.3e-4 -0.501402,-0.404577 -0.264648,-0.640625 l 4.824219,-4.824219 c 0.06699,-0.06732 0.155053,-0.105572 0.246094,-0.110351 z"
+     sodipodi:nodetypes="scccccccccccccccccccccccccccccccsscccccccsc" />
+  <path
+     id="path1472"
+     style="color:#000000;opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:0.999995;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 20.94935,14.501489 c -0.242353,0.01242 -0.477517,0.113244 -0.65625,0.291992 l -9.498497,9.488746 C 10.16547,24.911871 10.610622,25.998783 11.500658,26 h 1.499473 v -1 h 1 v 1 h 2 v -1 h 1 v 1 h 2 v -1 h 1 v 1 h 0.999023 c 0.552562,4.65e-4 1.000923,-0.4503 1.000977,-1.002929 V 24 h -1 v -1 h 1 v -2 h -1 v -1 h 1 v -2 h -1 v -1 h 1 v -1.499488 c -2.6e-5,-0.404392 -0.243654,-0.768996 -0.617188,-0.923828 -0.140115,-0.05804 -0.288183,-0.08265 -0.433593,-0.0752 z m -1.34375,3.923316 c 0.05462,-0.0029 0.110429,0.0065 0.163085,0.02832 0.140178,0.0581 0.231535,0.194939 0.231446,0.346679 V 23.625 c -2.1e-5,0.207098 -0.167902,0.37498 -0.375,0.375 h -4.825196 c -0.334322,-1.3e-4 -0.501402,-0.404577 -0.264648,-0.640625 l 4.824219,-4.824219 c 0.06699,-0.06732 0.155053,-0.105572 0.246094,-0.110351 z"
+     sodipodi:nodetypes="scccccccccccccccccccccccccccccccsscccccccsc" />
 </svg>

--- a/places/48/folder-templates-open.svg
+++ b/places/48/folder-templates-open.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48.055344"
    viewBox="0 0 48.055344 48"
    version="1.0"
    style="display:inline;enable-background:new"
    id="svg11300"
-   height="48">
+   height="48"
+   sodipodi:docname="folder-templates-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview46"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="16.208333"
+     inkscape:cx="18.601542"
+     inkscape:cy="24"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="380"
+     inkscape:window-y="37"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata154">
     <rdf:RDF>
@@ -216,11 +238,13 @@
      id="path3985"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient1369);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5;marker:none;enable-background:accumulate"
-     id="path7705"
-     d="M 31.4523,40 H 18.7456 14.7946 L 17.8032,37.9655 33.0953,28.5 Z m -2.3154,-6.36918 -6.3423,3.98073 h 5.6577 z" />
+     id="path1720"
+     style="color:#000000;opacity:0.3;fill:#ffffff;fill-opacity:0.9994449;stroke-width:0.999997;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 31.424273,27.001946 c -0.363528,0.01863 -0.716275,0.169866 -0.984375,0.437988 L 16.441904,38.42369 c -0.943699,0.944467 -0.275971,2.574835 1.059082,2.576661 h 3.499459 v -1.999713 h 1 v 1.999713 h 3 v -1.999713 h 1 v 1.999713 h 3 v -1.999713 h 1 v 1.999713 h 1.498535 c 0.828843,6.96e-4 1.501385,-0.67545 1.501465,-1.504395 v -1.495605 h -2 v -0.999713 h 2 v -2.000185 h -2 v -1 h 2 v -2.00024 h -2 v -1 h 2 V 28.50048 c -3.9e-5,-0.606589 -0.365481,-1.153495 -0.925781,-1.385742 -0.210174,-0.08706 -0.432275,-0.123971 -0.650391,-0.112792 z m -2.015156,4.735526 c 0.08194,-0.0043 0.165645,0.0098 0.244629,0.04248 0.210267,0.08715 0.347301,0.292409 0.347168,0.52002 v 5.137423 c -3.1e-5,0.310647 -0.251853,0.562469 -0.5625,0.5625 h -7.238482 c -0.501485,-1.96e-4 -0.752104,-0.606866 -0.396973,-0.960938 L 29.039976,31.903 c 0.100482,-0.100979 0.232581,-0.158359 0.369141,-0.165528 z"
+     sodipodi:nodetypes="scccccccccccccccccccccccccccccccsscccccccs" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
-     id="path181"
-     d="M 31.4523,39 H 18.7456 14.7946 L 17.8032,36.9655 33.0953,27.5 Z m -2.3154,-6.36918 -6.3423,3.98073 h 5.6577 z" />
+     id="path1472"
+     style="color:#000000;opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:0.999997;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 31.424273,26.001733 c -0.363528,0.01863 -0.716275,0.169866 -0.984375,0.437988 L 16.441904,37.423477 c -0.943699,0.944467 -0.275971,2.574835 1.059082,2.576661 h 3.499459 v -1.999713 h 1 v 1.999713 h 3 v -1.999713 h 1 v 1.999713 h 3 v -1.999713 h 1 v 1.999713 h 1.498535 c 0.828843,6.96e-4 1.501385,-0.67545 1.501465,-1.504395 v -1.495605 h -2 v -0.999713 h 2 V 34.00024 h -2 v -1 h 2 V 31 h -2 v -1 h 2 v -2.499733 c -3.9e-5,-0.606589 -0.365481,-1.153495 -0.925781,-1.385742 -0.210174,-0.08706 -0.432275,-0.123971 -0.650391,-0.112792 z m -2.015156,4.735526 c 0.08194,-0.0043 0.165645,0.0098 0.244629,0.04248 0.210267,0.08715 0.347301,0.292409 0.347168,0.52002 v 5.137423 c -3.1e-5,0.310647 -0.251853,0.562469 -0.5625,0.5625 h -7.238482 c -0.501485,-1.96e-4 -0.752104,-0.606866 -0.396973,-0.960938 l 7.237017,-5.135957 c 0.100482,-0.100979 0.232581,-0.158359 0.369141,-0.165528 z"
+     sodipodi:nodetypes="scccccccccccccccccccccccccccccccsscccccccs" />
 </svg>

--- a/places/48/folder-templates.svg
+++ b/places/48/folder-templates.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg18157">
+   id="svg18157"
+   sodipodi:docname="folder-templates.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="22.922045"
+     inkscape:cx="28.640551"
+     inkscape:cy="25.303152"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="1343"
+     inkscape:window-y="57"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg18157" />
   <defs
      id="defs18159">
     <linearGradient
@@ -183,7 +205,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -223,11 +244,13 @@
      id="path4587-3-5"
      d="m 2.5221121,16.499999 c 0.016793,0.183202 0.022163,0.537823 0.03125,0.908598 0.023112,0.08973 0.025524,0.06151 0.03125,0.09735 0.011058,0.06921 0.027034,0.143566 0.03125,0.1947 0.0064,0.07761 -0.00668,0.179686 0,0.292049 0.013352,0.224726 0.045306,0.530459 0.0625,0.908598 0.034388,0.756279 0.078083,1.7745 0.125,3.017843 0.093834,2.486687 0.2030642,5.769016 0.3125,9.02108 0.2122959,6.308724 0.3945663,12.188203 0.40625,12.558123 0.1225025,0.0037 0.071108,0 0.25,0 H 44.490862 c 0.0124,-0.341463 0.253182,-6.673493 0.5,-13.401821 0.126691,-3.453636 0.245386,-6.941969 0.34375,-9.572728 0.04918,-1.31538 0.09434,-2.421026 0.125,-3.212543 0.01322,-0.341237 0.02246,-0.594976 0.03125,-0.811249 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5;marker:none;enable-background:accumulate"
-     id="path4048"
-     d="M 32,23.555437 V 26.690832 36.550107 38 H 30.550107 18.950959 15 l 3.008529,-2.555437 11.599147,-9.859275 z M 29,30 23,35 h 6 z" />
+     id="path863"
+     style="color:#000000;opacity:0.3;fill:#ffffff;fill-opacity:0.99863505;stroke-width:0.999997;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 30.423828,23.001945 c -0.363528,0.01863 -0.716275,0.169866 -0.984375,0.437988 L 15.441459,37.423477 c -0.943699,0.944467 -0.275971,2.574835 1.059082,2.576661 H 20 v -1.999713 h 1 v 1.999713 h 3 v -1.999713 h 1 v 1.999713 h 3 v -1.999713 h 1 v 1.999713 h 1.498535 C 31.327378,40.000834 31.99992,39.324688 32,38.495743 v -1.495605 h -2 v -0.999713 h 2 v -3 h -2 v -1 h 2 v -3 h -2 v -1 h 2 V 24.50048 c -3.9e-5,-0.606589 -0.365481,-1.153495 -0.925781,-1.385742 -0.210174,-0.08706 -0.432275,-0.123971 -0.650391,-0.112793 z m -2.015156,5.735018 c 0.08194,-0.0043 0.165645,0.0098 0.244629,0.04248 0.210267,0.08715 0.347301,0.292409 0.347168,0.52002 v 7.137719 c -3.1e-5,0.310647 -0.251853,0.562469 -0.5625,0.5625 h -7.238482 c -0.501485,-1.96e-4 -0.752104,-0.606866 -0.396973,-0.960938 l 7.237017,-7.136253 c 0.100482,-0.100979 0.232581,-0.158359 0.369141,-0.165528 z"
+     sodipodi:nodetypes="scccccccccccccccccccccccccccccccsscccccccs" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.6;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
-     id="path181"
-     d="M 32,22.555437 V 25.690832 35.550108 37 H 30.550107 18.950959 15 l 3.008529,-2.555436 11.599147,-9.859276 z M 29,29 23,34 h 6 z" />
+     id="path1472"
+     style="color:#000000;opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:0.999997;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 30.423828,22.001732 c -0.363528,0.01863 -0.716275,0.169866 -0.984375,0.437988 L 15.441459,36.423264 c -0.943699,0.944467 -0.275971,2.574835 1.059082,2.576661 H 20 v -1.999713 h 1 v 1.999713 h 3 v -1.999713 h 1 v 1.999713 h 3 v -1.999713 h 1 v 1.999713 h 1.498535 C 31.327378,39.000621 31.99992,38.324475 32,37.49553 v -1.495605 h -2 v -0.999713 h 2 v -3 h -2 v -1 h 2 v -3 h -2 v -1 h 2 v -3.499945 c -3.9e-5,-0.606589 -0.365481,-1.153495 -0.925781,-1.385742 -0.210174,-0.08706 -0.432275,-0.123971 -0.650391,-0.112793 z m -2.015156,5.735018 c 0.08194,-0.0043 0.165645,0.0098 0.244629,0.04248 0.210267,0.08715 0.347301,0.292409 0.347168,0.52002 v 7.137719 c -3.1e-5,0.310647 -0.251853,0.562469 -0.5625,0.5625 h -7.238482 c -0.501485,-1.96e-4 -0.752104,-0.606866 -0.396973,-0.960938 l 7.237017,-7.136253 c 0.100482,-0.100979 0.232581,-0.158359 0.369141,-0.165528 z"
+     sodipodi:nodetypes="scccccccccccccccccccccccccccccccsscccccccs" />
 </svg>

--- a/places/64/folder-templates-open.svg
+++ b/places/64/folder-templates-open.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="64"
    height="64"
-   id="svg22774">
+   id="svg22774"
+   sodipodi:docname="folder-templates-open.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview45"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="34.383068"
+     inkscape:cx="33.752078"
+     inkscape:cy="46.44728"
+     inkscape:window-width="1317"
+     inkscape:window-height="1012"
+     inkscape:window-x="601"
+     inkscape:window-y="18"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg22774" />
   <defs
      id="defs22776">
     <linearGradient
@@ -172,7 +194,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -212,11 +233,13 @@
      id="path4183"
      d="m 1.472422,28.500092 2.9315,27.9845 55.13702,0.031 2.93148,-28.0155 z" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5;marker:none;enable-background:accumulate"
-     id="path9636"
-     d="M 46.3229,37 45.9807,40.25596 44.9046,50.49435 44.7463,52 H 42.4376 23.9684 17.6773 L 22.7467,49.3463 42.292,39.1079 Z m -5.6855,6.52174 -9.5484,5.21739 h 9 z" />
+     id="path1496"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="m 42.5,35 c -0.272077,0 -0.776418,0.03589 -1.458008,0.605469 L 21.605469,51.041992 C 21.158393,51.39706 21.000094,51.973149 21,52.5 21,53.331 21.669,54 22.5,54 H 29 v -2 h 1 v 2 h 4 v -2 h 1 v 2 h 4 v -2 h 1 v 2 h 2.5 c 0.831,0 1.5,-0.669 1.5,-1.5 v -2.500244 h -2 v -1 h 2 v -3 h -2 v -1 h 2 v -3 h -2 v -1 h 2 V 36.5 C 44,35.803737 43.527799,35.226264 42.886719,35.055664 42.759746,35.009264 42.5,35.000004 42.5,35.000004 Z m -3.025391,7.000489 c 0.07271,-0.0038 0.146734,0.0081 0.216797,0.03711 0.186781,0.07742 0.308581,0.259711 0.308594,0.461913 v 7.000244 c -2.8e-5,0.276131 -0.223891,0.499973 -0.5,0.5 l -9.499242,-2.43e-4 c -0.445283,-1.75e-4 -0.668268,-0.538517 -0.353515,-0.853515 l 9.499241,-7.000001 c 0.08937,-0.08938 0.206941,-0.139299 0.328125,-0.145508 z"
+     sodipodi:nodetypes="ccsccccccccccccccssccccccccccccccccccccccccc" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
-     id="path181-0"
-     d="M 46.3229,36 45.9807,39.25596 44.9046,49.49435 44.7463,51 H 42.4376 23.9684 17.6773 L 22.7467,48.3463 42.292,38.1079 Z m -5.6855,6.52174 -9.5484,5.21739 h 9 z" />
+     id="rect3855"
+     style="opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill"
+     d="m 42.5,34 c -0.272077,0 -0.776418,0.03589 -1.458008,0.605469 L 21.605469,50.041992 C 21.158393,50.39706 21.000094,50.973149 21,51.5 21,52.331 21.669,53 22.5,53 H 29 v -2 h 1 v 2 h 4 v -2 h 1 v 2 h 4 v -2 h 1 v 2 h 2.5 c 0.831,0 1.5,-0.669 1.5,-1.5 v -2.500244 h -2 v -1 h 2 v -3 h -2 v -1 h 2 v -3 h -2 v -1 h 2 V 35.5 C 44,34.803737 43.527799,34.226264 42.886719,34.055664 42.759746,34.009264 42.5,34.000004 42.5,34.000004 Z m -3.025391,7.000489 c 0.07271,-0.0038 0.146734,0.0081 0.216797,0.03711 0.186781,0.07742 0.308581,0.259711 0.308594,0.461913 v 7.000244 c -2.8e-5,0.276131 -0.223891,0.499973 -0.5,0.5 l -9.499242,-2.43e-4 c -0.445283,-1.75e-4 -0.668268,-0.538517 -0.353515,-0.853515 l 9.499241,-7.000001 c 0.08937,-0.08938 0.206941,-0.139299 0.328125,-0.145508 z"
+     sodipodi:nodetypes="ccsccccccccccccccssccccccccccccccccccccccccc" />
 </svg>

--- a/places/64/folder-templates.svg
+++ b/places/64/folder-templates.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg22774"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="folder-templates.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview45"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="24.3125"
+     inkscape:cx="36.66838"
+     inkscape:cy="37.634961"
+     inkscape:window-width="1317"
+     inkscape:window-height="984"
+     inkscape:window-x="601"
+     inkscape:window-y="8"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg22774" />
   <defs
      id="defs22776">
     <linearGradient
@@ -172,7 +194,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -212,11 +233,13 @@
      d="m 3,21.5 c -0.277,0 -0.5134886,0.185576 -0.5,0.416016 l 2,34.167968 C 4.5134886,56.314424 4.723,56.5 5,56.5 h 54 c 0.277,0 0.486511,-0.185576 0.5,-0.416016 l 2,-34.167968 C 61.513489,21.685576 61.277,21.5 61,21.5 Z"
      style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient5962);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;font-variant-east_asian:normal" />
   <path
-     d="M 44.001007,29 V 33.992472 49.691343 52 H 41.69235 23.22309 16.931998 L 21.722463,47.930991 40.191722,32.23212 Z m -5,10 -9,8 h 9 z"
-     id="path4048"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:5;marker:none;enable-background:accumulate" />
+     id="path2809"
+     style="color:#000000;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:0.999996;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 41.898438,29.002594 c -0.484705,0.02484 -0.955034,0.226488 -1.3125,0.583985 L 21.588945,48.564071 c -1.258265,1.259289 -0.367961,3.433113 1.41211,3.435547 H 29 v -2 h 1 v 2 h 4 v -2 h 1 v 2 h 4 v -2 h 1 v 2 h 1.998047 c 1.105124,9.29e-4 2.001846,-0.9006 2.001953,-2.005859 v -1.994141 h -2 v -1 h 2 v -4 h -2 v -1 h 2 v -4 h -2 v -1 h 2 v -5.998977 c -5.2e-5,-0.808785 -0.487308,-1.537993 -1.234375,-1.847656 -0.280231,-0.116076 -0.576366,-0.165294 -0.867187,-0.150391 z m -2.6875,7.846633 c 0.109248,-0.0057 0.220859,0.01308 0.326171,0.05664 0.280356,0.116195 0.463069,0.389878 0.462891,0.693359 v 9.650392 c -4.1e-5,0.414196 -0.335804,0.749959 -0.75,0.75 h -9.650391 c -0.668645,-2.61e-4 -1.002805,-0.809154 -0.529297,-1.28125 L 38.71875,37.06993 c 0.133976,-0.134638 0.310107,-0.211145 0.492188,-0.220703 z"
+     sodipodi:nodetypes="scccccccccccccccccccccccccccccccsscccccccs" />
   <path
-     d="M 44.001007,28 V 32.992472 48.691343 51 H 41.69235 23.22309 16.931998 L 21.722463,46.930991 40.191722,31.23212 Z m -5,10 -9,8 h 9 z"
-     id="path181"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#7e5514;fill-opacity:0.97111912;stroke:none;stroke-width:0.99999985;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:0.6;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922" />
+     id="path1472"
+     style="color:#000000;opacity:0.6;fill:#7e5514;fill-opacity:0.972549;stroke-width:0.999996;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 41.898438,28.002976 c -0.484705,0.02484 -0.955034,0.226488 -1.3125,0.583985 L 21.588945,47.564453 C 20.33068,48.823742 21.220984,50.997566 23.001055,51 H 29 v -2 h 1 v 2 h 4 v -2 h 1 v 2 h 4 v -2 h 1 v 2 h 1.998047 C 43.103171,51.000929 43.999893,50.0994 44,48.994141 V 47 h -2 v -1 h 2 v -4 h -2 v -1 h 2 v -4 h -2 v -1 h 2 v -5.998977 c -5.2e-5,-0.808785 -0.487308,-1.537993 -1.234375,-1.847656 -0.280231,-0.116076 -0.576366,-0.165294 -0.867187,-0.150391 z m -2.6875,7.846633 c 0.109248,-0.0057 0.220859,0.01308 0.326171,0.05664 0.280356,0.116195 0.463069,0.389878 0.462891,0.693359 V 46.25 c -4.1e-5,0.414196 -0.335804,0.749959 -0.75,0.75 h -9.650391 c -0.668645,-2.61e-4 -1.002805,-0.809154 -0.529297,-1.28125 l 9.648438,-9.648438 c 0.133976,-0.134638 0.310107,-0.211145 0.492188,-0.220703 z"
+     sodipodi:nodetypes="scccccccccccccccccccccccccccccccsscccccccs" />
 </svg>

--- a/places/symbolic/folder-templates-symbolic.svg
+++ b/places/symbolic/folder-templates-symbolic.svg
@@ -1,35 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    id="svg2"
    width="16.063"
-   height="16">
-  <metadata
-     id="metadata12">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+   height="16"
+   sodipodi:docname="folder-templates-symbolic.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="14.075844"
+     inkscape:cy="9.2365824"
+     inkscape:window-width="1317"
+     inkscape:window-height="986"
+     inkscape:window-x="801"
+     inkscape:window-y="600"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
   <defs
      id="defs10" />
-  <g
-     id="g4"
-     transform="matrix(-1,0,0,1,1169.063,315)">
-    <path
-       id="path6"
-       style="color:#000000;font-weight:400;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-transform:none;overflow:visible;fill:#666666;marker:none"
-       overflow="visible"
-       font-weight="400"
-       d="m 1153,-302 c 0,1 1,1 1,1 l 15.062,0 -16.062,-12.063 z m 3,-5.031 4.063,3.031 -4.063,0 z" />
-  </g>
+  <path
+     id="path1600"
+     style="color:#000000;fill:#666666;fill-opacity:1;stroke:none;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 14.371094 0.001953125 C 14.295985 0.005806805 14.22211 0.014642515 14.148438 0.029296875 C 13.853744 0.087914295 13.576558 0.23206067 13.355469 0.453125 L 0.45117188 13.355469 C -0.02161374 13.828549 -0.10374549 14.509594 0.1171875 15.042969 C 0.33812049 15.576343 0.8780445 15.999737 1.546875 16 L 6 16 L 6 15 L 7 15 L 7 16 L 9 16 L 9 15 L 10 15 L 10 16 L 12 16 L 12 15 L 13 15 L 13 16 L 14.449219 16 L 14.451172 16 C 15.300884 15.999915 15.999915 15.300975 16 14.451172 L 16 13 L 15 13 L 15 12 L 16 12 L 16 10 L 15 10 L 15 9 L 16 9 L 16 7 L 15 7 L 15 6 L 16 6 L 16 1.5488281 C 15.999959 0.92364536 15.620522 0.35653993 15.042969 0.1171875 C 14.826324 0.02746837 14.59642 -0.009607945 14.371094 0.001953125 z M 12.5 6 C 12.56575 6.0003104 12.630793 6.0135845 12.691406 6.0390625 C 12.877872 6.1163435 12.999593 6.2981535 13 6.5 L 13 12.5 C 12.999972 12.776131 12.776131 12.999972 12.5 13 L 6.5 13 C 6.0546811 12.999826 5.8317057 12.461481 6.1464844 12.146484 L 12.146484 6.1464844 C 12.24024 6.0527162 12.3674 6.0000254 12.5 6 z " />
 </svg>


### PR DESCRIPTION
Thought the templates folder symbol looked a little sharp when the others had some rounded edges and thought I'd give a new version a try. Gives it a little more distinct of a silhouette as well. Let me know if this is something you all like and if so if I can make any changes. Thanks!

Top: Current, Bottom: Proposed
![elementary-rounded-templates](https://user-images.githubusercontent.com/1984060/162103808-413500c0-e2bd-4318-8487-2073a99f7ffc.png)

Did the symbolic one as well but it's not pictured. The file size is 2.5kb when the other symbolic icons were ~700bytes. Not sure if I needed to run anything special (did a vacuum defs).