### PR TITLE
Actions: Make media-record more consistent

### DIFF
--- a/actions/16/media-record.svg
+++ b/actions/16/media-record.svg
@@ -1,235 +1,193 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg3033">
+   id="svg3033"
+   sodipodi:docname="media-record.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview11568"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="41.7193"
+     inkscape:cx="4.6860805"
+     inkscape:cy="13.470983"
+     inkscape:window-width="1326"
+     inkscape:window-height="754"
+     inkscape:window-x="554"
+     inkscape:window-y="141"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3033" />
   <defs
      id="defs3035">
     <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3280"
+       y2="23"
+       x2="39.441502"
+       y1="23"
+       x1="6.6574788"
+       gradientTransform="matrix(0,0.53572674,-0.53572674,0,20.321716,-4.3212879)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35135136,0,0,0.35135136,-17.203671,-0.90930025)">
+       id="linearGradient3932-9"
+       xlink:href="#linearGradient3907" />
+    <linearGradient
+       id="linearGradient3907">
       <stop
-         id="stop4013"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3909"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
       <stop
-         id="stop4015"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.50775999" />
-      <stop
-         id="stop4017"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456999" />
-      <stop
-         id="stop4019"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop3911"
+         offset="1"
+         style="stop-color:#abacae;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        x1="71.204002"
        y1="6.2375998"
        x2="71.204002"
        y2="44.341"
-       id="linearGradient3076"
+       id="linearGradient3101"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.18918919,0,0,-0.18918919,-5.571206,12.797424)">
+       gradientTransform="matrix(0.35135133,0,0,0.35135132,-17.203668,-0.9094021)">
       <stop
-         id="stop4013-2"
+         id="stop4013-7"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015-4"
+         id="stop4015-5"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.50775999" />
       <stop
-         id="stop4017-9"
+         id="stop4017-3"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456999" />
       <stop
-         id="stop4019-0"
+         id="stop4019-5"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3079"
+    <linearGradient
+       xlink:href="#linearGradient4011"
+       id="linearGradient3993-0-6-0-8-5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.29307547,-0.38685444,0,9.5435496,-1.6900315)">
+       gradientTransform="matrix(0.24324334,0,0,-0.24324335,-9.4487,14.16798)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       id="linearGradient4011">
       <stop
-         id="stop3244-4"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4013-35" />
       <stop
-         id="stop3246-5"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4015-62" />
       <stop
-         id="stop3248-0"
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4017-91" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4019-27" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="31.576309"
+       x2="24"
+       y1="16.500965"
+       x1="24"
+       id="linearGradient1006"
+       xlink:href="#linearGradient1004"
+       gradientTransform="matrix(0.46653537,0,0,0.46653537,-3.1968479,-3.196459)" />
+    <linearGradient
+       id="linearGradient1004">
+      <stop
+         id="stop1000"
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1" />
+      <stop
+         id="stop1002"
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.17195185,0,0,0.17195187,3.8729669,3.8731253)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3086"
+       id="linearGradient3039"
+       y2="45.368999"
+       x2="7.0776"
+       y1="3.0816"
+       x1="7.0776" />
+    <linearGradient
+       gradientTransform="matrix(0.36857196,0,0,0.36857202,15.153867,16.154407)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3086"
+       y2="45.368999"
+       x2="7.0776"
+       y1="3.0816"
+       x1="7.0776">
+      <stop
+         offset="0"
+         style="stop-color:#7a0000;stop-opacity:1"
+         id="stop2492-0-3" />
+      <stop
+         offset="1"
          style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-3"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       x1="7.0776"
-       y1="3.0816"
-       x2="7.0776"
-       y2="45.368999"
-       id="linearGradient3081"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.12279747,0,0,0.12279748,5.0528597,5.0527696)">
-      <stop
-         id="stop2492-0"
-         style="stop-color:#791235;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494-6"
-         style="stop-color:#c7321f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.87967058,-1.1611496,0,12.63299,-21.084396)">
-      <stop
-         id="stop3244-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-3"
-         style="stop-color:#dddddd;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-1"
-         style="stop-color:#abacae;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-9"
-         style="stop-color:#89898b;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       x1="18.379"
-       y1="44.98"
-       x2="18.379"
-       y2="3.0816"
-       id="linearGradient3089"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.36857849,0,0,0.36857855,-0.84588394,-0.84577376)">
-      <stop
-         id="stop2492-4"
-         style="stop-color:#505050;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494-7"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="1" />
+         id="stop2494-6-6" />
     </linearGradient>
     <linearGradient
        x1="71.204002"
        y1="6.2375998"
        x2="71.204002"
        y2="44.341"
-       id="linearGradient3014"
-       xlink:href="#linearGradient3280"
+       id="linearGradient3032"
+       xlink:href="#linearGradient3101-3"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35135136,0,0,0.35135136,-17.203671,-0.90930025)" />
+       gradientTransform="matrix(0.13513513,0,0,0.13513502,-1.6937189,4.5733093)" />
     <linearGradient
        x1="71.204002"
        y1="6.2375998"
        x2="71.204002"
        y2="44.341"
