### PR TITLE
Actions: Add some semi-transparent borders

### DIFF
--- a/actions/16/document-page-setup.svg
+++ b/actions/16/document-page-setup.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg3963">
+   id="svg3963"
+   sodipodi:docname="document-page-setup.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65756"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="35.532116"
+     inkscape:cx="4.7421887"
+     inkscape:cy="6.5011608"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="349"
+     inkscape:window-y="179"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3963" />
   <defs
      id="defs3965">
     <linearGradient
@@ -20,7 +43,7 @@
        id="linearGradient3138"
        xlink:href="#linearGradient3985-6-635-120-628-965"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.57418708,0,0,0.57270135,-100.42477,-7.1792409)" />
+       gradientTransform="matrix(0.57418708,0,0,0.57270135,-101.42477,-6.3175347)" />
     <linearGradient
        id="linearGradient3985-6-635-120-628-965">
       <stop
@@ -40,7 +63,7 @@
        id="linearGradient3168"
        xlink:href="#linearGradient3985-746-156-539-972"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.44035822,0,0,0.44035823,-76.20947,-3.1464798)" />
+       gradientTransform="matrix(0.44035822,0,0,0.44035823,-76.20947,-3.1465504)" />
     <linearGradient
        id="linearGradient3985-746-156-539-972">
       <stop
@@ -53,15 +76,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336"
-       id="linearGradient3143"
-       xlink:href="#linearGradient3600"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.31428714,0,0,0.3259265,0.457108,-0.32223804)" />
-    <linearGradient
        id="linearGradient3600">
       <stop
          id="stop3602"
@@ -70,54 +84,6 @@
       <stop
          id="stop3604"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3145"
-       xlink:href="#linearGradient3104"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
-    <linearGradient
-       id="linearGradient3104">
-      <stop
-         id="stop3106"
-         style="stop-color:#a0a0a0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3108"
-         style="stop-color:#bebebe;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.99999"
-       y1="5.5641499"
-       x2="23.99999"
-       y2="43"
-       id="linearGradient3988"
-       xlink:href="#linearGradient3977"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)" />
-    <linearGradient
-       id="linearGradient3977">
-      <stop
-         id="stop3979"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3981"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03626217" />
-      <stop
-         id="stop3983"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3985"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -140,6 +106,63 @@
        xlink:href="#linearGradient3104-5"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.32160807,0,0,0.3333374,-0.1751469,-0.34907707)" />
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128978,-0.68549001)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428717,0.23259179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621626,-0.43244101)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-9"
+       id="linearGradient3988-8"
+       y2="41.589603"
+       x2="23.99999"
+       y1="6.2052388"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977-9">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7" />
+      <stop
+         offset="0.02929282"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-3" />
+      <stop
+         offset="0.97230476"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3968">
@@ -149,42 +172,45 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <path
+     d="m 2.999999,0.99998698 c 2.2915074,0 9.999988,8.9042e-4 9.999988,8.9042e-4 l 1.2e-5,13.9991086 c 0,0 -6.6666668,0 -10,0 0,-4.666665 0,-9.3333326 0,-13.99999902 z"
+     id="path4160-2"
+     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none" />
+  <path
+     d="M 12.499999,14.499986 H 3.4999989 V 1.499987 h 9.0000001 z"
+     id="rect6741-1-9"
+     style="fill:none;stroke:url(#linearGradient3988-8);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 2.4999611,0.49996099 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909801 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 1e-7,-15.00005201 z"
+     id="path4160-8"
+     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <g
-     id="layer1">
-    <g
-       id="layer1-0">
-      <path
-         d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.0000759,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
-         id="path4160"
-         style="fill:url(#linearGradient3143);fill-opacity:1;stroke:url(#linearGradient3145);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-      <path
-         d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z"
-         id="rect6741-1"
-         style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <path
-         d="m 4.0000001,3.499995 0.7537691,0 z m 0.8643219,0 0.703517,0 z m 0.8140698,0 0.6231156,0 z m 0.7236186,0 0.2713566,0 z m 0.3819095,0 0.603015,0 z m 0.7236186,0 1.5879395,0 z m 1.6884415,0 1.216081,0 z m 1.316584,0 0.371858,0 z m -6.5125639,0.994817 0.9949753,0 z m 1.0954773,0 1.6281406,0 z m 1.7286437,0 0.7939702,0 z m 0.8944722,0 0.7437182,0 z m 0.8442213,0 0.6331654,0 z m 0.7336684,0 0.994975,0.010376 z m 1.085427,0.010376 1.61809,0 z M 4.0000001,5.5 l 0.5125628,0 z m 0.6733666,0 1.8994984,0 z m -0.6733666,1.9947954 0.9949753,0 z m 1.0954773,0 1.6281406,0 z m 1.7286437,0 0.7939702,0 z m 0.8944722,0 0.7437182,0 z m 0.8442213,0 0.6331654,0 z m 0.7336684,0 0.994975,0.010376 z m 1.085427,0.010376 1.61809,0 z M 4.0000001,8.5 l 0.7537691,0 z m 0.8643219,0 0.6934672,0 z m 0.8140698,0 0.6231156,0 z m 0.7236186,0 0.2713566,0 z m 0.3819095,0 0.603015,0 z m 0.7236186,0 1.5778887,0 z m 1.6884415,0 1.206031,0 z m 1.306533,0 0.381909,0 z m 0.482412,0 0.904523,0 z m -6.9849249,1 1.1758797,0 z m 1.3065331,0 0.5628138,0 z m 0.6633158,0 0.2814074,0 z m 0.3919602,0 0.5125629,0 z m 0.6231157,0 0.5226136,0 z m 0.6231156,0 0.8341715,0 z m 0.9447243,0 1.0854264,0 z m 1.1859294,0 0.7236178,0 z m 0.8241208,0 0.180904,0 z m -6.5628149,1.994804 0.9949753,0 z m 1.0954773,0 1.6281406,0 z m 1.7286437,0 0.7939702,0 z m 0.8944722,0 0.7437182,0 z m 0.8442213,0 0.6331654,0 z m 0.7336684,0 0.994975,0.01038 z m 1.085427,0.01038 1.61809,0 z M 4.0000001,12.5 l 1.2462313,0 z m 1.3567841,0 0.3919602,0 z m 0.4924622,0 0.8944722,0 z m 0.9949753,0 1.3165828,0 z m 1.4271356,0 0.8944723,0 z m 0.9849245,0 0.1909552,0 z m 0.2914572,0 1.135678,0 z m 1.256282,0 0.592964,0 z m -6.8040209,1 1.2462313,0 z m 1.3567841,0 0.5628138,0 z m 0.6633168,0 0.8844215,0 z m 0.9849245,0 0.954774,0 z m 1.0653268,0 0.3819094,0 z m 0.4824125,0 0.2110548,0 z m 0.3216076,0 0.5929652,0 z"
-         id="path3475"
-         style="fill:none;stroke:url(#linearGradient3961);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </g>
+     id="layer1-0">
     <path
