### PR TITLE
FileTypes: Use rounded square for audio icon

### DIFF
--- a/mimes/128/audio-x-generic.svg
+++ b/mimes/128/audio-x-generic.svg
@@ -1,134 +1,94 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="128"
+   id="svg4434"
    height="128"
-   id="svg3172">
+   width="128"
+   version="1.1"
+   sodipodi:docname="audio-x-generic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview42"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.65625"
+     inkscape:cx="17.313783"
+     inkscape:cy="128.46921"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="696"
+     inkscape:window-y="254"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4434" />
   <defs
-     id="defs3174">
+     id="defs4436">
     <linearGradient
-       id="linearGradient3600">
+       inkscape:collect="always"
+       id="linearGradient1317">
       <stop
-         id="stop3602"
-         style="stop-color:#f4f4f4;stop-opacity:1"
+         style="stop-color:#000000;stop-opacity:0.31764707"
+         offset="0"
+         id="stop1313" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.23921569"
+         offset="1"
+         id="stop1315" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1041">
+      <stop
+         id="stop1037"
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3604"
-         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop1039"
+         style="stop-color:#d4d4d4;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3702-501-757-486">
-      <stop
-         id="stop3100"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop3102"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3104"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3688-464-309-255">
-      <stop
-         id="stop3094"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3096"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336"
-       id="linearGradient3019-2"
-       xlink:href="#linearGradient3600"
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135184,1.488321)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
-    <linearGradient
-       x1="23.99999"
-       y1="5.5641499"
+       xlink:href="#linearGradient3924"
+       id="linearGradient4136"
+       y2="42.261559"
        x2="23.99999"
-       y2="42.194839"
-       id="linearGradient3016-9"
-       xlink:href="#linearGradient3977-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+       y1="5.5907431"
+       x1="23.99999" />
     <linearGradient
-       id="linearGradient3977-3">
+       id="linearGradient3924">
       <stop
-         id="stop3979-6"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3926" />
       <stop
-         id="stop3981-0"
+         offset="0.03750312"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.00648027" />
+         id="stop3928" />
       <stop
-         id="stop3983-6"
+         offset="0.96667296"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99423188" />
+         id="stop3930" />
       <stop
-         id="stop3985-2"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop3932" />
     </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3148"
-       xlink:href="#linearGradient3104-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
-    <linearGradient
-       id="linearGradient3104-6">
-      <stop
-         id="stop3106-3"
-         style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
-      <stop
-         id="stop3108-9"
-         style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3702-501-757-486"
-       id="linearGradient4097"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
-       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
     <radialGradient
-       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
+       gradientTransform="matrix(1.8628438,0,0,1.4,28.692172,-17.4)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-255"
-       id="radialGradient4095"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
-    <radialGradient
-       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-255"
+       xlink:href="#linearGradient3688-166-749-5"
        id="radialGradient4093"
        fy="43.5"
        fx="4.9929786"
@@ -136,7 +96,81 @@
        cy="43.5"
        cx="4.9929786" />
     <linearGradient
-       gradientTransform="matrix(2.0019317,0,0,2,10.971805,0.114079)"
+       id="linearGradient3688-166-749-5">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-0" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-5" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.8628438,0,0,1.4,-19.307834,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-464-309-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-9" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-0"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="translate(-1.4072085e-5)" />
+    <linearGradient
+       id="linearGradient3702-501-757-0">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-0" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-2" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1041"
+       id="linearGradient1035"
+       x1="40.874134"
+       y1="-26.713018"
+       x2="40.874134"
+       y2="145.83157"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1317"
+       id="linearGradient1319"
+       x1="41.36134"
+       y1="112.54736"
+       x2="41.36134"
+       y2="13.720499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(2.0019317,0,0,2,9.9718048,8.114079)"
        gradientUnits="userSpaceOnUse"
        y2="59.1875"
        x2="21.330717"
@@ -157,58 +191,77 @@
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3177">
+     id="metadata4439">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="g978"
-     style="opacity:0.2;stroke-width:1.03923047"
-     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
-    <rect
-       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
-       id="rect2801"
-       y="116.00149"
-       x="103.78947"
-       height="4.9999995"
-       width="14.210526" />
-    <rect
-       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
-       id="rect3696"
-       transform="scale(-1)"
-       y="-121.00149"
-       x="-24.210518"
-       height="4.9999995"
-       width="14.210526" />
-    <rect
-       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
-       id="rect3700"
-       y="116.00149"
-       x="24.210518"
-       height="5"
-       width="79.578949" />
+     style="display:inline"
+     id="g2036"
+     transform="matrix(2.6999989,0,0,0.55555607,-0.80000812,95.888691)">
+    <g
+       style="opacity:0.2;stroke-width:0.707107"
+       id="g3712"
+       transform="matrix(1.052632,0,0,2.571426,-1.263158,-72.056712)">
+      <rect
+         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:0.707107"
+         id="rect2801"
+         y="40"
+         x="37.999836"
+         height="7"
+         width="4.648315" />
+      <rect
+         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:0.707107"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10.000169"
+         height="7"
+         width="4.648315" />
+      <rect
+         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:0.707107"
+         id="rect3700"
+         y="40"
+         x="9.9999933"
+         height="7.0000005"
+         width="28.000019" />
+    </g>
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1035);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="rect5505-21-3"
+     y="16"
+     x="13"
+     ry="9.5"
+     rx="9.5"
+     height="102"
+     width="102" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient4136);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="16.501808"
+     x="13.499988"
+     ry="9"
+     rx="9"
+     height="101"
+     width="101" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient1319);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-21-3-1"
+     y="15.501808"
+     x="12.499988"
+     ry="10"
+     rx="10"
+     height="103"
+     width="103" />
   <path