-       id="linearGradient3017"
-       xlink:href="#linearGradient3076"
+       id="linearGradient3101-3"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.24324325,0,0,-0.24324327,-9.4486935,14.168118)" />
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3020"
-       xlink:href="#radialGradient3079"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.41038696,-0.54170353,0,10.161398,-5.5687319)" />
-    <linearGradient
-       x1="7.0776"
-       y1="3.0816"
-       x2="7.0776"
-       y2="45.368999"
-       id="linearGradient3022"
-       xlink:href="#linearGradient3081"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17195052,0,0,0.17195054,3.8731861,3.8730601)" />
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3025"
-       xlink:href="#radialGradient3087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.87967058,-1.1611496,0,12.63299,-21.084396)" />
-    <linearGradient
-       x1="18.379"
-       y1="44.98"
-       x2="18.379"
-       y2="3.0816"
-       id="linearGradient3027"
-       xlink:href="#linearGradient3089"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.36857849,0,0,0.36857855,-0.84588394,-0.84577376)" />
-    <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3280-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35135136,0,0,0.35135136,-17.203671,-0.90930025)">
+       gradientTransform="matrix(0.5135135,0,0,0.5135135,-24.836132,-1.021284)">
       <stop
-         id="stop4013-9"
+         id="stop4013-6"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015-3"
+         id="stop4015-1"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.50775999" />
       <stop
-         id="stop4017-1"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456999" />
       <stop
-         id="stop4019-9"
+         id="stop4019-9-6"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3046"
-       xlink:href="#linearGradient3280-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.13513513,0,0,0.13513513,-1.6937191,4.5733462)" />
   </defs>
   <metadata
      id="metadata3038">
@@ -239,28 +197,31 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="m 8,0.50183 c -4.1373,0 -7.4982,3.361 -7.4982,7.4982 0,4.1373 3.361,7.4982 7.4982,7.4982 4.1373,0 7.4982,-3.361 7.4982,-7.4982 0,-4.1373 -3.361,-7.4982 -7.4982,-7.4982 z"
-     id="path2555-4"
-     style="fill:url(#radialGradient3025);stroke:url(#linearGradient3027);stroke-width:1.00365412;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="m 8.0002651,0.50025341 c -4.142363,0 -7.50044005,3.35819029 -7.50044005,7.50008079 0,4.1422698 3.35811245,7.5002698 7.50044005,7.5002698 4.1421749,0 7.4999099,-3.358 7.4999099,-7.5002698 0,-4.1418905 -3.357735,-7.5000808 -7.4999099,-7.50008079 z"
+     id="path3902-8"
+     style="fill:url(#linearGradient3932-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1" />
   <path
-     d="m 8.0000001,4.5018272 c -1.9301424,0 -3.498173,1.5680306 -3.498173,3.498173 0,1.9301424 1.5680306,3.4981728 3.498173,3.4981728 1.9301419,0 3.4981729,-1.5680304 3.4981729,-3.4981728 0,-1.9301424 -1.568031,-3.498173 -3.4981729,-3.498173 z"
-     id="path2555-3"
-     style="fill:url(#radialGradient3020);stroke:url(#linearGradient3022);stroke-width:1.00365412;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="m 8.0000001,0.50182418 c -4.1374243,0 -7.49817528,3.36110812 -7.49817528,7.49817532 0,4.1374255 3.36110818,7.4981765 7.49817528,7.4981765 4.1374239,0 7.4981749,-3.361108 7.4981749,-7.4981765 0,-4.1374244 -3.361108,-7.49817531 -7.4981749,-7.49817532 z"
+     id="path2555-36"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1.00365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="M 12.5,8.0001291 C 12.5,5.5147145 10.485157,3.5000001 8.0001287,3.5000001 5.5147144,3.5000001 3.5,5.5148431 3.5,8.0001291 3.5,10.485415 5.5147144,12.5 8.0001287,12.5 10.485157,12.5 12.5,10.485415 12.5,8.0001291 z"
-     id="path8655-6-1"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3017);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
-  <path
-     d="M 14.5,7.9998 C 14.5,11.59 11.59,14.5 8.0001,14.5 4.4102,14.5 1.5,11.59 1.5,7.9998 1.5,4.41 4.4102,1.5 8.0001,1.5 11.59,1.5 14.5,4.41 14.5,7.9998 z"
+     d="m 14.5,7.9998969 c 0,3.5900541 -2.910632,6.5000001 -6.4999999,6.5000001 -3.589779,0 -6.5,-2.910631 -6.5,-6.5000001 0,-3.5897789 2.910221,-6.4997944 6.5000684,-6.4997944 3.5895735,0 6.4999315,2.9099471 6.4999315,6.4997944 z"
      id="path8655-6"
-     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient3014);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
+     style="color:#000000;fill:none;stroke:url(#linearGradient3101);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
   <path