-       d="M 0.50000002,2.5 11.5,13.5 0.50000002,13.5 z M 3,8.972375 3,11 5.0276245,11 z"
-       id="path3410"
-       style="color:#000000;fill:#81d72c;fill-opacity:0.58823529;fill-rule:evenodd;stroke:#4e9a06;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 1.5,4.8327372 c 0,2.5962789 0,5.0709828 0,7.6672628 2.5962772,0 5.0709871,0 7.6672633,0 C 9.1672633,12.5 1.5,4.8327372 1.5,4.8327372 z"
-       id="path3981"
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3168);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       d="M 2.5,7.1382939 2.5,11.5 l 3.9630656,0"
-       id="path3981-5"
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3138);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       d="m 2.4999545,14.5 9.0000915,0"
-       id="path3853"
-       style="opacity:0.3;fill:none;stroke:#85f619;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+       d="m 4.0000001,3.499995 h 0.7537691 z m 0.8643219,0 h 0.703517 z m 0.8140698,0 h 0.6231156 z m 0.7236186,0 H 6.673367 Z m 0.3819095,0 h 0.603015 z m 0.7236186,0 H 9.095478 Z m 1.6884415,0 h 1.216081 z m 1.316584,0 h 0.371858 z M 4.0000001,4.494812 h 0.9949753 z m 1.0954773,0 H 6.723618 Z m 1.7286437,0 h 0.7939702 z m 0.8944722,0 h 0.7437182 z m 0.8442213,0 H 9.19598 Z m 0.7336684,0 0.994975,0.010376 z M 10.38191,4.505188 H 12 Z M 4.0000001,5.5 h 0.5125628 z m 0.6733666,0 H 6.5728651 Z M 4.0000001,7.4947954 h 0.9949753 z m 1.0954773,0 H 6.723618 Z m 1.7286437,0 h 0.7939702 z m 0.8944722,0 h 0.7437182 z m 0.8442213,0 H 9.19598 Z m 0.7336684,0 0.994975,0.010376 z m 1.085427,0.010376 H 12 Z M 4.0000001,8.5 h 0.7537691 z m 0.8643219,0 h 0.6934672 z m 0.8140698,0 h 0.6231156 z m 0.7236186,0 H 6.673367 Z m 0.3819095,0 h 0.603015 z m 0.7236186,0 h 1.5778887 z m 1.6884415,0 h 1.206031 z m 1.306533,0 h 0.381909 z m 0.482412,0 h 0.904523 z m -6.9849249,1 h 1.1758797 z m 1.3065331,0 H 5.869347 Z m 0.6633158,0 h 0.2814074 z m 0.3919602,0 h 0.5125629 z m 0.6231157,0 h 0.5226136 z m 0.6231156,0 H 8.442212 Z m 0.9447243,0 h 1.0854264 z m 1.1859294,0 h 0.7236178 z m 0.8241208,0 h 0.180904 z m -6.5628149,1.994804 h 0.9949753 z m 1.0954773,0 H 6.723618 Z m 1.7286437,0 h 0.7939702 z m 0.8944722,0 h 0.7437182 z m 0.8442213,0 H 9.19598 Z m 0.7336684,0 0.994975,0.01038 z m 1.085427,0.01038 H 12 Z M 4.0000001,12.5 h 1.2462313 z m 1.3567841,0 h 0.3919602 z m 0.4924622,0 h 0.8944722 z m 0.9949753,0 h 1.3165828 z m 1.4271356,0 h 0.8944723 z m 0.9849245,0 H 9.447237 Z m 0.2914572,0 h 1.135678 z m 1.256282,0 h 0.592964 z m -6.8040209,1 h 1.2462313 z m 1.3567841,0 H 5.919598 Z m 0.6633168,0 h 0.8844215 z m 0.9849245,0 h 0.954774 z m 1.0653268,0 h 0.3819094 z m 0.4824125,0 h 0.2110548 z m 0.3216076,0 h 0.5929652 z"
+       id="path3475"
+       style="fill:none;stroke:url(#linearGradient3961);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
+  <path
+     d="m 0.5,2.4999293 11,10.9999997 H 0.5 Z M 2.5,8 v 2.5 H 5 Z"
+     id="path3410"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#9bdb4d;fill-opacity:0.996697;fill-rule:evenodd;stroke:#206b00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.55;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     d="m 1.5,4.9 v 7.599929 h 7.6 z"
+     id="path3981"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3168);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     sodipodi:nodetypes="cccc" />
+  <path
+     d="m 1.5,8 v 4.5 H 6"
+     id="path3981-5"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3138);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     sodipodi:nodetypes="ccc" />
+  <path
+     d="m 2.499955,14.499929 h 9.000091"
+     id="path3853"
+     style="opacity:0.3;fill:none;stroke:#85f619;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
 </svg>

--- a/actions/16/edit-copy.svg
+++ b/actions/16/edit-copy.svg
@@ -4,23 +4,37 @@
    height="16"
    width="16"
    version="1.1"
+   sodipodi:docname="edit-copy.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview312"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="4.6403882"
+     inkscape:cy="8.7946406"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="186"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3375" />
   <defs
      id="defs3377">
-    <linearGradient
-       gradientTransform="matrix(0.18918906,0,0,0.24324323,5.4591875,3.162165)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977-8"
-       id="linearGradient3069"
-       y2="40.444435"
-       x2="23.99999"
-       y1="7.5555444"
-       x1="23.99999" />
     <linearGradient
        id="linearGradient3977-8">
       <stop
@@ -41,15 +55,6 @@
          id="stop3985-4" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.25714449,0,0,0.23901336,3.8285322,2.897003)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-4-4"
-       id="linearGradient3072"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
-    <linearGradient
        id="linearGradient3600-4-4">
       <stop
          offset="0"
@@ -61,93 +66,74 @@
          id="stop3604-6-0" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.20764335,0,0,0.2236809,19.105546,2.630629)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5-8"
-       id="linearGradient3074"
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404" />
-    <linearGradient
-       id="linearGradient3104-5-8">
-      <stop
-         offset="0"
-         style="stop-color:#a0a0a0;stop-opacity:1"
-         id="stop3106-6-6" />
-      <stop
-         offset="1"
-         style="stop-color:#bebebe;stop-opacity:1"
-         id="stop3108-9-8" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.18918906,0,0,0.24324323,1.4591872,0.16216496)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977-8-8"
-       id="linearGradient3069-8"
-       y2="40.444435"
-       x2="23.99999"
+       x1="23.99999"
        y1="7.5555444"
-       x1="23.99999" />
-    <linearGradient
-       id="linearGradient3977-8-8">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979-4-3" />
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981-3-1" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983-1-8" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985-4-9" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600-4-4-4">
-      <stop
-         offset="0"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7-3-3" />
-      <stop
-         offset="1"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6-0-3" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3104-5-8-8">
-      <stop
-         offset="0"
-         style="stop-color:#a0a0a0;stop-opacity:1"
-         id="stop3106-6-6-60" />
-      <stop
-         offset="1"
-         style="stop-color:#bebebe;stop-opacity:1"
-         id="stop3108-9-8-4" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.25714449,0,0,0.23901336,-0.1714682,-0.10299704)"
+       x2="23.99999"
+       y2="40.444435"
+       id="linearGradient3069-3"
+       xlink:href="#linearGradient3977-8"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-4-4-4"
-       id="linearGradient3371"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
+       gradientTransform="matrix(0.18918906,0,0,0.24324323,5.4591872,3.162165)" />
     <linearGradient
-       gradientTransform="matrix(0.20764335,0,0,0.2236809,15.105546,-0.36937104)"
+       gradientTransform="matrix(0.20764343,0,0,0.22368116,19.105551,2.6306276)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5-8-8"
-       id="linearGradient3373"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
        y2="2.9062471"
        x2="-51.786404"
        y1="50.786446"
        x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3600-4-4"