-     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
-     id="path4160"
-     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
-  <path
-     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
-     id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
-     id="path4160-6-1"
-     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4179-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4179-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path16590-0"
-     d="m 85.499147,28 -29.513339,7.621088 c -2.217019,0.593454 -4.001822,2.954324 -4.001822,5.247306 v 36.356339 c -2.248089,-1.176037 -5.135355,-1.651552 -8.128663,-0.874553 -5.401492,1.402123 -8.7863,5.933557 -7.628461,10.119806 1.157838,4.186253 6.478892,6.524492 11.880384,5.122371 4.309258,-1.118587 7.279765,-4.2836 7.753501,-7.621088 L 55.985668,49.613904 83.998319,42.117753 V 69.228836 C 81.75023,68.0528 78.862963,67.577285 75.869655,68.354287 c -5.401492,1.402119 -8.786299,5.933554 -7.628461,10.119803 1.157858,4.186253 6.478892,6.524493 11.880384,5.122373 C 84.430836,82.477877 87.526264,79.31286 88,75.975374 l 10e-7,-44.727042 c 0,-1.719758 -1.063848,-3.006416 -2.501134,-3.248332 z" />
+     d="m 84.499147,36 -29.513339,7.621088 c -2.217019,0.593454 -4.001822,2.954324 -4.001822,5.247306 v 36.356339 c -2.248089,-1.176037 -5.135355,-1.651552 -8.128663,-0.874553 -5.401492,1.402123 -8.7863,5.933557 -7.628461,10.119806 1.157838,4.186253 6.478892,6.524494 11.880384,5.122371 4.309258,-1.118587 7.279765,-4.2836 7.753501,-7.621088 L 54.985668,57.613904 82.998319,50.117753 V 77.228836 C 80.75023,76.0528 77.862963,75.577285 74.869655,76.354287 c -5.401492,1.402119 -8.786299,5.933554 -7.628461,10.119803 1.157858,4.186253 6.478892,6.524493 11.880384,5.122373 C 83.430836,90.477877 86.526264,87.31286 87,83.975374 l 10e-7,-44.727042 c 0,-1.719758 -1.063848,-3.006416 -2.501134,-3.248332 z" />
 </svg>

--- a/mimes/16/audio-x-generic.svg
+++ b/mimes/16/audio-x-generic.svg
@@ -1,85 +1,107 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg3810">
+   id="svg4372"
+   sodipodi:docname="audio-x-generic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview21"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="10.40625"
+     inkscape:cy="13.75"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="68"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4372" />
   <defs
-     id="defs3812">
+     id="defs4374">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1158">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.34117648"
+         offset="0"
+         id="stop1154" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.24705882"
+         offset="1"
+         id="stop1156" />
+    </linearGradient>
     <linearGradient
        x1="23.99999"
-       y1="6.9230647"
+       y1="7.0845122"
        x2="23.99999"
-       y2="41.076912"
-       id="linearGradient3988"
-       xlink:href="#linearGradient3977"
+       y2="40.764229"
+       id="linearGradient3304"
+       xlink:href="#linearGradient3924-4-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)" />
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486906,0.8648672)" />
     <linearGradient
-       id="linearGradient3977">
+       id="linearGradient3924-4-8">
       <stop
-         id="stop3979"
+         id="stop3926-0-4"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3981"
+         id="stop3928-6-8"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
+         offset="0.0001" />
       <stop
-         id="stop3983"
+         id="stop3930-2-1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
+         offset="0.99989998" />
       <stop
-         id="stop3985"
+         id="stop3932-9-0"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3600">
+       id="linearGradient909">
       <stop
-         id="stop3602"
-         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop905"
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3604"
-         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop907"
+         style="stop-color:#d4d4d4;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336"
-       id="linearGradient3806"
-       xlink:href="#linearGradient3600"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)" />
+       xlink:href="#linearGradient909"
+       id="linearGradient1562"
+       x1="9.9545555"
+       y1="-2.5631022"
+       x2="9.9545555"
+       y2="18.088587"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient3104-9">
-      <stop
-         id="stop3106-5"
-         style="stop-color:#000000;stop-opacity:0.33950618"
-         offset="0" />
-      <stop
-         id="stop3108-5"
-         style="stop-color:#000000;stop-opacity:0.24691358"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3019"
-       xlink:href="#linearGradient3104-9"
+       y2="79.212646"
+       x2="21.736967"
+       y1="3.4214787"
+       x1="43.141579"
+       gradientTransform="matrix(0.2529987,-0.06188599,0.07145079,0.18134844,-4.1587784,1.5786316)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
+       id="linearGradient4236"
+       xlink:href="#linearGradient4417" />
     <linearGradient
        id="linearGradient4417">
       <stop
@@ -92,41 +114,71 @@
          id="stop4421" />
     </linearGradient>
     <linearGradient
-       y2="79.212646"
-       x2="21.736967"
-       y1="3.4214787"
-       x1="43.141579"
-       gradientTransform="matrix(0.2529987,-0.06188599,0.07145079,0.18134844,-4.1592307,2.5785007)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4236"
-       xlink:href="#linearGradient4417" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient1158"
+       id="linearGradient1160"
+       x1="6.5792532"
+       y1="13.883394"
+       x2="6.5792532"
+       y2="1.0863786"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata3815">
+     id="metadata4377">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none"
-     id="path4160"
-     d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z" />
-  <path
-     style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect6741-1"
-     d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 Z" />
-  <path
-     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="path4160-8"
-     d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z" />
+  <rect
+     width="12"
+     height="12"
+     rx="0.5"
+     ry="0.5"
+     x="2"
+     y="2"
+     id="rect5505-21-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1562);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999997;marker:none;enable-background:accumulate" />
+  <rect
+     width="13"
+     height="13.000003"
+     rx="1"
+     ry="1"
+     x="1.5"
+     y="1.499997"
+     id="rect5505-21-2-6"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1160);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000" />
+  <rect
+     width="11"
+     height="11"
+     x="2.5"
+     y="2.4999969"
+     id="rect6741-0-3-5"
+     style="opacity:1;fill:none;stroke:url(#linearGradient3304);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="13.000003"
+     height="13.000003"
+     rx="1"
+     ry="1"
+     x="1.5"
+     y="1.499997"
+     id="rect5505-21-2-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="13.000003"
+     height="13.000003"
+     rx="1"
+     ry="1"
+     x="1.5"
+     y="1.499997"
+     id="rect5505-21-2-8-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
      id="path4192"