-     d="M 10.5,7.999923 C 10.5,9.3807691 9.3807691,10.5 8.0000383,10.5 6.6193076,10.5 5.5,9.3807691 5.5,7.999923 5.5,6.6192307 6.6193076,5.5 8.0000383,5.5 9.3807691,5.5 10.5,6.6192307 10.5,7.999923 z"
-     id="path8655-6-4"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3046);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
+     d="m 12.500002,8.0001597 c 0,-2.485362 -2.014868,-4.5001617 -4.4999447,-4.5001617 -2.4853046,0 -4.5000593,2.0148219 -4.5000593,4.5001617 0,2.4852483 2.0147547,4.4998423 4.5000593,4.4998423 2.4850767,0 4.4999447,-2.014594 4.4999447,-4.4998423 z"
+     id="path8655-1-6-9-4-8-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3993-0-6-0-8-5);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="fill:url(#linearGradient1006);fill-opacity:1;stroke:url(#linearGradient3039);stroke-width:1.00365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+     id="path2555-3"
+     d="m 8.0000006,4.5018252 c -1.9301502,0 -3.4981754,1.5680252 -3.4981754,3.4981753 0,1.9301494 1.5680252,3.4981745 3.4981754,3.4981745 1.9301503,0 3.4981744,-1.5680251 3.4981744,-3.4981745 0,-1.9301501 -1.5680241,-3.4981753 -3.4981744,-3.4981753 z" />
+  <path
+     d="M 10.5,7.9999606 C 10.5,9.3807493 9.380526,10.499959 8,10.499959 6.6193155,10.499959 5.5,9.3804857 5.5,7.9999606 5.5,6.6192772 6.6193155,5.5000413 8.0000265,5.5000413 9.3806317,5.5000413 10.5,6.6192508 10.5,7.9999606 Z"
+     id="path8655-6-3"
+     style="color:#000000;opacity:0.5;fill:none;stroke:url(#linearGradient3032);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
 </svg>

--- a/actions/24/media-record.svg
+++ b/actions/24/media-record.svg
@@ -1,124 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="24"
    height="24"
-   id="svg3041">
+   id="svg3041"
+   sodipodi:docname="media-record.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview2183"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="19.666667"
+     inkscape:cx="1.2711864"
+     inkscape:cy="14.110169"
+     inkscape:window-width="1326"
+     inkscape:window-height="817"
+     inkscape:window-x="88"
+     inkscape:window-y="167"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3041" />
   <defs
      id="defs3043">
-    <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3082"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.29729726,0,0,-0.29729726,-9.3261789,19.538808)">
-      <stop
-         id="stop4013-2"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4015-4"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.50775999" />
-      <stop
-         id="stop4017-9"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456999" />
-      <stop
-         id="stop4019-0"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3085"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.52770723,-0.69656421,0,14.779293,-5.4477218)">
-      <stop
-         id="stop3244-4"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-5"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-0"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-3"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       x1="7.0776"
-       y1="3.0816"
-       x2="7.0776"
-       y2="45.368999"
-       id="linearGradient3087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.22110724,0,0,0.22110728,6.6934256,6.693263)">
-      <stop
-         id="stop2492-0"
-         style="stop-color:#791235;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494-6"
-         style="stop-color:#c7321f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3093"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.2316483,-1.625754,0,18.486966,-28.721977)">
-      <stop
-         id="stop3244-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-3"
-         style="stop-color:#dddddd;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-1"
-         style="stop-color:#abacae;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-9"
-         style="stop-color:#89898b;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       x1="18.379"
-       y1="44.98"
-       x2="18.379"
-       y2="3.0816"
-       id="linearGradient3095"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.51605578,0,0,0.51605586,-0.38513694,-0.38538676)">
-      <stop
-         id="stop2492-4"
-         style="stop-color:#505050;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494-7"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        x1="71.204002"
        y1="6.2375998"
@@ -144,22 +60,6 @@
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="62.625"
-       cy="4.625"
-       r="10.625"
-       id="radialGradient3109"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1294118,0,0,0.2823525,-58.729414,19.694118)">
-      <stop
-         id="stop8840"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8842"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </radialGradient>
     <linearGradient
        x1="71.204002"
        y1="6.2375998"
@@ -213,6 +113,131 @@
        id="linearGradient3259"
        xlink:href="#linearGradient3990"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       y2="23"
+       x2="38.961662"
+       y1="23"
+       x1="7.0767264"
+       gradientTransform="matrix(0,0.74999994,-0.74999994,0,29.25,-5.2500002)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3932-9"
+       xlink:href="#linearGradient3907" />
+    <linearGradient
+       id="linearGradient3907">
+      <stop
+         id="stop3909"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop3911"
+         offset="1"
+         style="stop-color:#abacae;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4011"
+       id="linearGradient3993-0-6-0-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29729728,0,0,-0.29729729,-9.326179,19.538639)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4013-35" />
+      <stop
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4015-62" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4017-91" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4019-27" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="31.576309"
+       x2="24"
+       y1="16.500965"
+       x1="24"
+       id="linearGradient1006"
+       xlink:href="#linearGradient1004"
+       gradientTransform="matrix(0.59990065,0,0,0.59990065,-2.3976156,-2.3971153)" />
+    <linearGradient
+       id="linearGradient1004">
+      <stop
+         id="stop1000"
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1" />
+      <stop
+         id="stop1002"
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.22110656,0,0,0.22110659,6.6931991,6.6934031)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3086"
+       id="linearGradient3039"
+       y2="45.368999"
+       x2="7.0776"
+       y1="3.0816"
+       x1="7.0776" />
+    <linearGradient
+       gradientTransform="matrix(0.36857196,0,0,0.36857202,15.153867,16.154407)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3086"
+       y2="45.368999"
+       x2="7.0776"
+       y1="3.0816"
+       x1="7.0776">
+      <stop
+         offset="0"
+         style="stop-color:#7a0000;stop-opacity:1"
+         id="stop2492-0-3" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop2494-6-6" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3300-8-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
+    <linearGradient
+       id="linearGradient3820-7-2">
+      <stop
+         id="stop3822-2-6"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3824-1-2"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient4192-6-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
   </defs>
   <metadata
      id="metadata3046">