+       id="linearGradient2063"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857087,0,0,0.21728333,4.5142984,3.4518602)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3600-4-4"
+       id="linearGradient3947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857087,0,0,0.21728333,0.51429834,0.45186025)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3949"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20764343,0,0,0.22368116,15.105551,-0.3693719)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3977-8"
+       id="linearGradient10311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18918906,0,0,0.24324323,1.4591875,0.16216499)"
+       x1="23.99999"
+       y1="7.5555444"
+       x2="23.99999"
+       y2="40.444435" />
   </defs>
   <metadata
      id="metadata3380">
@@ -161,23 +147,29 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="m 1.499961,0.49996096 c 2.0623745,0 9.000067,7.12e-4 9.000067,7.12e-4 l 1.2e-5,10.99936604 c 0,0 -6.0000528,0 -9.000079,0 0,-3.66669 0,-7.333378 0,-11.00006704 z"
-     id="path4160-3-9-8"
-     style="display:inline;fill:url(#linearGradient3371);fill-opacity:1;stroke:url(#linearGradient3373);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="display:inline;fill:url(#linearGradient3947);fill-opacity:1;stroke:none;stroke-width:0.999921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.345098"
+     id="path2061-7"
+     d="m 2,1 c 1.8332053,0 7.9999894,6.473e-4 7.9999894,6.473e-4 L 10,11 C 10,11 4.6666667,11 2,11 2,7.6666691 2,4.33334 2,1.00001 Z" />
   <path
-     d="m 9.4999998,10.5 -7.0000001,0 0,-9 7.0000001,0 z"
-     id="rect6741-1-2-8"
-     style="fill:none;stroke:url(#linearGradient3069-8);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="fill:none;stroke:url(#linearGradient10311);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path10309"
+     d="M 9.5000003,10.5 H 2.5 v -9 h 7.0000003 z" />
   <path
-     d="m 4,2 c 1.6040548,0 6.999992,6.68e-4 6.999992,6.68e-4 L 11,12 C 11,12 6.3333332,12 4,12 4,8.666675 4,5.333352 4,2.000029 Z"
-     id="path4160-3-9-6"
-     style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none" />
+     style="font-variation-settings:normal;display:inline;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3949);stroke-width:0.999923;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     id="path4160-3-9-9-5"
+     d="m 1.4999615,0.4999615 9.0000665,7.12e-4 1.2e-5,10.9993655 H 1.4999615 V 0.4999725 Z"
+     sodipodi:nodetypes="cccccc" />
   <path
-     d="m 5.4999613,3.499961 c 2.0623745,0 9.0000667,7.12e-4 9.0000667,7.12e-4 l 1.2e-5,10.999366 c 0,0 -6.0000525,0 -9.0000787,0 0,-3.66669 0,-7.333378 0,-11.000067 z"
-     id="path4160-3-9"
-     style="display:inline;fill:url(#linearGradient3072);fill-opacity:1;stroke:url(#linearGradient3074);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="display:inline;fill:url(#linearGradient2063);fill-opacity:1;stroke:none;stroke-width:0.999921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.345098"
+     id="path2061"
+     d="m 6,4 c 1.8332053,0 7.999989,6.473e-4 7.999989,6.473e-4 L 14,14 c 0,0 -5.3333332,0 -8,0 0,-3.333331 0,-6.66666 0,-9.99999 z" />
   <path
-     d="m 13.5,13.5 -7,0 0,-9 7,0 z"
-     id="rect6741-1-2"
-     style="fill:none;stroke:url(#linearGradient3069);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3019);stroke-width:0.999923;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path4160-3-9-9"
+     d="m 5.499961,3.499961 9.000067,7.12e-4 1.2e-5,10.999366 H 5.499961 V 3.499972 Z"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3069-3);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1-2-1"
+     d="M 13.5,13.5 H 6.4999997 v -9 H 13.5 Z" />
 </svg>

--- a/actions/16/edit-cut.svg
+++ b/actions/16/edit-cut.svg
@@ -1,39 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg4296">
+   id="svg4296"
+   sodipodi:docname="edit-cut.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview13563"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="8.883029"
+     inkscape:cx="-9.0059371"
+     inkscape:cy="9.3436597"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="640"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs4298">
-    <linearGradient
-       id="linearGradient3810">
-      <stop
-         id="stop3812"
-         style="stop-color:#a60101;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3814"
-         style="stop-color:#5f0101;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3774">
-      <stop
-         id="stop3776"
-         style="stop-color:#444444;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3778"
-         style="stop-color:#9e9e9e;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient3764">
       <stop
@@ -45,235 +46,6 @@
          style="stop-color:#eaeaea;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient2264">
-      <stop
-         id="stop2266"
-         style="stop-color:#d7e866;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2268"
-         style="stop-color:#8cab2a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="24.481066"
-       y1="5.0808945"
-       x2="24.481066"
-       y2="45.074459"
-       id="linearGradient2494"
-       xlink:href="#linearGradient3781"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5384199,0,0,0.5384199,-0.922077,-1.4604985)" />
-    <linearGradient
-       id="linearGradient3781">
-      <stop
-         id="stop3783"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3785"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="63.397362"
-       y1="-12.489107"
-       x2="63.397362"
-       y2="5.4675598"
-       id="linearGradient2497"
-       xlink:href="#linearGradient4873"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0862728,0,0,1.0862481,-55.56661,15.813638)" />
-    <linearGradient
-       id="linearGradient4873">
-      <stop
-         id="stop4875"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4877"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.895569"
-       cy="3.9900031"
-       r="20.397499"
-       fx="23.895569"
-       fy="3.9900031"
-       id="radialGradient2500"
-       xlink:href="#linearGradient3242"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.2316137,-1.6257082,0,18.486581,-28.720783)" />
-    <linearGradient
-       id="linearGradient3242">
-      <stop
-         id="stop3244"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="18.379412"
-       y1="44.980297"
-       x2="18.379412"
-       y2="3.0816143"
-       id="linearGradient2502"
-       xlink:href="#linearGradient2490"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5160413,0,0,0.5160413,-0.384991,-0.3849911)" />
-    <linearGradient
-       id="linearGradient2490">
-      <stop
-         id="stop2492"
-         style="stop-color:#791235;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#dd3b27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="62.625"
-       cy="4.625"
-       r="10.625"
-       fx="62.625"
-       fy="4.625"
-       id="radialGradient2478"
-       xlink:href="#linearGradient8838"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1294118,0,0,0.2823525,-58.729414,19.694118)" />
-    <linearGradient
-       id="linearGradient8838">
-      <stop
-         id="stop8840"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8842"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="12"
-       cy="15.166395"
-       r="4.0006957"
-       fx="12"
-       fy="15.166395"
-       id="radialGradient4039"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.55698928,1.3924728,-2.4995652,-0.99982634,32.648616,1040.5691)" />
-    <radialGradient
-       cx="14.999991"
-       cy="1039.7"
-       r="3.5266583"
-       fx="14.999991"
-       fy="1039.7"
-       id="radialGradient4053"
-       xlink:href="#linearGradient3764"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.56710644,-1.1342033,-1.7012993,0.85065685,1783.5334,176.41224)" />
-    <linearGradient
-       x1="17"
-       y1="1042.3622"
-       x2="15"
-       y2="1038.3622"
-       id="linearGradient4055"
-       xlink:href="#linearGradient3774"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,21.186157,2.4649363)" />
-    <radialGradient
-       cx="9"
-       cy="1035.5266"
-       r="4.0006957"
-       fx="9"
-       fy="1035.5266"
-       id="radialGradient4057"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.9795548,0.28278205,-0.24994327,-1.749674,285.6389,2844.6513)" />
-    <radialGradient
-       cx="14.999991"
-       cy="1039.7"
-       r="3.5266583"
-       fx="14.999991"
-       fy="1039.7"
-       id="radialGradient4061"
-       xlink:href="#linearGradient3764"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.56710644,-1.1342033,1.7012993,0.85065685,-1767.3472,176.41224)" />
-    <linearGradient
-       x1="17"
-       y1="1042.3622"
-       x2="15"
-       y2="1038.3622"
-       id="linearGradient4063"
-       xlink:href="#linearGradient3774"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-4.9999995,2.4649363)" />
-    <radialGradient
-       cx="9"
-       cy="1035.5266"
-       r="4.0006957"
-       fx="9"
-       fy="1035.5266"
-       id="radialGradient4088"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.9795548,0.28278205,-0.24994327,-1.749674,285.6389,2844.6513)" />
-    <radialGradient
-       cx="9"
-       cy="1035.5266"
-       r="4.0006957"
-       fx="9"
-       fy="1035.5266"
-       id="radialGradient4090"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.9795548,0.28278205,-0.24994327,-1.749674,285.6389,2844.6513)" />
-    <radialGradient
-       cx="9"
-       cy="1035.5266"
-       r="4.0006957"
-       fx="9"
-       fy="1035.5266"
-       id="radialGradient4093"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.9795548,0.28278205,-0.24994327,-1.749674,272.81602,2844.3414)" />
-    <radialGradient
-       cx="9"
-       cy="1035.5266"
-       r="4.0006957"
-       fx="9"
-       fy="1035.5266"
-       id="radialGradient4096"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.4136868,0.20263254,-0.17849544,-1.2537602,203.0431,2343.7642)" />
-    <radialGradient
-       cx="9"
-       cy="1035.5266"
-       r="4.0006957"
-       fx="9"
-       fy="1035.5266"
-       id="radialGradient4100"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4136868,0.20263254,0.17849544,-1.2537602,-186.98775,2343.7642)" />
     <radialGradient
        cx="14.999991"
        cy="1039.7"