-     d="M 10.722656 4.0058594 C 10.668132 3.995603 10.608 3.9982973 10.544922 4.015625 L 6.4550781 5.1386719 C 6.2027663 5.2079828 6 5.4866719 6 5.7636719 L 6 6.3261719 L 6 6.609375 L 6 11.025391 A 0.98817231 1.5078181 82.261693 0 0 5.1308594 11.064453 A 0.98817231 1.5078181 82.261693 0 0 4.046875 12.355469 A 0.98817231 1.5078181 82.261693 0 0 5.8691406 12.935547 A 0.98817231 1.5078181 82.261693 0 0 6.9980469 11.849609 L 7 11.849609 L 7 6.8339844 L 10 6.0117188 L 10 10.025391 A 0.98817231 1.5078181 82.261693 0 0 9.1308594 10.064453 A 0.98817231 1.5078181 82.261693 0 0 8.046875 11.355469 A 0.98817231 1.5078181 82.261693 0 0 9.8691406 11.935547 A 0.98817231 1.5078181 82.261693 0 0 10.998047 10.882812 L 11 10.882812 L 11 5.2363281 L 11 4.390625 C 11 4.182875 10.886229 4.0366285 10.722656 4.0058594 z "
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4236);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0022527;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="m 10.723108,3.0059903 c -0.05452,-0.010256 -0.114656,-0.00756 -0.177734,0.00977 L 6.4555304,4.1388028 c -0.2523118,0.069311 -0.4550781,0.348 -0.4550781,0.625 v 0.5625 0.2832031 4.4160161 a 0.98817231,1.5078181 82.261693 0 0 -0.8691406,0.03906 0.98817231,1.5078181 82.261693 0 0 -1.0839844,1.291016 0.98817231,1.5078181 82.261693 0 0 1.8222656,0.580078 0.98817231,1.5078181 82.261693 0 0 1.1289063,-1.085938 h 0.00195 V 5.8341153 L 10.000452,5.0118497 V 9.025522 a 0.98817231,1.5078181 82.261693 0 0 -0.8691401,0.03906 0.98817231,1.5078181 82.261693 0 0 -1.083985,1.291016 0.98817231,1.5078181 82.261693 0 0 1.822266,0.580078 0.98817231,1.5078181 82.261693 0 0 1.1289061,-1.052735 h 0.002 V 4.236459 3.3907559 c 0,-0.20775 -0.113771,-0.3539965 -0.277344,-0.3847656 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4236);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00225;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/24/audio-x-generic.svg
+++ b/mimes/24/audio-x-generic.svg
@@ -1,120 +1,161 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg3828"
+   id="svg4157"
    height="24"
    width="24"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="audio-x-generic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview51"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4"
+     inkscape:cx="9.125"
+     inkscape:cy="36"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="468"
+     inkscape:window-y="357"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4157" />
   <defs
-     id="defs3830">
+     id="defs4159">
     <linearGradient
-       id="linearGradient3977">
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,0.9717328)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.414463"
+       x2="23.99999"
+       y1="6.5493407"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
       <stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979" />
+         id="stop4097" />
       <stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981" />
+         id="stop4100" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983" />
+         id="stop4102" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985" />
+         id="stop4104" />
     </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
-       id="linearGradient3600-4">
+       id="linearGradient3688-166-749-9">
       <stop
          offset="0"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-2" />
       <stop
          offset="1"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-2" />
     </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-7-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
-       id="linearGradient5060">
+       id="linearGradient3688-464-309-7-6">
       <stop
          offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-75" />
       <stop
          offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4-9" />
     </linearGradient>
     <linearGradient
-       id="linearGradient5048">
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-1"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-1">
       <stop
          offset="0"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-2" />
       <stop
          offset="0.5"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-89" />
       <stop
          offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-36" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977"
-       id="linearGradient3013"
-       y2="41.526306"
-       x2="23.99999"
-       y1="6.4736748"
-       x1="23.99999" />
+       id="linearGradient909">
+      <stop
+         id="stop905"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop907"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
+       xlink:href="#linearGradient909"
+       id="linearGradient903"
+       x1="14.329722"
+       y1="37.247574"
+       x2="14.329722"
+       y2="-5.535521"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3016"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
-    <radialGradient
-       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3021"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <radialGradient
-       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3024"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
+       gradientTransform="matrix(0.69230769,0,0,0.69230769,0.92307623,-23.076924)" />
     <linearGradient
-       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
+       y2="84.235909"
+       x2="17.238106"
+       y1="25.439518"
+       x1="36.948124"
+       gradientTransform="matrix(0.33469959,-0.0946529,0.11219966,0.32923278,-5.7485046,-3.4069578)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5048"
-       id="linearGradient3027"
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715" />
+       id="linearGradient4252"
+       xlink:href="#linearGradient4417" />
     <linearGradient
        id="linearGradient4417">
       <stop
@@ -126,57 +167,80 @@
          offset="1"
          id="stop4421" />
     </linearGradient>
-    <linearGradient
-       y2="84.235909"
-       x2="17.238106"
-       y1="25.439518"
-       x1="36.948124"
-       gradientTransform="matrix(0.33469959,-0.0946529,0.11219966,0.32923278,-5.7488173,-3.4071265)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4252"
-       xlink:href="#linearGradient4417" />
   </defs>
   <metadata
-     id="metadata3833">
+     id="metadata4162">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     transform="matrix(0.55,0,0,0.3333336,-1.2000011,7.33333)"
+     id="g2036-4"
+     style="display:inline">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-8"
+       style="opacity:0.15">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801-6"
+         style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1,-1)"
+         id="rect3696-20"
+         style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700-5"
+         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" />
+    </g>
+  </g>
   <rect
-     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2879"
-     y="22"
-     x="3.5000007"
-     height="2"
-     width="16.999998" />
-  <path
-     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2881"
-     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
-  <path
-     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2883"
-     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
-  <path
-     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none"
-     id="path4160-3"
-     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z" />
-  <path
-     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-     id="rect6741-1"
-     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
-  <path
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-     id="path4160-3-1"
-     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
+     transform="scale(1,-1)"
+     width="18"
+     height="18"
+     rx="1.5"
+     ry="1.5"
+     x="3"
+     y="-21"
+     id="rect5505"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient903);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="19.000002"
+     height="19.000002"
+     rx="2"
+     ry="2"
+     x="2.4999981"
+     y="2.5000257"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="17"
+     height="17"
+     x="3.5012455"
+     y="3.4987564"
+     id="rect6741-9"
+     style="opacity:1;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" />
   <path
      id="path4192"