@@ -222,30 +247,42 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     id="g4198-4-0"
+     transform="matrix(0.375,0,0,0.35714136,5.8125e-7,1.1422987)"
+     style="stroke-width:2.73252">
+    <path
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
+       id="path3818-0-6-9"
+       style="opacity:0.2;fill:url(#radialGradient3300-8-3);fill-opacity:1;stroke:none;stroke-width:2.73252" />
+    <path
+       style="opacity:0.4;fill:url(#radialGradient4192-6-5);fill-opacity:1;stroke:none;stroke-width:2.73252"
+       id="path4190-2-3"
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
+  </g>
   <path
-     d="m 24,21 c 0,1.6569 -5.3726,3 -12,3 -6.6274,0 -12,-1.343 -12,-3 0,-1.657 5.3726,-3 12,-3 6.6274,0 12,1.3431 12,3 z"
-     id="path8836"
-     style="opacity:0.3;fill:url(#radialGradient3109);fill-rule:evenodd" />
+     d="M 12.000371,1.5000001 C 6.2011981,1.5000001 1.5,6.2013568 1.5,11.999868 1.5,17.79891 6.2012478,22.5 12.000371,22.5 17.799281,22.5 22.5,17.79891 22.5,11.999868 22.5,6.2013568 17.799281,1.5000001 12.000371,1.5000001 Z"
+     id="path3902-8"
+     style="fill:url(#linearGradient3932-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1" />
   <path
      d="m 12,1.5014 c -5.7927,0 -10.498,4.7058 -10.498,10.498 0,5.7927 4.7058,10.498 10.498,10.498 5.7927,0 10.498,-4.7058 10.498,-10.498 C 22.498,6.2067 17.7922,1.5014 12,1.5014 z"
      id="path2555-36"
-     style="fill:url(#radialGradient3093);stroke:url(#linearGradient3095);stroke-width:1.00365412;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0" />
-  <path
-     d="M 12,7.5018 C 9.5181,7.5018 7.5018,9.518 7.5018,12 c 0,2.4819 2.0163,4.4982 4.4982,4.4982 2.4819,0 4.4982,-2.0162 4.4982,-4.4982 C 16.4982,9.5181 14.482,7.5018 12,7.5018 z"
-     id="path2555-3"
-     style="fill:url(#radialGradient3085);stroke:url(#linearGradient3087);stroke-width:1.00365412;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0" />
-  <path
-     d="M 17.5,12 C 17.5,8.9625 15.037,6.5 12,6.5 8.9625,6.5 6.5,8.9626 6.5,12 c 0,3.038 2.4625,5.5 5.5,5.5 3.037,0 5.5,-2.462 5.5,-5.5 z"
-     id="path8655-6-1"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3082);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
+     style="fill:none;stroke:#555761;stroke-width:1.00365412;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:0.6;fill-opacity:1" />
   <path
      d="m 21.5,12 c 0,5.247 -4.254,9.5 -9.5,9.5 C 6.7534,21.5 2.5,17.246 2.5,12 2.5,6.7534 6.7534,2.5003 12.0001,2.5003 17.2464,2.5003 21.5,6.7533 21.5,12 z"
      id="path8655-6"
