### PR TITLE
FileTypes: Fix incorrect SVG symlink

### DIFF
--- a/mimes/meson.build
+++ b/mimes/meson.build
@@ -134,7 +134,7 @@ mime_links = [
     ['x-office-drawing', 'application-vnd.oasis.opendocument.drawing'],
     ['x-office-drawing', 'application-vnd.oasis.opendocument.graphics'],
     ['x-office-drawing', 'application-vnd.sun.xml.draw'],
-    ['x-office-drawing', 'image-x-svg+xml'],
+    ['x-office-drawing', 'image-svg+xml'],
     ['x-office-drawing', 'office-illustration'],
 
     ['x-office-drawing-template', 'application-vnd.oasis.opendocument.graphics-template'],


### PR DESCRIPTION
If you disable thumbnails, you can verify that this is actually the correct icon name and it was broken before