-     d="M 15.722656 7.0058594 C 15.668041 6.9952844 15.606152 6.9986658 15.542969 7.015625 L 10.457031 8.3808594 C 10.204297 8.4486961 10 8.7269063 10 9.0039062 L 10 10.607422 L 10 15.044922 A 1.5171451 2.0185373 78.171094 0 0 8.5097656 15.017578 A 1.5171451 2.0185373 78.171094 0 0 7.0605469 17.005859 A 1.5171451 2.0185373 78.171094 0 0 9.4902344 17.898438 A 1.5171451 2.0185373 78.171094 0 0 10.998047 16.291016 L 11 16.291016 L 11 10.837891 L 15 9.765625 L 15 14.044922 A 1.5171451 2.0185373 78.171094 0 0 13.509766 14.017578 A 1.5171451 2.0185373 78.171094 0 0 12.060547 16.005859 A 1.5171451 2.0185373 78.171094 0 0 14.490234 16.898438 A 1.5171451 2.0185373 78.171094 0 0 15.998047 15.291016 L 16 15.291016 L 16 8.9960938 L 16 7.3925781 C 16 7.1848281 15.886503 7.0375842 15.722656 7.0058594 z "
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4252);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00069865;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0" />
+     d="m 15.722969,7.006028 c -0.05462,-0.01057 -0.116504,-0.0072 -0.179687,0.0098 l -5.085938,1.36523 c -0.252734,0.06784 -0.457031,0.346047 -0.457031,0.623047 v 1.603516 4.4375 a 1.5171451,2.0185373 78.171094 0 0 -1.4902347,-0.02734 1.5171451,2.0185373 78.171094 0 0 -1.4492187,1.988281 1.5171451,2.0185373 78.171094 0 0 2.4296875,0.892579 1.5171451,2.0185373 78.171094 0 0 1.5078129,-1.607422 h 0.002 v -5.453125 l 4,-1.072266 v 4.279297 a 1.5171451,2.0185373 78.171094 0 0 -1.490234,-0.02734 1.5171451,2.0185373 78.171094 0 0 -1.449219,1.988281 1.5171451,2.0185373 78.171094 0 0 2.429687,0.892579 1.5171451,2.0185373 78.171094 0 0 1.507813,-1.607422 h 0.002 V 8.996293 7.392777 c 0,-0.20775 -0.113497,-0.354994 -0.277344,-0.386719 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4252);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/32/audio-x-generic.svg
+++ b/mimes/32/audio-x-generic.svg
@@ -1,168 +1,174 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg3182"
+   id="svg4715"
    height="32"
    width="32"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="audio-x-generic.svg">
+   sodipodi:docname="audio-x-generic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
+     id="namedview51"
      pagecolor="#ffffff"
      bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
+     borderopacity="1.0"
      inkscape:pageshadow="2"
-     inkscape:window-width="3200"
-     inkscape:window-height="1674"
-     id="namedview35"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="2"
-     inkscape:cx="16"
-     inkscape:cy="16"
-     inkscape:window-x="0"
-     inkscape:window-y="60"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3182">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4190" />
-  </sodipodi:namedview>
+     inkscape:zoom="7.5351066"
+     inkscape:cx="-4.4458561"
+     inkscape:cy="13.403924"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="595"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4715" />
   <defs
-     id="defs3184">
+     id="defs4717">
     <linearGradient
-       id="linearGradient3977">
+       inkscape:collect="always"
+       id="linearGradient922">
       <stop
+         style="stop-color:#000000;stop-opacity:0.31764707"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979" />
+         id="stop918" />
       <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981" />
-      <stop
-         offset="0.99999994"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983" />
-      <stop
+         style="stop-color:#000000;stop-opacity:0.23921569"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985" />
+         id="stop920" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3600-4">
+       id="linearGradient909">
       <stop
-         offset="0"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
-      <stop
-         offset="1"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
-      <stop
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977"
-       id="linearGradient3013"
-       y2="41.814808"
-       x2="23.99999"
-       y1="6.1851754"
-       x1="23.99999" />
-    <linearGradient
-       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3016"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
-    <radialGradient
-       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3021"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <radialGradient
-       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3024"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5048"
-       id="linearGradient3027"
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715" />
-    <linearGradient
-       id="linearGradient3104-6">
-      <stop
-         id="stop3106-3"
-         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop905"
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3108-9"
-         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop907"
+         style="stop-color:#d4d4d4;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.04026115"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.95833331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3148"
-       xlink:href="#linearGradient3104-6" />
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3163"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3165"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient3167"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.67567568,0,0,0.67567567,-0.2162133,-0.21620877)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="41.759991"
+       x2="23.999996"
+       y1="6.2399888"
+       x1="23.999996" />
+    <linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient903"
+       x1="14.329722"
+       y1="38.764687"
+       x2="14.329722"
+       y2="-3.3867714"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-32)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4179-5"
+       x1="1558.0084"
+       y1="-978.039"
+       x2="1558.0084"
+       y2="-916.15015"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46198453,0,0,0.46875001,-14.77563,-14.536001)" />
     <linearGradient
        id="linearGradient4417"
        inkscape:collect="always">
@@ -175,104 +181,6 @@
          offset="1"
          style="stop-color:#cc3b02;stop-opacity:1" />
     </linearGradient>
-    <filter
-       id="filter7554"
-       color-interpolation-filters="sRGB">
-      <feBlend
-         mode="darken"
-         in2="BackgroundImage"
-         id="feBlend7556" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4419"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
-       x1="38.299992"
-       y1="14.922255"
-       x2="38.299992"
-       y2="76.811172" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4421"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
-       x1="38.299992"
-       y1="14.922255"
-       x2="38.299992"
-       y2="76.811172" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4423"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
-       x1="38.299992"
-       y1="14.922255"
-       x2="38.299992"
-       y2="76.811172" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4425"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
-       x1="38.299992"
-       y1="14.922255"
-       x2="38.299992"
-       y2="76.811172" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4429"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
-       x1="38.299992"
-       y1="14.922255"
-       x2="38.299992"
-       y2="76.811172" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4431"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
-       x1="38.299992"
-       y1="14.922255"
-       x2="38.299992"
-       y2="76.811172" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4433"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
-       x1="38.299992"
-       y1="14.922255"
-       x2="38.299992"
-       y2="76.811172" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4435"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46198453,0,0,0.46875001,-5.7757408,-6.535763)"
-       x1="38.299992"
-       y1="14.922255"
-       x2="38.299992"
-       y2="76.811172" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4179-5"
-       x1="1558.0084"
-       y1="-978.039"
-       x2="1558.0084"
-       y2="-916.15015"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46198453,0,0,0.46875001,-14.77563,-14.536001)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4417"
@@ -283,86 +191,95 @@
        y1="-1002.4898"
        x2="1555.844"
        y2="-940.50317" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient922"