-     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient3101);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
+     style="opacity:1;color:#000000;fill:none;stroke:url(#linearGradient3101);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
+  <path
+     d="M 17.5,12.000195 C 17.5,8.962532 15.037385,6.5 12.00007,6.5 8.9624768,6.5 6.5,8.962559 6.5,12.000195 6.5,15.037719 8.9624768,17.5 12.00007,17.5 15.037385,17.5 17.5,15.037719 17.5,12.000195 Z"
+     id="path8655-1-6-9-4-8-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3993-0-6-0-8-5);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="fill:url(#linearGradient1006);fill-opacity:1;stroke:url(#linearGradient3039);stroke-width:1.00365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+     id="path2555-3"
+     d="m 12,7.501825 c -2.481909,0 -4.4981751,2.0162661 -4.4981751,4.498175 0,2.481909 2.0162661,4.498175 4.4981751,4.498175 2.481909,0 4.498175,-2.016266 4.498175,-4.498175 0,-2.4819089 -2.016266,-4.498175 -4.498175,-4.498175 z" />
   <path
      d="M 15.499905,12.000095 C 15.499905,13.933148 13.932684,15.5 12,15.5 c -1.932906,0 -3.4999053,-1.567221 -3.4999053,-3.499905 0,-1.932906 1.5669993,-3.4997951 3.4999423,-3.4997951 1.932795,0 3.499868,1.5668521 3.499868,3.4997951 z"
      id="path8655-6-3"

--- a/actions/32/media-record.svg
+++ b/actions/32/media-record.svg
@@ -1,259 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg4064">
+   id="svg4064"
+   sodipodi:docname="media-record.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview12405"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="10.429825"
+     inkscape:cx="21.333052"
+     inkscape:cy="28.571908"
+     inkscape:window-width="1326"
+     inkscape:window-height="794"
+     inkscape:window-x="693"
+     inkscape:window-y="210"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4064" />
   <defs
      id="defs4066">
-    <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3205"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35135134,0,0,-0.35135134,-9.203668,24.909301)">
-      <stop
-         id="stop4013-2"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4015-4"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.50775999" />
-      <stop
-         id="stop4017-9"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456999" />
-      <stop
-         id="stop4019-0"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3037"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.64502634,-0.85142336,0,19.397182,-5.3264752)">
-      <stop
-         id="stop3244-4"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-5"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-0"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-3"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       x1="7.0776"
-       y1="3.0816"
-       x2="7.0776"
-       y2="45.368999"
-       id="linearGradient3039"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27026349,0,0,0.27026353,9.5136756,9.5136758)">
-      <stop
-         id="stop2492-0"
-         style="stop-color:#791235;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494-6"
-         style="stop-color:#c7321f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3524"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.67567564,0,0,0.67567563,-32.468591,-1.1332679)">
-      <stop
-         id="stop4013"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4015"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.50775999" />
-      <stop
-         id="stop4017"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456999" />
-      <stop
-         id="stop4019"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3013"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.5835582,-2.0902688,0,24.340178,-36.357109)">
-      <stop
-         id="stop3244"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246"
-         style="stop-color:#dddddd;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248"
-         style="stop-color:#abacae;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250"
-         style="stop-color:#89898b;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       x1="18.379"
-       y1="44.98"
-       x2="18.379"
-       y2="3.0816"
-       id="linearGradient3015"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66350462,0,0,0.66350472,0.07588745,0.0758879)">
-      <stop
-         id="stop2492"
-         style="stop-color:#505050;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="62.625"
-       cy="4.625"
-       r="10.625"
-       id="radialGradient4053"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5058824,0,0,0.37647,-78.305888,26.258824)">
-      <stop
-         id="stop8840"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8842"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3018"
-       xlink:href="#linearGradient3205"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35135134,0,0,-0.35135134,-9.203668,24.909301)" />
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3021"
-       xlink:href="#radialGradient3037"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.64502634,-0.85142336,0,19.397182,-5.3264752)" />
-    <linearGradient
-       x1="7.0776"
-       y1="3.0816"
-       x2="7.0776"
-       y2="45.368999"
-       id="linearGradient3023"
-       xlink:href="#linearGradient3039"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27026349,0,0,0.27026353,9.5136756,9.5136758)" />
-    <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3026"
-       xlink:href="#linearGradient3524"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.67567564,0,0,0.67567563,-32.468591,-1.1332679)" />
-    <radialGradient
-       cx="23.896"
-       cy="3.99"
-       r="20.396999"
-       id="radialGradient3029"
-       xlink:href="#radialGradient3013"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.5835582,-2.0902688,0,24.340178,-36.357109)" />
-    <linearGradient
-       x1="18.379"
-       y1="44.98"
-       x2="18.379"
-       y2="3.0816"
-       id="linearGradient3031"
-       xlink:href="#linearGradient3015"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66350462,0,0,0.66350472,0.07588745,0.0758879)" />
-    <radialGradient
-       cx="62.625"
-       cy="4.625"
-       r="10.625"
-       id="radialGradient3034"
-       xlink:href="#radialGradient4053"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5058824,0,0,0.37647,-78.305888,26.258824)" />
-    <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3524-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.67567564,0,0,0.67567563,-32.468591,-1.1332679)">
-      <stop
-         id="stop4013-1"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4015-2"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.50775999" />
-      <stop
-         id="stop4017-93"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456999" />
-      <stop
-         id="stop4019-1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="71.204002"
-       y1="6.2375998"
-       x2="71.204002"
-       y2="44.341"
-       id="linearGradient3053"
-       xlink:href="#linearGradient3524-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.24324324,0,0,0.24324324,-1.4486925,9.8320237)" />
     <linearGradient
        id="linearGradient3990">
       <stop
@@ -272,7 +53,192 @@
        y2="65.922028"
        id="linearGradient3175"
        xlink:href="#linearGradient3990"