@@ -284,51 +56,6 @@
        xlink:href="#linearGradient3764"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-0.56710644,-1.1342033,-1.7012993,0.85065685,1784.0587,176.41224)" />
-    <linearGradient
-       x1="17"
-       y1="1042.3622"
-       x2="15"
-       y2="1038.3622"
-       id="linearGradient4106"
-       xlink:href="#linearGradient3774"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,21.71146,2.4649363)" />
-    <radialGradient
-       cx="14.999991"
-       cy="1039.7"
-       r="3.5266583"
-       fx="14.999991"
-       fy="1039.7"
-       id="radialGradient4110"
-       xlink:href="#linearGradient3764"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.56710644,-1.1342033,1.7012993,0.85065685,-1767.1587,176.41224)" />
-    <linearGradient
-       x1="17"
-       y1="1042.3622"
-       x2="15"
-       y2="1038.3622"
-       id="linearGradient4112"
-       xlink:href="#linearGradient3774"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-4.8114602,2.4649363)" />
-    <linearGradient
-       x1="6"
-       y1="11"
-       x2="4"
-       y2="15"
-       id="linearGradient3817"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       x1="6"
-       y1="11"
-       x2="4"
-       y2="15"
-       id="linearGradient3822"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,16.0004,1036.3622)" />
     <radialGradient
        cx="14.999991"
        cy="1039.7"
@@ -339,24 +66,6 @@
        xlink:href="#linearGradient3764"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.56710644,-1.1342033,1.7012993,0.85065685,-1767.9332,176.41224)" />
-    <linearGradient
-       x1="17"
-       y1="1042.3622"
-       x2="15"
-       y2="1038.3622"
-       id="linearGradient3828"
-       xlink:href="#linearGradient3774"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-5.585923,2.4649363)" />
-    <linearGradient
-       x1="6"
-       y1="11"
-       x2="4"
-       y2="15"
-       id="linearGradient3044"
-       xlink:href="#linearGradient3810"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,16.000399,1036.3622)" />
   </defs>
   <metadata
      id="metadata4301">
@@ -366,7 +75,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -376,19 +84,19 @@
     <path
        d="m 7.5,1044.8622 5.5,-7.5 c 0,0 3.012802,6.2915 -5.3744632,10 z"
        id="path3824"
-       style="fill:url(#radialGradient3826);fill-opacity:1;stroke:url(#linearGradient3828);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="fill:url(#radialGradient3826);fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.40000001" />
     <path
        d="M 8.5405904,1044.8622 3,1037.3622 c 0,0 -2.80608422,6.4945 5.5,10 z"
        id="path4102"
-       style="fill:url(#radialGradient4104);fill-opacity:1;stroke:url(#linearGradient4106);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="fill:url(#radialGradient4104);fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.40000001" />
     <path
        d="m 3.1623616,12.837639 c 0.7220462,-1.600995 1.92432,-1.608588 2.6217712,-0.878229 0.2822879,1.081181 -0.2393877,1.642526 -0.9464944,1.878229 -0.7071068,0.235702 -1.6752768,-0.254644 -1.6752768,-1 z M 5.1707033,10.5 C 4.1849083,10.553 1.5,11.145 1.5,13 c 0,2.12 1.6175168,2.5024 2.5548536,2.5 C 4.9921904,15.5 7.4636365,14.8643 7.5,12.7149 7.528987,11.0015 5.9721355,10.6055 5.4831412,10.5 c -0.061124,-0.013 -0.17161,-0.01 -0.3124379,0 z"
        transform="translate(0,1036.3622)"
        id="path3041"
-       style="fill:#ee5050;fill-opacity:1;stroke:url(#linearGradient3817);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+       style="fill:#ed5353;fill-opacity:1;stroke:#7a0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:0.80000001" />
     <path
        d="m 12.838038,1049.1998 c -0.722046,-1.601 -1.92432,-1.6085 -2.621771,-0.8782 -0.282288,1.0812 0.239387,1.6425 0.946494,1.8782 0.707107,0.2357 1.675277,-0.2546 1.675277,-1 z m -2.008342,-2.3376 c 0.985795,0.053 3.670703,0.645 3.670703,2.5 0,2.12 -1.617516,2.5024 -2.554853,2.5 -0.937337,0 -3.4087831,-0.6357 -3.4451466,-2.7851 -0.028987,-1.7134 1.5278646,-2.1094 2.0168586,-2.2149 0.06112,-0.013 0.17161,-0.01 0.312438,0 z"
        id="path3042"
-       style="fill:#ee5050;fill-opacity:1;stroke:url(#linearGradient3044);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+       style="fill:#ed5353;fill-opacity:1;stroke:#7a0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:0.80000001" />
   </g>
 </svg>

--- a/actions/24/edit-cut.svg
+++ b/actions/24/edit-cut.svg
@@ -1,37 +1,60 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="24"
    height="24"
-   id="svg4296">
+   id="svg4296"
+   sodipodi:docname="edit-cut.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview38593"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.844039"
+     inkscape:cx="18.448099"
+     inkscape:cy="18.490315"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="568"
+     inkscape:window-y="1"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4011" />
   <defs
      id="defs4298">
     <linearGradient
-       id="linearGradient3810">
+       id="linearGradient51694">
       <stop
-         id="stop3812"
-         style="stop-color:#a60101;stop-opacity:1"
+         id="stop51690"
+         style="stop-color:#000000;stop-opacity:0.56;"
          offset="0" />
       <stop
-         id="stop3814"
-         style="stop-color:#5f0101;stop-opacity:1"
+         id="stop51692"
+         style="stop-color:#000000;stop-opacity:0.36000001;"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3774">
+       id="linearGradient39137">
       <stop
-         id="stop3776"
-         style="stop-color:#444444;stop-opacity:1"
+         id="stop39133"
+         style="stop-color:#7a0000;stop-opacity:0.60000002;"
          offset="0" />
       <stop
-         id="stop3778"
-         style="stop-color:#9e9e9e;stop-opacity:1"
+         id="stop39135"
+         style="stop-color:#7a0000;stop-opacity:0.80000001;"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -61,7 +84,7 @@
        x2="15"
        y2="1038.3622"
        id="linearGradient3780"
-       xlink:href="#linearGradient3774"
+       xlink:href="#linearGradient51694"
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(1,-2.0000083)" />
     <radialGradient
@@ -80,7 +103,7 @@
        x2="15"
        y2="1038.3622"
        id="linearGradient3786"
-       xlink:href="#linearGradient3774"
+       xlink:href="#linearGradient51694"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-1,0,0,1,23.053316,-2.0000083)" />
     <radialGradient
@@ -90,7 +113,7 @@
        fx="12"
        fy="15.166395"
        id="radialGradient3816"
-       xlink:href="#linearGradient3810"
+       xlink:href="#linearGradient39137"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-0.55698928,1.3924728,-2.4995652,-0.99982634,57.593265,1041.8163)" />
     <radialGradient