+       id="linearGradient924"
+       x1="10.018317"
+       y1="28.052393"
+       x2="10.018317"
+       y2="2.240432"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata3187">
+     id="metadata4720">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     style="display:inline"
+     id="g2036"
+     transform="matrix(0.6999997,0,0,0.44444486,-0.8000003,10.111104)">
+    <g
+       style="opacity:0.3"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
+         id="rect3696"
+         transform="scale(-1,-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
+  </g>
   <rect
-     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2879"
-     y="29"
-     x="4.9499893"
-     height="2"
-     width="22.100021" />
-  <path
-     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2881"
-     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z" />
-  <path
-     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2883"
-     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z" />
-  <path
-     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline"
-     id="path4160-3"
-     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z" />
-  <path
-     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-     id="rect6741-1"
-     d="m 26.5,28.5 -21,0 0,-27 21,0 z" />
-  <path
-     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z"
-     id="path4160-6-1"
-     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient903);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="rect5505"
+     y="-29"
+     x="3"
+     ry="2.5"
+     rx="2.5"
+     height="26"
+     width="26"
+     transform="scale(1,-1)" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient924);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-6-6"
+     y="2.5"
+     x="2.5"
+     ry="3"
+     rx="3"
+     height="27"
+     width="27" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3027);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="3.4999998"
+     x="3.5"
+     ry="2"
+     rx="2"
+     height="25"
+     width="25" />
   <g
-     id="layer9"
-     style="display:inline;fill:url(#linearGradient4419)"
-     transform="translate(-685.0002,484.99179)" />
-  <g
-     id="layer10"
-     style="display:inline;fill:url(#linearGradient4421)"
-     transform="translate(-685.0002,484.99179)" />
-  <g
-     style="fill:url(#linearGradient4423)"
-     id="layer11"
-     transform="translate(-685.0002,484.99179)" />
-  <g
-     id="layer13"
-     style="display:inline;fill:url(#linearGradient4425)"
-     transform="translate(-685.0002,484.99179)" />
-  <g
-     style="fill:url(#linearGradient4179-5);color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4179-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="layer14"
-     transform="translate(-685.0002,484.99179)">
+     transform="translate(-685.0002,485.992)">
     <path
        inkscape:connector-curvature="0"
-       d="m 706.36939,-478 -7.375,1.90625 c -0.554,0.14844 -1,0.73896 -1,1.3125 l 0,9.09375 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34976,0.35071 -2.19558,1.48415 -1.90625,2.53125 0.28933,1.0471 1.61899,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07145 1.9375,-1.90625 l 0.0312,-8.59375 7,-1.875 0,6.78125 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34976,0.35071 -2.19558,1.48415 -1.90625,2.53125 0.28933,1.0471 1.61899,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07145 1.9375,-1.90625 l 0.0312,-11.1875 c 0,-0.43016 -0.26584,-0.75199 -0.625,-0.8125 z"
+       d="m 706.36939,-478 -7.375,1.90625 c -0.554,0.14844 -1,0.73896 -1,1.3125 v 9.09375 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34976,0.35071 -2.19558,1.48415 -1.90625,2.53125 0.28933,1.0471 1.61899,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07145 1.9375,-1.90625 l 0.0312,-8.59375 7,-1.875 v 6.78125 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34976,0.35071 -2.19558,1.48415 -1.90625,2.53125 0.28933,1.0471 1.61899,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07145 1.9375,-1.90625 l 0.0312,-11.1875 c 0,-0.43016 -0.26584,-0.75199 -0.625,-0.8125 z"
        id="path16590"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4470);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4470);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   </g>
-  <g
-     id="layer15"
-     style="display:inline;fill:url(#linearGradient4429)"
-     transform="translate(-685.0002,484.99179)" />
-  <g
-     id="g71291"
-     style="display:inline;fill:url(#linearGradient4431)"
-     transform="translate(-685.0002,484.99179)" />
-  <g
-     id="g4953"
-     style="display:inline;fill:url(#linearGradient4433)"
-     transform="translate(-685.0002,484.99179)" />
-  <g
-     id="layer12"
-     style="display:inline;fill:url(#linearGradient4435)"
-     transform="translate(-685.0002,484.99179)" />
 </svg>

--- a/mimes/48/audio-x-generic.svg
+++ b/mimes/48/audio-x-generic.svg
@@ -1,140 +1,300 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg3901"
-   height="48"
+   version="1.1"
    width="48"
-   version="1.1">
+   height="48"
+   id="svg4117"
+   sodipodi:docname="audio-x-generic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview83"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.1041668"
+     inkscape:cx="24.140762"
+     inkscape:cy="10.134897"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="66"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4117" />
   <defs
-     id="defs3903">
+     id="defs4119">
     <linearGradient
-       id="linearGradient3403">
+       inkscape:collect="always"
+       id="linearGradient1157">
       <stop
-         id="stop3405"
+         style="stop-color:#000000;stop-opacity:0.31764707"
+         offset="0"
+         id="stop1153" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.23921569"
+         offset="1"
+         id="stop1155" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         id="stop3926"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3407"
+         id="stop3928"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
+         offset="0.02705082" />
       <stop
-         id="stop3409"
+         id="stop3930"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
+         offset="0.97222221" />
       <stop
-         id="stop3411"
+         id="stop3932"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.12489,-17.4)" />
     <linearGradient
-       id="linearGradient3600">
+       id="linearGradient3688-166-749">
       <stop