-       gradientUnits="userSpaceOnUse" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21882967,0,0,0.21882967,1.3571447,0.41837063)" />
+    <linearGradient
+       x1="71.204002"
+       y1="6.2375998"
+       x2="71.204002"
+       y2="44.341"
+       id="linearGradient3101"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567566,0,0,0.67567566,-32.468594,-1.133466)">
+      <stop
+         id="stop4013-29"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015-1"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.50775999" />
+      <stop
+         id="stop4017-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456999" />
+      <stop
+         id="stop4019-7"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="23"
+       x2="38.961662"
+       y1="23"
+       x1="7.0767264"
+       gradientTransform="matrix(0,0.96429817,-0.96429817,0,38.178859,-6.1780897)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3932-9"
+       xlink:href="#linearGradient3907" />
+    <linearGradient
+       id="linearGradient3907">
+      <stop
+         id="stop3909"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop3911"
+         offset="1"
+         style="stop-color:#abacae;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4011"
+       id="linearGradient3993-0-6-0-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135143,0,0,-0.35135144,-9.2036733,24.909303)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4013-35" />
+      <stop
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4015-62" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4017-91" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4019-27" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="31.576309"
+       x2="24"
+       y1="16.500965"
+       x1="24"
+       id="linearGradient1006"
+       xlink:href="#linearGradient1004"
+       gradientTransform="matrix(0.73326596,0,0,0.73326596,-1.5983825,-1.597771)" />
+    <linearGradient
+       id="linearGradient1004">
+      <stop
+         id="stop1000"
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1" />
+      <stop
+         id="stop1002"
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27026127,0,0,0.27026131,9.5134323,9.513681)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3086"
+       id="linearGradient3039-0"
+       y2="45.368999"
+       x2="7.0776"
+       y1="3.0816"
+       x1="7.0776" />
+    <linearGradient
+       gradientTransform="matrix(0.36857196,0,0,0.36857202,15.153867,16.154407)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3086"
+       y2="45.368999"
+       x2="7.0776"
+       y1="3.0816"
+       x1="7.0776">
+      <stop
+         offset="0"
+         style="stop-color:#7a0000;stop-opacity:1"
+         id="stop2492-0-3" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop2494-6-6" />
+    </linearGradient>
+    <linearGradient
+       x1="71.204002"
+       y1="6.2375998"
+       x2="71.204002"
+       y2="44.341"
+       id="linearGradient3032"
+       xlink:href="#linearGradient3101-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.24324329,-1.4486949,9.831951)" />
+    <linearGradient
+       x1="71.204002"
+       y1="6.2375998"
+       x2="71.204002"
+       y2="44.341"
+       id="linearGradient3101-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5135135,0,0,0.5135135,-24.836132,-1.021284)">
+      <stop
+         id="stop4013-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015-1-9"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.50775999" />
+      <stop
+         id="stop4017-2-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456999" />
+      <stop
+         id="stop4019-9"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3300-8-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
+    <linearGradient
+       id="linearGradient3820-7-2">
+      <stop
+         id="stop3822-2-6"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3824-1-2"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient4192-6-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
   </defs>
   <metadata
      id="metadata4069">
@@ -282,37 +248,48 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     id="g4198-4-0"
+     transform="matrix(0.5,0,0,0.49999791,7.75e-7,-7.8216253e-4)"
+     style="stroke-width:2">
+    <path
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
+       id="path3818-0-6-9"
+       style="opacity:0.2;fill:url(#radialGradient3300-8-3);fill-opacity:1;stroke:none;stroke-width:2" />
+    <path
+       style="opacity:0.4;fill:url(#radialGradient4192-6-5);fill-opacity:1;stroke:none;stroke-width:2"
+       id="path4190-2-3"
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
+  </g>
   <path
-     d="m 32,28 c 0,2.2091 -7.1634,4 -16,4 -8.8366,0 -16,-1.791 -16,-4 0,-2.2091 7.1634,-4 16,-4 8.8366,0 16,1.7909 16,4 z"
-     id="path8836"
-     style="opacity:0.3;fill:url(#radialGradient3034);fill-rule:evenodd" />
+     d="m 16.000477,2.5005958 c -7.4561765,0 -13.5006527,6.0446801 -13.5006527,13.5000062 0,7.456008 6.0445401,13.500345 13.5006527,13.500345 7.455838,0 13.499698,-6.044337 13.499698,-13.500345 0,-7.4553261 -6.04386,-13.5000062 -13.499698,-13.5000062 z"
+     id="path3902-8"
+     style="fill:url(#linearGradient3932-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1" />
   <path
-     d="m 16,2.5018 c -7.4478,0 -13.498,6.0503 -13.498,13.498 0,7.4478 6.0503,13.498 13.498,13.498 7.4478,0 13.498,-6.0503 13.498,-13.498 C 29.498,8.552 23.4477,2.5018 16,2.5018 z"
-     id="path2555"
-     style="fill:url(#radialGradient3029);stroke:url(#linearGradient3031);stroke-width:1.00365412;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="M 16,2.5023957 C 8.5521459,2.5023957 2.5023958,8.5527887 2.5023958,16 2.5023958,23.447854 8.5527887,29.497604 16,29.497604 23.447853,29.497604 29.497604,23.447211 29.497604,16 29.497604,8.5521458 23.447211,2.5023957 16,2.5023957 Z"
+     id="path2555-36"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1.00365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="M 28.5,16 C 28.5,22.903 22.903,28.5 16,28.5 9.0965,28.5 3.5,22.903 3.5,16 3.5,9.0961 9.0965,3.5 16,3.5 22.903,3.5 28.5,9.0961 28.5,16 z"
+     d="m 28.5,15.999802 c 0,6.903948 -5.597369,12.500001 -12.5,12.500001 -6.9034209,0 -12.4999999,-5.597369 -12.4999999,-12.500001 0,-6.9034207 5.596579,-12.4996048 12.5001309,-12.4996048 6.903027,0 12.499869,5.5960526 12.499869,12.4996048 z"
      id="path8655-6"