@@ -100,119 +123,9 @@
        fx="9"
        fy="1035.5266"
        id="radialGradient3824"
-       xlink:href="#linearGradient3810"
+       xlink:href="#linearGradient39137"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.9795548,0.28278205,-0.24994327,-1.749674,285.6389,2844.6513)" />
-    <linearGradient
-       id="linearGradient2264">
-      <stop
-         id="stop2266"
-         style="stop-color:#d7e866;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2268"
-         style="stop-color:#8cab2a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="24.481066"
-       y1="5.0808945"
-       x2="24.481066"
-       y2="45.074459"
-       id="linearGradient2494"
-       xlink:href="#linearGradient3781"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5384199,0,0,0.5384199,-0.922077,-1.4604985)" />
-    <linearGradient
-       id="linearGradient3781">
-      <stop
-         id="stop3783"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3785"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="63.397362"
-       y1="-12.489107"
-       x2="63.397362"
-       y2="5.4675598"
-       id="linearGradient2497"
-       xlink:href="#linearGradient4873"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0862728,0,0,1.0862481,-55.56661,15.813638)" />
-    <linearGradient
-       id="linearGradient4873">
-      <stop
-         id="stop4875"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4877"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.895569"
-       cy="3.9900031"
-       r="20.397499"
-       fx="23.895569"
-       fy="3.9900031"
-       id="radialGradient2500"
-       xlink:href="#linearGradient3242"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.2316137,-1.6257082,0,18.486581,-28.720783)" />
-    <linearGradient
-       id="linearGradient3242">
-      <stop
-         id="stop3244"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="18.379412"
-       y1="44.980297"
-       x2="18.379412"
-       y2="3.0816143"
-       id="linearGradient2502"
-       xlink:href="#linearGradient2490"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5160413,0,0,0.5160413,-0.384991,-0.3849911)" />
-    <linearGradient
-       id="linearGradient2490">
-      <stop
-         id="stop2492"
-         style="stop-color:#791235;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#dd3b27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="62.625"
-       cy="4.625"
-       r="10.625"
-       fx="62.625"
-       fy="4.625"
-       id="radialGradient2478"
-       xlink:href="#linearGradient8838"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1294118,0,0,0.2823525,-58.729414,19.694118)" />
+       gradientTransform="matrix(-1.9795548,0.28278205,-0.24994327,-1.749674,286.6389,2852.6513)" />
     <linearGradient
        id="linearGradient8838">
       <stop
@@ -224,43 +137,6 @@
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="24.481066"
-       y1="5.0808945"
-       x2="24.481066"
-       y2="45.074459"
-       id="linearGradient3975"
-       xlink:href="#linearGradient3781"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5384199,0,0,0.5384199,-44.014327,1034.0991)" />
-    <linearGradient
-       x1="63.397362"
-       y1="-12.489107"
-       x2="63.397362"
-       y2="5.4675598"
-       id="linearGradient3978"
-       xlink:href="#linearGradient4873"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0862728,0,0,1.0862481,-98.65886,1051.3732)" />
-    <radialGradient
-       cx="23.895569"
-       cy="3.9900031"
-       r="20.397499"
-       fx="23.895569"
-       fy="3.9900031"
-       id="radialGradient3981"
-       xlink:href="#linearGradient3242"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.2316137,-1.6257082,0,-24.605669,1006.8388)" />
-    <linearGradient
-       x1="18.379412"
-       y1="44.980297"
-       x2="18.379412"
-       y2="3.0816143"
-       id="linearGradient3983"
-       xlink:href="#linearGradient2490"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5160413,0,0,0.5160413,-43.477241,1035.1746)" />
     <radialGradient
        cx="62.625"
        cy="4.625"