-         offset="0"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602" />
-      <stop
-         offset="1"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
-      <stop
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3104-6">
-      <stop
-         id="stop3106-3"
-         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3108-9"
-         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.875506,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       y2="42.110645"
-       x2="23.99999"
-       y1="5.9404659"
-       x1="23.99999"
-       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617"
+       xlink:href="#linearGradient3702-501-757"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3106"
-       xlink:href="#linearGradient3403" />
+       gradientTransform="matrix(0.93830969,0,0,1,1.4805601,0)" />
     <linearGradient
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275"
-       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3109"
-       xlink:href="#linearGradient3600" />
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3112"
-       xlink:href="#linearGradient5060" />
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3115"
-       xlink:href="#linearGradient5060" />
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3831"
+       x="-0.076499999"
+       y="-0.067999999"
+       width="1.153"
+       height="1.136">
+      <feGaussianBlur
+         stdDeviation="0.6375"
+         id="feGaussianBlur3833" />
+    </filter>
+    <clipPath
+       id="clipPath3823">
+      <path
+         d="M 108.8125,58 C 107.25437,58 106,59.254375 106,60.8125 l 0,24.375 C 106,86.745625 107.25437,88 108.8125,88 l 24.375,0 C 134.74562,88 136,86.745625 136,85.1875 l 0,-24.375 C 136,59.254375 134.74562,58 133.1875,58 l -24.375,0 z m 7.1875,4.5 10,0 0,8.75 5,0 -10,13.75 -10,-13.75 5,0 0,-8.75 z"
+         id="path3825"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </clipPath>
     <linearGradient
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715"
-       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       x1="65.262688"
+       y1="64.205269"
+       x2="65.262688"
+       y2="50.068527"
+       id="linearGradient3812"
+       xlink:href="#linearGradient5010"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3118"
-       xlink:href="#linearGradient5048" />
+       gradientTransform="matrix(0.625,0,0,0.625,78.5,32.25)" />
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3806"
+       x="-0.096000004"
+       y="-0.096000004"
+       width="1.192"
+       height="1.192">
+      <feGaussianBlur
+         stdDeviation="1.2"
+         id="feGaussianBlur3808" />
+    </filter>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       x1="70"
+       y1="54"
+       x2="70"
+       y2="75.095024"
+       id="linearGradient3788"
+       xlink:href="#linearGradient3737"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3170"
-       xlink:href="#linearGradient3104-6" />
+       gradientTransform="translate(0,4)" />
+    <linearGradient
+       x1="56"
+       y1="72"
+       x2="88"
+       y2="72"
+       id="linearGradient3773"
+       xlink:href="#linearGradient3778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9375,0,0,0.9375,-140.5,3.5)" />
+    <linearGradient
+       x1="65.262688"
+       y1="64.205269"
+       x2="65.262688"
+       y2="50.068527"
+       id="linearGradient3832"
+       xlink:href="#linearGradient3737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.625,0,0,0.625,28.5,31.25)" />
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3174"
+       x="-0.047720931"
+       y="-0.047172415"
+       width="1.0954419"
+       height="1.0943448">
+      <feGaussianBlur
+         stdDeviation="1.71"
+         id="feGaussianBlur3176" />
+    </filter>
+    <linearGradient
+       id="linearGradient3737">
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3741"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="45.447727"
+       y1="92.539597"
+       x2="45.447727"
+       y2="7.0165396"
+       id="ButtonShadow"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.0058652,0.994169)">
+      <stop
+         id="stop3750"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752"
+         style="stop-color:#000000;stop-opacity:0.58823532"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5010">
+      <stop
+         id="stop5012"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5014"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3778">
+      <stop
+         id="stop3780"
+         style="stop-color:#499119;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3782"
+         style="stop-color:#8fd625;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.999998"
+       y1="6.0325513"
+       x2="23.999998"
+       y2="42.032551"
+       id="linearGradient3084"
+       xlink:href="#linearGradient3924"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.4e-6,0.9674489)" />
+    <linearGradient
+       id="linearGradient909">
+      <stop
+         id="stop905"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop907"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient903"
+       x1="14.329722"
+       y1="39.244267"
+       x2="14.329722"
+       y2="-3.7957916"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4615385,0,0,1.4615385,0.61538514,-48.352052)" />
+    <linearGradient
+       y2="75.923912"
+       x2="23.504675"
+       y1="21.421766"
+       x1="38.172356"
+       gradientTransform="matrix(0.74314615,-0.2014786,0.19999636,0.75521721,-12.07918,-6.0108763)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4321"
+       xlink:href="#linearGradient4417" />
     <linearGradient
        id="linearGradient4417">
       <stop
@@ -147,56 +307,136 @@
          id="stop4421" />
     </linearGradient>
     <linearGradient
-       y2="75.923912"
-       x2="23.504675"
-       y1="21.421766"
-       x1="38.172356"
-       gradientTransform="matrix(0.74314615,-0.2014786,0.19999636,0.75521721,-12.079371,-8.0110727)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4321"
-       xlink:href="#linearGradient4417" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient1157"
+       id="linearGradient1159"
+       x1="19.166555"
+       y1="42.817169"
+       x2="19.166555"
+       y2="4.3599734"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata3906">
+     id="metadata4122">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     transform="matrix(1.1,0,0,0.4444449,-2.4000022,25.11107)"
+     id="g2036"
+     style="display:inline">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.3">
+      <rect
+         width="5"
+         height="7"
+         x="37.136761"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient2873-966-168);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10.863636"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient2875-742-326);fill-opacity:1;stroke:none" />
+      <rect
+         width="26.272671"
+         height="7.0000005"
+         x="10.863657"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient2877-634-617);fill-opacity:1;stroke:none;stroke-width:1" />
+    </g>
+  </g>
   <rect