-     style="opacity:0.8;color:#000000;fill:none;stroke:url(#linearGradient3026);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
+     style="color:#000000;fill:none;stroke:url(#linearGradient3101);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
   <path
-     d="m 16,10.502 c -3.0337,0 -5.4982,2.4645 -5.4982,5.4982 0,3.0337 2.4645,5.4982 5.4982,5.4982 3.0337,0 5.4982,-2.4645 5.4982,-5.4982 0,-3.0337 -2.4645,-5.4982 -5.4982,-5.4982 z"
+     d="m 22.500002,16.00023 c 0,-3.589966 -2.910364,-6.500232 -6.49992,-6.500232 -3.589883,0 -6.5000837,2.910298 -6.5000837,6.500232 0,3.589802 2.9102007,6.499772 6.5000837,6.499772 3.589556,0 6.49992,-2.90997 6.49992,-6.499772 z"
+     id="path8655-1-6-9-4-8-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3993-0-6-0-8-5);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="fill:url(#linearGradient1006);fill-opacity:1;stroke:url(#linearGradient3039-0);stroke-width:1.00365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
      id="path2555-3"
-     style="fill:url(#radialGradient3021);stroke:url(#linearGradient3023);stroke-width:1.00365412;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="m 16.000001,10.501826 c -3.033668,0 -5.498175,2.464507 -5.498175,5.498174 0,3.033668 2.464507,5.498174 5.498175,5.498174 3.033667,0 5.498173,-2.464506 5.498173,-5.498174 0,-3.033668 -2.464506,-5.498175 -5.498173,-5.498174 z" />
   <path
-     d="M 22.5,16 C 22.5,12.41 19.5896,9.4998 16.0001,9.4998 12.4102,9.4998 9.5,12.4101 9.5,16 c 0,3.5898 2.9102,6.4998 6.5001,6.4998 3.5896,0 6.4999,-2.91 6.4999,-6.4998 z"
-     id="path8655-6-1"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3018);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
+     d="m 20.5,15.999929 c 0,2.485422 -2.015054,4.500001 -4.5,4.500001 -2.485232,0 -4.5,-2.015053 -4.5,-4.500001 0,-2.485232 2.014768,-4.499859 4.500047,-4.499859 2.48509,0 4.499953,2.014579 4.499953,4.499859 z"
+     id="path8655-6-3"
+     style="color:#000000;opacity:0.5;fill:none;stroke:url(#linearGradient3032);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
   <path
-     d="m 20.500001,16 c 0,2.485081 -2.01492,4.500001 -4.5,4.500001 C 13.514741,20.500001 11.5,18.485081 11.5,16 c 0,-2.485403 2.014741,-4.5 4.500001,-4.5 2.48508,0 4.5,2.014597 4.5,4.5 z"
-     id="path8655-6-9"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3053);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate" />
-  <path
-     d="m 78.338799,64.349724 a 11.424408,11.424408 0 1 1 -22.848816,0 11.424408,11.424408 0 1 1 22.848816,0 z"
-     transform="matrix(0.26259566,0,0,0.26259566,-1.5714286,-1.8979581)"
+     d="m 18.5,14.5 a 2.5,2.5 0 1 1 -5,0 2.5,2.5 0 1 1 5,0 z"
      id="path3220"
-     style="opacity:0.4;color:#000000;fill:url(#linearGradient3175);fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#linearGradient3175);fill-opacity:1;stroke:none;stroke-width:0.175064;marker:none;enable-background:accumulate" />
 </svg>

--- a/actions/48/media-record.svg
+++ b/actions/48/media-record.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3047"
    height="48"
    width="48"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="media-record.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10980"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="20.084746"
+     inkscape:cy="29.288136"
+     inkscape:window-width="1326"
+     inkscape:window-height="810"
+     inkscape:window-x="686"
+     inkscape:window-y="178"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3047" />
   <defs
      id="defs3049">
     <linearGradient
@@ -77,7 +100,7 @@
          id="stop3994" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.35012755,0,0,0.35012755,0.5714278,-0.53164511)"
+       gradientTransform="matrix(0.35012755,0,0,0.35012755,0.571428,-0.53164511)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3990"
        id="linearGradient3101"
@@ -86,7 +109,7 @@
        y1="52.925316"
        x1="68.313301" />
     <linearGradient
-       gradientTransform="matrix(0.35135131,0,0,0.35135131,-1.2040722,15.090074)"
+       gradientTransform="matrix(0.35135131,0,0,0.35135131,-1.204072,15.090074)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3089"
        id="linearGradient3031"
@@ -139,7 +162,7 @@
        x2="39.441502"
        y1="23"
        x1="6.6574788"
-       gradientTransform="matrix(0,1.4285713,-1.4285713,0,56.857142,-8.857474)"
+       gradientTransform="matrix(0,1.4642856,-1.4642856,0,57.678571,-9.6785706)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3932-9"
        xlink:href="#linearGradient3907" />
@@ -186,7 +209,7 @@
        xlink:href="#linearGradient4011"
        id="linearGradient3993-0-6-0-8-5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945943,0,0,-0.45945945,-8.958641,35.64979)"