@@ -290,43 +166,35 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="translate(0,-1028.3622)"
-     id="layer1">
-    <g
-       id="g4011">
-      <path
-         d="m 11.553316,1039.3622 -5.2999997,-9.8 c 0,0 -3.6999995,7.8 5.2999997,12.8 z"
-         id="path3782"
-         style="fill:url(#radialGradient3784);fill-opacity:1;stroke:url(#linearGradient3786);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         d="m 12.5,1039.3622 5.3,-9.8 c 0,0 3.7,7.8 -5.3,12.8 z"
-         id="path2990"
-         style="fill:url(#radialGradient3772);fill-opacity:1;stroke:url(#linearGradient3780);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         d="m 14,1049.3622 c 0,1.6569 -2.686291,3 -6,3 -3.3137085,0 -6,-1.3431 -6,-3 0,-1.6569 2.6862915,-3 6,-3 3.313709,0 6,1.3431 6,3 l 0,0 z"
-         id="path8836"
-         style="opacity:0.4;fill:url(#radialGradient3986);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999988;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="m 22,1049.3622 c 0,1.6569 -2.686291,3 -6,3 -3.313709,0 -6,-1.3431 -6,-3 0,-1.6569 2.686291,-3 6,-3 3.313709,0 6,1.3431 6,3 l 0,0 z"
-         id="path4007"
-         style="opacity:0.4;fill:url(#radialGradient4009);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999988;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="m 14,1042.3622 c -0.684728,0.1472 -1.54059,1.1088 -1.5,3.5 0.05092,2.9996 2.187468,4 3.5,4 1.312532,0 3.5,-1.0415 3.5,-4 0,-2.9586 -4.815272,-3.6472 -5.5,-3.5 z m 0.4375,1.875 c 0,0 5.23936,0.8914 2.25,3.125 -2.688286,2.0087 -2.25,-3.125 -2.25,-3.125 z"
-         id="path3788"
-         style="fill:#ee5050;fill-opacity:1;stroke:url(#radialGradient3816);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <g
-         transform="translate(1,7.9999917)"
-         id="g3798">
-        <path
-           d="m 8.5625,1034.3622 c -1.3803873,0.074 -5.0625,0.9112 -5.0625,3.5 0,2.9585 2.1874677,4.0034 3.5,4 1.3125323,0 3.449081,-1.0004 3.5,-4 0.04059,-2.3912 -0.815272,-3.3528 -1.5,-3.5 -0.085591,-0.018 -0.2403018,-0.011 -0.4375,0 z m 0,1.875 c 0,0 0.4382857,5.1337 -2.25,3.125 -2.9893599,-2.2336 2.25,-3.125 2.25,-3.125 z"
-           id="path3793"
-           style="fill:#ee5050;fill-opacity:1;stroke:url(#radialGradient3824);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      </g>
-    </g>
+     id="g4011"
+     transform="translate(0,-1028.3622)">
+    <path
+       d="m 11.553316,1039.3622 -5.2999997,-9.8 c 0,0 -3.6999995,7.8 5.2999997,12.8 z"
+       id="path3782"
+       style="fill:url(#radialGradient3784);fill-opacity:1;stroke:url(#linearGradient3786);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 12.5,1039.3622 5.3,-9.8 c 0,0 3.7,7.8 -5.3,12.8 z"
+       id="path2990"
+       style="fill:url(#radialGradient3772);fill-opacity:1;stroke:url(#linearGradient3780);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 14,1049.3622 c 0,1.6569 -2.686291,3 -6,3 -3.3137085,0 -6,-1.3431 -6,-3 0,-1.6569 2.6862915,-3 6,-3 3.313709,0 6,1.3431 6,3 z"
+       id="path8836"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient3986);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="m 22,1049.3622 c 0,1.6569 -2.686291,3 -6,3 -3.313709,0 -6,-1.3431 -6,-3 0,-1.6569 2.686291,-3 6,-3 3.313709,0 6,1.3431 6,3 z"
+       id="path4007"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient4009);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+    <path
+       d="m 14,1042.3622 c -0.684728,0.1472 -1.54059,1.1088 -1.5,3.5 0.05092,2.9996 2.187468,4 3.5,4 1.312532,0 3.5,-1.0415 3.5,-4 0,-2.9586 -4.815272,-3.6472 -5.5,-3.5 z m 0.4375,1.875 c 0,0 5.23936,0.8914 2.25,3.125 -2.688286,2.0087 -2.25,-3.125 -2.25,-3.125 z"
+       id="path3788"
+       style="fill:#ee5050;fill-opacity:1;stroke:url(#radialGradient3816);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 9.5625,1042.3622 c -1.3803873,0.074 -5.0625,0.9112 -5.0625,3.5 0,2.9585 2.1874677,4.0034 3.5,4 1.3125323,0 3.449081,-1.0004 3.5,-4 0.04059,-2.3912 -0.815272,-3.3528 -1.5,-3.5 -0.085591,-0.018 -0.2403018,-0.011 -0.4375,0 z m 0,1.875 c 0,0 0.438286,5.1337 -2.25,3.125 -2.9893599,-2.2336 2.25,-3.125 2.25,-3.125 z"
+       id="path3793"
+       style="fill:#ee5050;fill-opacity:1;stroke:url(#radialGradient3824);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/actions/32/document-page-setup.svg
+++ b/actions/32/document-page-setup.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg4042">
+   id="svg4042"
+   sodipodi:docname="document-page-setup.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview120480"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="6.28125"
+     inkscape:cx="13.054726"
+     inkscape:cy="8.278607"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="640"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1-0" />
   <defs
      id="defs4044">
     <linearGradient
@@ -115,7 +138,7 @@
        id="linearGradient3122"
        xlink:href="#linearGradient3600-4"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.65714319,0,0,0.63012397,0.228556,-1.0896478)" />
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
     <linearGradient
        id="linearGradient3600-4">
       <stop
@@ -125,26 +148,6 @@
       <stop
          id="stop3604-6"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3124"
-       xlink:href="#linearGradient3104-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.53064102,0,0,0.58970216,39.269585,-1.7919079)" />
-    <linearGradient
-       id="linearGradient3104-5">
-      <stop
-         id="stop3106-6"
-         style="stop-color:#a0a0a0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3108-9"
-         style="stop-color:#bebebe;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -195,6 +198,26 @@
        xlink:href="#linearGradient3104-5-4"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.72361808,0,0,0.66666603,-2.3940795,-2.198042)" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791901)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9-6"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata4047">
@@ -204,7 +227,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -228,9 +250,9 @@
          id="path2883"
          style="opacity:0.15;fill:url(#radialGradient3045);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
       <path
-         d="m 4.499961,0.49996093 c 5.270482,0 23.000037,0.00185 23.000037,0.00185 l 2.8e-5,28.99822807 c 0,0 -15.333376,0 -23.000065,0 0,-9.666692 0,-19.333383 0,-29.00007387 z"
+         d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 Z"
          id="path4160-3"