-     width="32.508301"
-     height="3.5700529"
-     x="7.7378473"
-     y="42.429947"
-     id="rect2879"
-     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
-     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
-     id="path2881"
-     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
-     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
-     id="path2883"
-     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
-     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z"
-     id="path4160"
-     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline" />
-  <path
-     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
-     id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-  <path
-     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z"
-     id="path4160-6-1"
-     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+     transform="scale(1,-1)"
+     width="38"
+     height="38"
+     rx="3.5"
+     ry="3.5"
+     x="5"
+     y="-43.967438"
+     id="rect5505-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient903);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="39"
+     height="39"
+     rx="4"
+     ry="4"
+     x="4.5"
+     y="5.4674392"
+     id="rect5505-21"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1159);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="37"
+     height="37"
+     rx="3"
+     ry="3"
+     x="5.5"
+     y="6.4674392"
+     id="rect6741-2"
+     style="fill:none;stroke:url(#linearGradient3084);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <g
+     transform="translate(-135.85714,-31.05041)"
+     id="layer2"
+     style="display:none">
+    <path
+       d="M 11,7 48,5 85,7 c 3.324,0 6,2.676 6,6 l 0,73 c 0,3.324 -2.676,6 -6,6 L 11,92 C 7.676,92 5,89.324 5,86 L 5,13 C 5,9.676 7.676,7 11,7 z"
+       id="rect3745"
+       style="opacity:0.9;fill:url(#ButtonShadow);fill-opacity:1;fill-rule:nonzero;stroke:none;filter:url(#filter3174)" />
+  </g>
+  <g
+     transform="translate(-135.85714,-31.05041)"
+     id="layer4"
+     style="display:none">
+    <rect
+       width="30"
+       height="30"
+       rx="2.8125"
+       ry="2.8125"
+       x="-86"
+       y="56"
+       transform="matrix(0,-1,1,0,0,4)"
+       id="rect3790"
+       style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;filter:url(#filter3806)" />
+    <rect
+       width="30"
+       height="30"
+       rx="2.8125"
+       ry="2.8125"
+       x="-88"
+       y="56"
+       transform="matrix(0,-1,1,0,0,0)"
+       id="rect2993"
+       style="fill:url(#linearGradient3773);fill-opacity:1;stroke:none" />
+    <path
+       d="M 58.8125,58 C 57.254375,58 56,59.254375 56,60.8125 l 0,24.375 c 0,0.873066 0.410816,1.641163 1.03125,2.15625 C 57.02841,87.289908 57,87.242129 57,87.1875 l 0,-24.375 C 57,61.254375 58.17075,60 59.625,60 l 22.75,0 C 83.82925,60 85,61.254375 85,62.8125 l 0,24.375 c 0,0.05463 -0.02841,0.102408 -0.03125,0.15625 C 85.589184,86.828663 86,86.060566 86,85.1875 l 0,-24.375 C 86,59.254375 84.745625,58 83.1875,58 l -24.375,0 z"
+       id="rect3775"
+       style="opacity:0.5;fill:url(#linearGradient3788);fill-opacity:1;stroke:none" />
+    <path
+       d="m 116,63.5 0,8.75 -5,0 10,13.75 10,-13.75 -5,0 0,-8.75 -10,0 z"
+       transform="translate(-50,0)"
+       clip-path="url(#clipPath3823)"
+       id="path3810"
+       style="opacity:0.6;fill:url(#linearGradient3812);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline;filter:url(#filter3831)" />
+    <path
+       d="m 66,62.5 0,8.75 -5,0 10,13.75 10,-13.75 -5,0 0,-8.75 -10,0 z"
+       id="path4278"
+       style="fill:url(#linearGradient3832);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+  </g>
   <path
      id="path4201"
-     d="M 32.445312,10.009766 C 32.336477,9.990812 32.217707,9.998697 32.091797,10.035156 L 19.908203,13.5625 C 19.404564,13.708337 19,14.272172 19,14.826172 l 0,13.511719 c -0.870948,-0.376328 -1.900382,-0.438401 -2.882812,-0.173829 -2.154814,0.584184 -3.505906,2.551792 -3.017579,4.394532 0.488754,1.841328 2.62967,2.860645 4.783203,2.277344 1.774251,-0.483156 3.052032,-1.929487 3.109376,-3.519532 l 0.0078,-0.273438 0,-12.39453 10,-2.894532 0,9.583985 c -0.870948,-0.376328 -1.900382,-0.438401 -2.882812,-0.173829 -2.154814,0.584184 -3.505906,2.551792 -3.017579,4.394532 0.488754,1.841328 2.62967,2.860645 4.783203,2.277344 1.774251,-0.483156 3.052032,-1.929487 3.109376,-3.519532 l 0.0078,-0.105469 0,-17.439453 c 0,-0.4155 -0.22818,-0.704858 -0.554688,-0.761718 z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4321);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="m 32.445503,12.009963 c -0.108835,-0.01895 -0.227605,-0.01107 -0.353515,0.02539 l -12.183594,3.527344 c -0.503639,0.145837 -0.908203,0.709672 -0.908203,1.263672 v 13.511719 c -0.870948,-0.376328 -1.900382,-0.438401 -2.882812,-0.173829 -2.154814,0.584184 -3.505906,2.551792 -3.017579,4.394532 0.488754,1.841328 2.62967,2.860645 4.783203,2.277344 1.774251,-0.483156 3.052032,-1.929487 3.109376,-3.519532 l 0.0078,-0.273438 v -12.39453 l 10,-2.894532 v 9.583985 c -0.870948,-0.376328 -1.900382,-0.438401 -2.882812,-0.173829 -2.154814,0.584184 -3.505906,2.551792 -3.017579,4.394532 0.488754,1.841328 2.62967,2.860645 4.783203,2.277344 1.774251,-0.483156 3.052032,-1.929487 3.109376,-3.519532 l 0.0078,-0.105469 V 12.771681 c 0,-0.4155 -0.22818,-0.704858 -0.554688,-0.761718 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4321);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/mimes/64/audio-x-generic.svg
+++ b/mimes/64/audio-x-generic.svg
@@ -1,42 +1,144 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg3844"
+   id="svg13986"
    height="64"
    width="64"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="audio-x-generic.svg">
+   sodipodi:docname="audio-x-generic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
+     id="namedview50"
      pagecolor="#ffffff"
      bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
+     borderopacity="1.0"
      inkscape:pageshadow="2"
-     inkscape:window-width="3200"
-     inkscape:window-height="1674"
-     id="namedview43"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
      showgrid="false"
-     showborder="false"
-     inkscape:zoom="2"
-     inkscape:cx="155.75"
-     inkscape:cy="32"
-     inkscape:window-x="0"
-     inkscape:window-y="60"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3844" />
+     inkscape:zoom="7.5351066"
+     inkscape:cx="21.034872"
+     inkscape:cy="26.277"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="1037"
+     inkscape:window-y="147"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg13986" />
   <defs
-     id="defs3846">
+     id="defs13988">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1129">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.31764707"
+         offset="0"
+         id="stop1125" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.23921569"
+         offset="1"
+         id="stop1127" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926-9-4-9-6" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928-9-8-6-5" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930-3-5-1-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932-8-0-4-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749-4-0-3-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-4-0-1-8" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-9-2-9-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-8-4-1-1">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-8-9-9-1" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-7-8-7-7" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-4-5-1-5" />
+    </linearGradient>
+    <linearGradient
+       y2="42.11261"
+       x2="23.99999"
+       y1="5.8649616"
+       x1="23.99999"
+       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,-2.4707781)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3647"
+       xlink:href="#linearGradient3924-2-2-5-8" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2-3"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,41.985755,16.000001)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4-5"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,-22.014244,-103)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient6394"
+       xlink:href="#linearGradient3702-501-757-8-4-1-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5714286,0,0,0.7142857,-5.7142853,28.428572)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4417"
+       id="linearGradient4179-5"
+       x1="21.330717"
+       y1="0.44737434"
+       x2="21.330717"
+       y2="59.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4.510977,2.0570397)" />
     <linearGradient
        id="linearGradient4417"
        inkscape:collect="always">