+       gradientTransform="matrix(0.45945943,0,0,-0.45945945,-8.9586408,35.64979)"
        x1="71.204407"
        y1="6.2375584"
        x2="71.204407"
@@ -208,29 +231,28 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
      id="g4198-4-0"
-     transform="matrix(0.70833333,0,0,0.71428273,1.33333,0.784605)"
-     style="stroke-width:1.40587306">
+     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.784605)"
+     style="stroke-width:1.40587">
     <path
        d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6-9"
-       style="opacity:0.2;fill:url(#radialGradient3300-8-3);fill-opacity:1;stroke:none;stroke-width:1.40587306" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8-3);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       style="opacity:0.4;fill:url(#radialGradient4192-6-5);fill-opacity:1;stroke:none;stroke-width:1.40587306"
+       style="opacity:0.4;fill:url(#radialGradient4192-6-5);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2-3"
        d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
-     d="M 24.000705,3.999669 C 12.954663,3.999669 4,12.954634 4,23.999416 4,35.04521 12.954758,43.999667 24.000705,43.999667 35.046251,43.999667 44,35.04521 44,23.999416 44,12.954634 35.046251,3.999669 24.000705,3.999669 Z"
+     d="m 24.000723,3.500001 c -11.322193,0 -20.5007228,9.178839 -20.5007228,20.499741 0,11.321939 9.1786268,20.500257 20.5007228,20.500257 C 35.322407,44.499999 44.5,35.321681 44.5,23.999742 44.5,12.67884 35.322407,3.500001 24.000723,3.500001 Z"
      id="path3902-8"
      style="fill:url(#linearGradient3932-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1" />
   <path
-     d="m 43.5,23.998975 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 -10.769649,0 -19.5002474,-8.730889 -19.5002474,-19.50069 0,-10.769402 8.7305984,-19.499308 19.5002474,-19.499308 C 34.76891,4.499667 43.5,13.229573 43.5,23.998975 Z"
+     d="m 43.5,23.998975 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 -10.769649,0 -19.5002472,-8.730889 -19.5002472,-19.50069 0,-10.769402 8.7305982,-19.499308 19.5002472,-19.499308 C 34.76891,4.499667 43.5,13.229573 43.5,23.998975 Z"
      id="path8655-9"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3111-7);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
@@ -238,22 +260,22 @@
      id="path8655-1-6-9-4-8-2"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3993-0-6-0-8-5);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 24.000003,3.499665 c -11.311193,0 -20.5000034,9.188806 -20.5000034,20.5 0,11.311194 9.1888104,20.500005 20.5000034,20.500002 11.311188,0 20.500008,-9.188808 20.499997,-20.500002 0,-11.311194 -9.188809,-20.5 -20.499997,-20.5 z"
+     d="m 24.000003,3.499665 c -11.311193,0 -20.5000032,9.188806 -20.5000032,20.5 0,11.311194 9.1888102,20.500005 20.5000032,20.500002 11.311188,0 20.500008,-9.188808 20.499997,-20.500002 0,-11.311194 -9.188809,-20.5 -20.499997,-20.5 z"
      id="path2555-6-6"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <g
      id="g999"
      transform="translate(-601,110.99967)" />
   <path
-     style="fill:url(#linearGradient1006);stroke:url(#linearGradient3039);stroke-width:1.00365412;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;fill-opacity:1"
+     style="fill:url(#linearGradient1006);fill-opacity:1;stroke:url(#linearGradient3039);stroke-width:1.00365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
      id="path2555-3"
      d="m 24,16.500966 c -4.1372,0 -7.4982,3.361 -7.4982,7.4982 0,4.1372 3.361,7.4982 7.4982,7.4982 4.1372,0 7.4982,-3.361 7.4982,-7.4982 0,-4.1372 -3.361,-7.4982 -7.4982,-7.4982 z" />
   <path
-     style="color:#000000;opacity:0.5;fill:none;stroke:url(#linearGradient3031);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate"
+     style="color:#000000;opacity:0.5;fill:none;stroke:url(#linearGradient3031);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;enable-background:accumulate"
      id="path8655-6"
      d="m 30.5,23.998966 c 0,3.5896 -2.9104,6.5 -6.5,6.5 -3.5898,0 -6.5,-2.9104 -6.5,-6.5 0,-3.59 2.9102,-6.5 6.5,-6.5 3.5896,0 6.5,2.91 6.5,6.5 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#linearGradient3101);fill-opacity:1;stroke:none;stroke-width:0.35012755;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#linearGradient3101);fill-opacity:1;stroke:none;stroke-width:0.350128;marker:none;enable-background:accumulate"
      id="path3220"
      d="m 28,21.998966 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" />
 </svg>


### PR DESCRIPTION


The 48px media-record icon was updated in a192e78 ([ref to media-record](https://github.com/elementary/icons/commit/a192e7847c3b1fe2a98c81befd966ac084b6f183#diff-701885c65f2e4ed3ef3eaa7f30dd44303fd31caa20e8796b1a58d509d7d7f2c3)) to be a little brighter and user the newer palette.

This updates the other sizes to give the same look. Also updates shadows and switches to semi-transparent borders for sharper look, especially in dark themes.