-         style="fill:url(#linearGradient3122);fill-opacity:1;stroke:url(#linearGradient3124);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+         style="display:inline;fill:url(#linearGradient3122);fill-opacity:1;stroke:none;stroke-width:0.999929;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <path
          d="m 26.5,28.5 -21,0 0,-27 21,0 z"
          id="rect6741-1"
@@ -239,6 +261,10 @@
          d="m 6.9999999,5.5 1.6959806,0 z m 1.9447253,0 1.5829128,0 z m 1.8316568,0 1.40201,0 z m 1.628142,0 0.610552,0 z m 0.859296,0 1.356785,0 z m 1.628141,0 3.572865,0 z m 3.798994,0 2.736182,0 z m 2.962311,0 0.836685,0 z m -14.6532661,1.9895805 2.2386946,0 z m 2.4648248,0 3.6633173,0 z m 3.8894473,0 1.786432,0 z m 2.012564,0 1.673366,0 z m 1.899496,0 1.424623,0 z m 1.650754,0 2.238693,0.020839 z m 2.442212,0.020839 3.640702,0 z M 6.9999999,9.5 l 1.1532667,0 z m 1.515076,0 4.2738701,0 z m -1.515076,2.989582 2.2386946,0 z m 2.4648248,0 3.6633173,0 z m 3.8894473,0 1.786432,0 z m 2.012564,0 1.673366,0 z m 1.899496,0 1.424623,0 z m 1.650754,0 2.238693,0.02084 z m 2.442212,0.02084 3.640702,0 z M 6.9999999,14.5 l 2.8492474,0 z m 3.0753781,0 3.052764,0 z m 3.278894,0 1.17588,0 z m 1.40201,0 2.871859,0 z m 3.097989,0 3.618091,0 z m 3.866834,0 1.334172,0 z m -14.7211051,2.000003 3.0979911,0 z m 3.3467341,0 3.346734,0 z m 3.572865,0 1.33417,0 z m 1.560301,0 3.143217,0 z m 3.346733,0 2.148242,0 z m 2.396985,0 0.859298,0 z m 1.085428,0 0.474874,0 z m 0.723618,0 1.334171,0 z m -16.0326641,1.999786 2.6457294,0 z m 2.9396997,0 1.2663314,0 z m 1.4924624,0 0.633166,0 z m 0.881909,0 1.153267,0 z m 1.40201,0 1.17588,0 z m 1.402011,0 1.876884,0 z m 2.125627,0 2.442211,0 z m 2.668343,0 1.628139,0 z m 1.854271,0 0.407035,0 z m -14.7663331,2.989581 2.2386946,0 z m 2.4648248,0 3.6633173,0 z m 3.8894473,0 1.786432,0 z m 2.012564,0 1.673366,0 z m 1.899496,0 1.424623,0 z m 1.650754,0 2.238693,0.02084 z m 2.442212,0.02084 3.640702,0 z M 6.9999999,23.5 l 2.8040207,0 z m 3.0527641,0 0.881912,0 z m 1.108041,0 2.012562,0 z m 2.238694,0 2.962311,0 z m 3.211054,0 2.012564,0 z m 2.21608,0 0.429648,0 z m 0.655779,0 2.555277,0 z m 2.826634,0 1.334171,0 z m -15.3090461,2 2.8040207,0 z m 3.0527641,0 1.266332,0 z m 1.492463,0 1.98995,0 z m 2.21608,0 2.148242,0 z m 2.396985,0 0.859297,0 z m 1.085427,0 0.474874,0 z m 0.723618,0 1.334171,0 z"
          id="path3475"
          style="fill:none;stroke:url(#linearGradient4040);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         d="m 4.499961,0.49996099 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.99811201 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.99995601 z"
+         id="path4160-6-1"
+         style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
     <path
        d="M 1.4999999,4.4999989 23.5,26.499998 l -22.0000001,0 z m 4.999959,12.0211451 0,4.978856 4.9788891,0 z"

--- a/actions/32/edit-copy.svg
+++ b/actions/32/edit-copy.svg
@@ -4,12 +4,35 @@
    height="32"
    width="32"
    version="1.1"
+   sodipodi:docname="edit-copy.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview106789"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="8.8830289"
+     inkscape:cx="12.158015"
+     inkscape:cy="19.025042"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="601"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1-8" />
   <defs
      id="defs5020">
     <linearGradient
@@ -68,7 +91,7 @@
        cy="486.64789"
        cx="605.71429" />
     <linearGradient
-       gradientTransform="matrix(0.48571543,0,0,0.45629666,0.3428289,8.3488617)"
+       gradientTransform="matrix(0.4571418,0,0,0.43456585,1.0285959,8.9037249)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600-4-4"
        id="linearGradient3181"
@@ -86,26 +109,6 @@
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
          id="stop3604-6-0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.39221364,0,0,0.42702571,29.199296,7.8403287)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5-8"
-       id="linearGradient3183"
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404" />
-    <linearGradient
-       id="linearGradient3104-5-8">
-      <stop
-         offset="0"
-         style="stop-color:#a0a0a0;stop-opacity:1"
-         id="stop3106-6-6" />
-      <stop
-         offset="1"
-         style="stop-color:#bebebe;stop-opacity:1"
-         id="stop3108-9-8" />
     </linearGradient>
     <linearGradient
        gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,7.6756805)"
@@ -191,7 +194,7 @@
        cy="486.64789"
        cx="605.71429" />
     <linearGradient
-       gradientTransform="matrix(0.48571543,0,0,0.45629666,0.3428289,8.3488617)"
+       gradientTransform="matrix(0.45714178,0,0,0.43456668,1.0285964,8.9037189)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600-4-4-7"
        id="linearGradient3181-4"
@@ -209,26 +212,6 @@
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
          id="stop3604-6-0-8" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.39221364,0,0,0.42702571,29.199296,7.8403287)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5-8-0"
-       id="linearGradient3183-9"
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404" />
-    <linearGradient
-       id="linearGradient3104-5-8-0">
-      <stop
-         offset="0"
-         style="stop-color:#a0a0a0;stop-opacity:1"
-         id="stop3106-6-6-6" />
-      <stop
-         offset="1"
-         style="stop-color:#bebebe;stop-opacity:1"
-         id="stop3108-9-8-8" />
     </linearGradient>
     <linearGradient
        id="linearGradient3977-8-9">
@@ -258,6 +241,36 @@
        x2="23.99999"
        y1="5.5641499"
        x1="23.99999" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.39221369,0,0,0.4270244,29.199296,7.8403341)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient111404"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39221373,0,0,0.4270247,29.199298,7.840337)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
   </defs>
   <metadata
      id="metadata5023">
@@ -289,13 +302,17 @@
        id="path2883-8-6"
        style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3179-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
     <path
-       d="m 3.4999601,9.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z"
+       d="m 4,9.999996 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 l 2e-5,19.9987 c 0,0 -10.6666663,0 -16,0 0,-6.66666 0,-13.333318 0,-19.999979 z"
        id="path4160-3-9-5"
-       style="display:inline;fill:url(#linearGradient3181-4);fill-opacity:1;stroke:url(#linearGradient3183-9);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="display:inline;fill:url(#linearGradient3181-4);fill-opacity:1;stroke:none;stroke-width:0.999925;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        d="m 19.5,29.5 -15.0000004,0 0,-19 L 19.5,10.5 Z"
        id="rect6741-1-2-2"
        style="fill:none;stroke:url(#linearGradient5016);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 3.499962,9.499958 c 3.8955768,0 17.00006,0.00145 17.00006,0.00145 l 1.8e-5,20.998629 c 0,0 -11.3333851,0 -17.000078,0 0,-7.000039 0,-14.000007 0,-20.9999643 z"
+       id="path4160-6-1"
+       style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.999924;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
   <path
      d="m 10,6.0000003 c 2.520657,0 10.999987,0.0012 10.999987,0.0012 L 21,24.000003 c 0,0 -7.333334,0 -11,0 0,-5.999983 0,-11.999966 0,-17.9999507 z"
@@ -320,12 +337,16 @@
        id="path2883-8"
        style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3179);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
     <path
-       d="m 3.4999601,9.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z"
+       d="m 3.9999996,10 c 3.6664119,0 15.9999814,0.0013 15.9999814,0.0013 L 20,30 c 0,0 -10.6666666,0 -16.0000004,0 0,-6.666647 0,-13.333293 0,-19.999941 z"
        id="path4160-3-9"
-       style="display:inline;fill:url(#linearGradient3181);fill-opacity:1;stroke:url(#linearGradient3183);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="display:inline;fill:url(#linearGradient3181);fill-opacity:1;stroke:none;stroke-width:0.999924;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        d="m 19.5,29.5 -15.0000004,0 0,-19 L 19.5,10.5 Z"
        id="rect6741-1-2"
        style="fill:none;stroke:url(#linearGradient3185);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 3.4999616,9.499962 c 3.8955759,0 17.0000624,0.00143 17.0000624,0.00143 l 1.7e-5,20.998644 c 0,0 -11.3333859,0 -17.0000794,0 0,-7.000043 0,-14.000017 0,-20.9999795 z"
+       id="path4160-6-1-5"
+       style="display:inline;fill:none;stroke:url(#linearGradient111404);stroke-width:0.999917;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
 </svg>

--- a/actions/48/document-page-setup.svg
+++ b/actions/48/document-page-setup.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg4041">
+   id="svg4041"
+   sodipodi:docname="document-page-setup.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview132266"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16.75"
+     inkscape:cx="23.61194"
+     inkscape:cy="13.61194"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="649"
+     inkscape:window-y="64"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs4043">
     <linearGradient
@@ -108,7 +131,7 @@
        id="linearGradient3322"
        xlink:href="#linearGradient3600"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-1e-7,-1.9149218)" />