@@ -50,181 +152,110 @@
          style="stop-color:#cc3b02;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-6"
-       id="linearGradient3033"
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404" />
-    <linearGradient
-       id="linearGradient3104-6">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0.31782946"
-         id="stop3106-3" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.24031007"
-         id="stop3108-9" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977-4"
-       id="linearGradient3093"
-       y2="42.175503"
-       x2="23.99999"
-       y1="5.8641062"
-       x1="23.99999" />
-    <linearGradient
-       id="linearGradient3977-4">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979-7" />
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981-6" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983-5" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985-6" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-9"
-       id="linearGradient3096"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient1129"
+       id="linearGradient1131"
+       x1="20.409748"
+       y1="58.406929"
+       x2="20.409748"
+       y2="3.5774846"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
        id="linearGradient3600-9">
       <stop
-         offset="0"
+         id="stop3602-3"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-3" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-7"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-7" />
+         offset="1" />
     </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3153"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3156"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
-      <stop
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5048"
-       id="linearGradient3842"
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4417"
-       id="linearGradient4179-5"
-       x1="21.330717"
-       y1="0.44737434"
-       x2="21.330717"
-       y2="59.5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(5.5109472,0.05698564)" />
+       xlink:href="#linearGradient3600-9"
+       id="linearGradient1503"
+       x1="30.087938"
+       y1="2.6783686"
+       x2="30.087938"
+       y2="56.895988"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata3849">
+     id="metadata13991">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     id="g866">
+    <rect
+       style="opacity:0.15;fill:url(#radialGradient3337-2-2-3);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect2801-5-5-7-9"
+       y="57"
+       x="54"
+       height="5"
+       width="6" />
+    <rect
+       style="opacity:0.15;fill:url(#radialGradient3339-1-4-5);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-62"
+       x="-10"
+       height="5"
+       width="6" />
+    <rect
+       style="opacity:0.15;fill:url(#linearGradient6394);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3700-5-6-8-4"
+       y="57"
+       x="10"
+       height="5.0000005"
+       width="44" />
+  </g>
   <rect
-     width="44.199997"
-     height="5"
-     x="9.8999996"
-     y="57.000004"
-     id="rect2879"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-  <path
-     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z"
-     id="path2881"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-  <path
-     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z"
-     id="path2883"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-  <path
-     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
-     id="path4160-6"
-     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none" />
-  <path
-     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z"
-     id="rect6741-1-8"
-     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
-     id="path4160-6-1"
-     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     width="54"
+     height="54"
+     rx="5.5"
+     ry="5.5"
+     x="5"
+     y="5"
+     id="rect5505-21-3-8-5-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1503);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="53"
+     height="53.142479"
+     rx="5"
+     ry="5"
+     x="5.4999986"
+     y="5.4287739"
+     id="rect6741-5-0-2-3"
+     style="fill:none;stroke:url(#linearGradient3647);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="55"
+     height="55"
+     rx="6"
+     ry="6"
+     x="4.4999986"
+     y="4.5000019"
+     id="rect5505-21-3-8-9-1-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient1131);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <g
+     id="layer4-0"
+     transform="matrix(0.9047486,0,0,0.9047486,-570.51497,-675.56047)" />
+  <g
+     id="layer4-0-7"
+     transform="matrix(0.9047486,0,0,0.9047486,-570.51497,-668.32248)" />
+  <g
+     id="layer1-3"
+     transform="matrix(0.9047486,0,0,0.9047486,-73.807987,0.49666306)" />
   <path
      inkscape:connector-curvature="0"
-     d="m 42.738661,13.999946 -14.74243,3.810544 c -1.10744,0.296727 -1.99898,1.477162 -1.99898,2.623653 l 0,18.178169 c -1.12296,-0.588018 -2.5652,-0.825776 -4.06041,-0.437276 -2.69814,0.701061 -4.388911,2.966778 -3.81055,5.059903 0.57836,2.093126 3.23632,3.262246 5.93446,2.561185 2.15255,-0.559293 3.63637,-2.1418 3.87301,-3.810544 l 0.0624,-17.178682 13.99281,-3.748076 0,13.555542 c -1.12296,-0.588018 -2.5652,-0.825776 -4.06041,-0.437275 -2.69814,0.70106 -4.38891,2.966777 -3.81055,5.059902 0.57837,2.093126 3.23632,3.262246 5.93446,2.561186 2.15255,-0.559293 3.63637,-2.141801 3.87301,-3.810544 l 0.0624,-22.363521 c 0,-0.859879 -0.53141,-1.503208 -1.24936,-1.624166 z"
+     d="m 41.738692,16 -14.74243,3.810544 c -1.10744,0.296727 -1.99898,1.477162 -1.99898,2.623653 v 18.178169 c -1.12296,-0.588018 -2.5652,-0.825776 -4.06041,-0.437276 -2.69814,0.701061 -4.388911,2.966778 -3.81055,5.059903 0.57836,2.093126 3.23632,3.262246 5.93446,2.561185 2.15255,-0.559293 3.63637,-2.1418 3.87301,-3.810544 l 0.0624,-17.178682 13.99281,-3.748076 v 13.555542 c -1.12296,-0.588018 -2.5652,-0.825776 -4.06041,-0.437275 -2.69814,0.70106 -4.38891,2.966777 -3.81055,5.059902 0.57837,2.093126 3.23632,3.262246 5.93446,2.561186 2.15255,-0.559293 3.63637,-2.141801 3.87301,-3.810544 l 0.0624,-22.363521 c 0,-0.859879 -0.53141,-1.503208 -1.24936,-1.624166 z"
      id="path16590-0"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4179-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4179-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>


### PR DESCRIPTION
The audio mimetype icon currently has the look of an icon that would represent a document or text. Most mimetype icons that represent binary files use a different shape (Package, Video, Executable files use a more square shape).

This switches the shape of the audio icon to more closely resemble the style of other binary mimetypes and makes the audio icon look less like a document.

I used the new `image-missing` icon and adjusted the gradient, borders, and shadows to match the current audio icon. I think this gives it a mimetype look while the shape differentiates it from a file that represents text.