+       gradientTransform="matrix(0.97142632,0,0,0.9343194,0.68576679,-1.3569997)" />
     <linearGradient
        id="linearGradient3600">
       <stop
@@ -118,26 +141,6 @@
       <stop
          id="stop3604"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3324"
-       xlink:href="#linearGradient3104"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8074968,0,0,0.8948322,59.410232,-2.9805531)" />
-    <linearGradient
-       id="linearGradient3104">
-      <stop
-         id="stop3106"
-         style="stop-color:#a0a0a0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3108"
-         style="stop-color:#bebebe;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <radialGradient
@@ -195,6 +198,26 @@
        xlink:href="#linearGradient5048"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410233,-2.977344)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata4046">
@@ -204,7 +227,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -226,9 +248,13 @@
        id="path2883"
        style="opacity:0.3;fill:url(#radialGradient3327);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
     <path
-       d="M 6.4999609,0.497199 C 14.520256,0.497199 41.5,0.5 41.5,0.5 l 4.2e-5,44.002803 c 0,0 -23.333387,0 -35.0000811,0 0,-14.668535 0,-29.33707 0,-44.00560407 z"
+       d="m 7,1 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666667 7,15.333333 7,1 Z"
        id="path4160"
-       style="fill:url(#linearGradient3322);fill-opacity:1;stroke:url(#linearGradient3324);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       style="display:inline;fill:url(#linearGradient3322);fill-opacity:1;stroke:none;stroke-width:0.999925;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 6.499961,0.49996099 c 8.020289,0 35.000042,0.003 35.000042,0.003 l 3.7e-5,43.99709601 c 0,0 -23.333385,0 -35.000079,0 0,-14.666738 0,-29.333326 0,-43.99989201 z"
+       id="path4160-6-1"
+       style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
        id="rect6741-1"

--- a/actions/48/edit-copy.svg
+++ b/actions/48/edit-copy.svg
@@ -4,12 +4,35 @@
    height="48"
    width="48"
    version="1.1"
+   sodipodi:docname="edit-copy.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview134885"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16.75"
+     inkscape:cx="23.58209"
+     inkscape:cy="24.059701"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="640"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4427" />
   <defs
      id="defs4429">
     <linearGradient
@@ -41,7 +64,7 @@
          id="stop3985-9" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.65714319,0,0,0.63012397,2.228569,2.9103979)"
+       gradientTransform="matrix(0.62856997,0,0,0.60839401,2.9143198,3.4652534)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600-4-8"
        id="linearGradient4308"
@@ -59,26 +82,6 @@
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
          id="stop3604-6-3" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.53064102,0,0,0.58970216,41.269598,2.2081379)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5-1"
-       id="linearGradient4310"
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404" />
-    <linearGradient
-       id="linearGradient3104-5-1">
-      <stop
-         offset="0"
-         style="stop-color:#a0a0a0;stop-opacity:1"
-         id="stop3106-6-0" />
-      <stop
-         offset="1"
-         style="stop-color:#bebebe;stop-opacity:1"
-         id="stop3108-9-3" />
     </linearGradient>
     <radialGradient
        gradientTransform="matrix(0.01566318,0,0,0.00823529,19.610446,29.980611)"
@@ -155,7 +158,7 @@
          id="stop3985" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.65714319,0,0,0.63012397,14.228569,10.910352)"
+       gradientTransform="matrix(0.62856997,0,0,0.60839401,14.91432,11.465253)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600-4"
        id="linearGradient4291"
@@ -173,26 +176,6 @@
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
          id="stop3604-6" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.53064102,0,0,0.58970216,53.269598,10.208092)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-5"
-       id="linearGradient4293"
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404" />
-    <linearGradient
-       id="linearGradient3104-5">
-      <stop
-         offset="0"
-         style="stop-color:#a0a0a0;stop-opacity:1"
-         id="stop3106-6" />
-      <stop
-         offset="1"
-         style="stop-color:#bebebe;stop-opacity:1"
-         id="stop3108-9" />
     </linearGradient>
     <radialGradient
        gradientTransform="matrix(0.01566318,0,0,0.00823529,31.610446,37.980565)"
@@ -258,6 +241,36 @@
        x2="302.85715"
        y1="366.64789"
        x1="302.85715" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.53064141,0,0,0.58970026,41.269609,2.208101)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9-1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient136385"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970026,53.269609,10.208101)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
   </defs>
   <metadata
      id="metadata4432">
@@ -286,9 +299,9 @@
      id="path2883-5"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient4313);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 6.499974,4.5000069 c 5.270482,0 23.000037,0.0018 23.000037,0.0018 l 2.8e-5,28.9982281 c 0,0 -15.333376,0 -23.000065,0 0,-9.666692 0,-19.333383 0,-29.0000741 z"
+     d="m 7,5.0000444 c 5.041316,0 21.999973,0.00174 21.999973,0.00174 L 29,33 C 29,33 14.333334,33 7,33 7,23.666666 7,14.333333 7,5 Z"
      id="path4160-3-6"
-     style="display:inline;fill:url(#linearGradient4308);fill-opacity:1;stroke:url(#linearGradient4310);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="display:inline;fill:url(#linearGradient4308);fill-opacity:1;stroke:none;stroke-width:0.999929;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
      d="m 28.500013,32.500046 -21,0 0,-27.0000001 21,0 z"
      id="rect6741-1-6"
@@ -313,11 +326,19 @@
      id="path2883"
      style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient4296);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 18.499974,12.499961 c 5.270482,0 23.000037,0.0018 23.000037,0.0018 l 2.8e-5,28.998228 c 0,0 -15.333376,0 -23.000065,0 0,-9.666692 0,-19.333383 0,-29.000074 z"
+     d="m 6.499962,4.499962 c 5.270481,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998102 c 0,0 -15.333385,0 -23.000078,0 0,-9.666719 0,-19.333339 0,-28.999945 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999924;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 19,13.000044 c 5.041316,0 21.999973,0.0017 21.999973,0.0017 L 41,41 c 0,0 -14.666666,0 -22,0 0,-9.333334 0,-18.666667 0,-28 z"
      id="path4160-3"
-     style="display:inline;fill:url(#linearGradient4291);fill-opacity:1;stroke:url(#linearGradient4293);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="display:inline;fill:url(#linearGradient4291);fill-opacity:1;stroke:none;stroke-width:0.999929;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
      d="m 40.500013,40.5 -21,0 0,-27 21,0 z"
      id="rect6741-1"
      style="fill:none;stroke:url(#linearGradient4288);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 18.499962,12.499962 c 5.270481,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998102 c 0,0 -15.333385,0 -23.000078,0 0,-9.666719 0,-19.333339 0,-28.999945 z"
+     id="path136383"
+     style="display:inline;fill:none;stroke:url(#linearGradient136385);stroke-width:0.999924;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
 </svg>


### PR DESCRIPTION
This adds some semi-transparent borders to a few icons that did not have them at certain sizes (mostly document actions). Should look a bit sharper with dark backgrounds.

---

Sorry, hope little things like this aren't too annoying!

Current:
![16-px-borders-current](https://github.com/elementary/icons/assets/1984060/0c701a7b-6187-48eb-a8d1-4c8baed9a072)


Proposed:
![16-px-borders-proposed](https://github.com/elementary/icons/assets/1984060/3846f080-fea1-4ab4-a657-34c3768c88e9)
