### PR TITLE
Add Rust icons based on the official raster versions

### DIFF
--- a/mimes/128/text-rust.svg
+++ b/mimes/128/text-rust.svg
@@ -1,0 +1,16665 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3172"
+   height="128"
+   width="128"
+   version="1.1"
+   sodipodi:docname="text-rust.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview36"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:snap-page="true"
+     inkscape:zoom="2.2925728"
+     inkscape:cx="93.781102"
+     inkscape:cy="85.057278"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3172">
+    <inkscape:grid
+       type="xygrid"
+       id="grid13456" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3100" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3102" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3104" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3019-2"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-3"
+       id="linearGradient3016-9"
+       y2="42.194839"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-6" />
+      <stop
+         offset="0.00648027"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-0" />
+      <stop
+         offset="0.99423188"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4097"
+       xlink:href="#linearGradient3702-501-757-486"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient4095"
+       xlink:href="#linearGradient3688-464-309-255"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient4093"
+       xlink:href="#linearGradient3688-464-309-255"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)" />
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none"
+     id="path4160"
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z" />
+  <g
+     id="g975">
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,91.000002 h 1 v 1 h -1"
+       id="path9167" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,91.000002 h 1 v 1 h -1"
+       id="path9165" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,91.000002 h 1 v 1 h -1"
+       id="path9163" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,91.000002 h 1 v 1 h -1"
+       id="path9161" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,91.000002 h 1 v 1 h -1"
+       id="path9159" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,91.000002 h 1 v 1 h -1"
+       id="path9157" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,91.000002 h 1 v 1 h -1"
+       id="path9155" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,91.000002 h 1 v 1 h -1"
+       id="path9153" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,91.000002 h 1 v 1 h -1"
+       id="path9151" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,91.000002 h 1 v 1 h -1"
+       id="path9149" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,91.000002 h 1 v 1 h -1"
+       id="path9147" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,91.000002 h 1 v 1 h -1"
+       id="path9145" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,91.000002 h 1 v 1 h -1"
+       id="path9143" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,91.000002 h 1 v 1 h -1"
+       id="path9141" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,91.000002 h 1 v 1 h -1"
+       id="path9139" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,91.000002 h 1 v 1 h -1"
+       id="path9137" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,91.000002 h 1 v 1 h -1"
+       id="path9135" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,91.000002 h 1 v 1 h -1"
+       id="path9133" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,91.000002 h 1 v 1 h -1"
+       id="path9131" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,91.000002 h 1 v 1 h -1"
+       id="path9129" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,91.000002 h 1 v 1 h -1"
+       id="path9127" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,91.000002 h 1 v 1 h -1"
+       id="path9125" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,91.000002 h 1 v 1 h -1"
+       id="path9123" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,91.000002 h 1 v 1 h -1"
+       id="path9121" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,91.000002 h 1 v 1 h -1"
+       id="path9119" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,91.000002 h 1 v 1 h -1"
+       id="path9117" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,91.000002 h 1 v 1 h -1"
+       id="path9115" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,91.000002 h 1 v 1 h -1"
+       id="path9113" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,91.000002 h 1 v 1 h -1"
+       id="path9111" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,91.000002 h 1 v 1 h -1"
+       id="path9109" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,91.000002 h 1 v 1 h -1"
+       id="path9107" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,91.000002 h 1 v 1 h -1"
+       id="path9105" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,91.000002 h 1 v 1 h -1"
+       id="path9103" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,91.000002 h 1 v 1 h -1"
+       id="path9101" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,91.000002 h 1 v 1 h -1"
+       id="path9099" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,91.000002 h 1 v 1 h -1"
+       id="path9097" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,91.000002 h 1 v 1 h -1"
+       id="path9095" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,91.000002 h 1 v 1 h -1"
+       id="path9093" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,91.000002 h 1 v 1 h -1"
+       id="path9091" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,91.000002 h 1 v 1 h -1"
+       id="path9089" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,91.000002 h 1 v 1 h -1"
+       id="path9087" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,91.000002 h 1 v 1 h -1"
+       id="path9085" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,91.000002 h 1 v 1 h -1"
+       id="path9083" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,91.000002 h 1 v 1 h -1"
+       id="path9081" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,91.000002 h 1 v 1 h -1"
+       id="path9079" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,91.000002 h 1 v 1 h -1"
+       id="path9077" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,91.000002 h 1 v 1 h -1"
+       id="path9075" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,91.000002 h 1 v 1 h -1"
+       id="path9073" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,91.000002 h 1 v 1 h -1"
+       id="path9071" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,91.000002 h 1 v 1 h -1"
+       id="path9069" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,91.000002 h 1 v 1 h -1"
+       id="path9067" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,91.000002 h 1 v 1 h -1"
+       id="path9065" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,91.000002 h 1 v 1 h -1"
+       id="path9063" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,91.000002 h 1 v 1 h -1"
+       id="path9061" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,91.000002 h 1 v 1 h -1"
+       id="path9059" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,91.000002 h 1 v 1 h -1"
+       id="path9057" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,91.000002 h 1 v 1 h -1"
+       id="path9055" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,91.000002 h 1 v 1 h -1"
+       id="path9053" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,91.000002 h 1 v 1 h -1"
+       id="path9051" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,91.000002 h 1 v 1 h -1"
+       id="path9049" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,91.000002 h 1 v 1 h -1"
+       id="path9047" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,91.000002 h 1 v 1 h -1"
+       id="path9045" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,91.000002 h 1 v 1 h -1"
+       id="path9043" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,91.000002 h 1 v 1 h -1"
+       id="path9041" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,90.000002 h 1 v 1 h -1"
+       id="path9039" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,90.000002 h 1 v 1 h -1"
+       id="path9037" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,90.000002 h 1 v 1 h -1"
+       id="path9035" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,90.000002 h 1 v 1 h -1"
+       id="path9033" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,90.000002 h 1 v 1 h -1"
+       id="path9031" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,90.000002 h 1 v 1 h -1"
+       id="path9029" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,90.000002 h 1 v 1 h -1"
+       id="path9027" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,90.000002 h 1 v 1 h -1"
+       id="path9025" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,90.000002 h 1 v 1 h -1"
+       id="path9023" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,90.000002 h 1 v 1 h -1"
+       id="path9021" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,90.000002 h 1 v 1 h -1"
+       id="path9019" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,90.000002 h 1 v 1 h -1"
+       id="path9017" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,90.000002 h 1 v 1 h -1"
+       id="path9015" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,90.000002 h 1 v 1 h -1"
+       id="path9013" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,90.000002 h 1 v 1 h -1"
+       id="path9011" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,90.000002 h 1 v 1 h -1"
+       id="path9009" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,90.000002 h 1 v 1 h -1"
+       id="path9007" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,90.000002 h 1 v 1 h -1"
+       id="path9005" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,90.000002 h 1 v 1 h -1"
+       id="path9003" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,90.000002 h 1 v 1 h -1"
+       id="path9001" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,90.000002 h 1 v 1 h -1"
+       id="path8999" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,90.000002 h 1 v 1 h -1"
+       id="path8997" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,90.000002 h 1 v 1 h -1"
+       id="path8995" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,90.000002 h 1 v 1 h -1"
+       id="path8993" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,90.000002 h 1 v 1 h -1"
+       id="path8991" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,90.000002 h 1 v 1 h -1"
+       id="path8989" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,90.000002 h 1 v 1 h -1"
+       id="path8987" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,90.000002 h 1 v 1 h -1"
+       id="path8985" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,90.000002 h 1 v 1 h -1"
+       id="path8983" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,90.000002 h 1 v 1 h -1"
+       id="path8981" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,90.000002 h 1 v 1 h -1"
+       id="path8979" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,90.000002 h 1 v 1 h -1"
+       id="path8977" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,90.000002 h 1 v 1 h -1"
+       id="path8975" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,90.000002 h 1 v 1 h -1"
+       id="path8973" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,90.000002 h 1 v 1 h -1"
+       id="path8971" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,90.000002 h 1 v 1 h -1"
+       id="path8969" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,90.000002 h 1 v 1 h -1"
+       id="path8967" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,90.000002 h 1 v 1 h -1"
+       id="path8965" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,90.000002 h 1 v 1 h -1"
+       id="path8963" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,90.000002 h 1 v 1 h -1"
+       id="path8961" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,90.000002 h 1 v 1 h -1"
+       id="path8959" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,90.000002 h 1 v 1 h -1"
+       id="path8957" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,90.000002 h 1 v 1 h -1"
+       id="path8955" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,90.000002 h 1 v 1 h -1"
+       id="path8953" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,90.000002 h 1 v 1 h -1"
+       id="path8951" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,90.000002 h 1 v 1 h -1"
+       id="path8949" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,90.000002 h 1 v 1 h -1"
+       id="path8947" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,90.000002 h 1 v 1 h -1"
+       id="path8945" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,90.000002 h 1 v 1 h -1"
+       id="path8943" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,90.000002 h 1 v 1 h -1"
+       id="path8941" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,90.000002 h 1 v 1 h -1"
+       id="path8939" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,90.000002 h 1 v 1 h -1"
+       id="path8937" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,90.000002 h 1 v 1 h -1"
+       id="path8935" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,90.000002 h 1 v 1 h -1"
+       id="path8933" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,90.000002 h 1 v 1 h -1"
+       id="path8931" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,90.000002 h 1 v 1 h -1"
+       id="path8929" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,90.000002 h 1 v 1 h -1"
+       id="path8927" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,90.000002 h 1 v 1 h -1"
+       id="path8925" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,90.000002 h 1 v 1 h -1"
+       id="path8923" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,90.000002 h 1 v 1 h -1"
+       id="path8921" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,90.000002 h 1 v 1 h -1"
+       id="path8919" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,90.000002 h 1 v 1 h -1"
+       id="path8917" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,90.000002 h 1 v 1 h -1"
+       id="path8915" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,90.000002 h 1 v 1 h -1"
+       id="path8913" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,89.000002 h 1 v 1 h -1"
+       id="path8911" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,89.000002 h 1 v 1 h -1"
+       id="path8909" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,89.000002 h 1 v 1 h -1"
+       id="path8907" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,89.000002 h 1 v 1 h -1"
+       id="path8905" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,89.000002 h 1 v 1 h -1"
+       id="path8903" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,89.000002 h 1 v 1 h -1"
+       id="path8901" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,89.000002 h 1 v 1 h -1"
+       id="path8899" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,89.000002 h 1 v 1 h -1"
+       id="path8897" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,89.000002 h 1 v 1 h -1"
+       id="path8895" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,89.000002 h 1 v 1 h -1"
+       id="path8893" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,89.000002 h 1 v 1 h -1"
+       id="path8891" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,89.000002 h 1 v 1 h -1"
+       id="path8889" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,89.000002 h 1 v 1 h -1"
+       id="path8887" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,89.000002 h 1 v 1 h -1"
+       id="path8885" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,89.000002 h 1 v 1 h -1"
+       id="path8883" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,89.000002 h 1 v 1 h -1"
+       id="path8881" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,89.000002 h 1 v 1 h -1"
+       id="path8879" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,89.000002 h 1 v 1 h -1"
+       id="path8877" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,89.000002 h 1 v 1 h -1"
+       id="path8875" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,89.000002 h 1 v 1 h -1"
+       id="path8873" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,89.000002 h 1 v 1 h -1"
+       id="path8871" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,89.000002 h 1 v 1 h -1"
+       id="path8869" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,89.000002 h 1 v 1 h -1"
+       id="path8867" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,89.000002 h 1 v 1 h -1"
+       id="path8865" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,89.000002 h 1 v 1 h -1"
+       id="path8863" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,89.000002 h 1 v 1 h -1"
+       id="path8861" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,89.000002 h 1 v 1 h -1"
+       id="path8859" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,89.000002 h 1 v 1 h -1"
+       id="path8857" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,89.000002 h 1 v 1 h -1"
+       id="path8855" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66.25,89.250002 0.75,-0.25 v 1 h -1"
+       id="path8853" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64.75,89.250002 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path8851" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,89.000002 0.75,0.25 0.25,0.75 h -1"
+       id="path8849" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63.25,89.250002 0.75,-0.25 v 1 h -1"
+       id="path8847" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61.75,89.250002 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path8845" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,89.000002 0.75,0.25 0.25,0.75 h -1"
+       id="path8843" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,89.000002 h 1 v 1 h -1"
+       id="path8841" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,89.000002 h 1 v 1 h -1"
+       id="path8839" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,89.000002 h 1 v 1 h -1"
+       id="path8837" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,89.000002 h 1 v 1 h -1"
+       id="path8835" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,89.000002 h 1 v 1 h -1"
+       id="path8833" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,89.000002 h 1 v 1 h -1"
+       id="path8831" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,89.000002 h 1 v 1 h -1"
+       id="path8829" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,89.000002 h 1 v 1 h -1"
+       id="path8827" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,89.000002 h 1 v 1 h -1"
+       id="path8825" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,89.000002 h 1 v 1 h -1"
+       id="path8823" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,89.000002 h 1 v 1 h -1"
+       id="path8821" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,89.000002 h 1 v 1 h -1"
+       id="path8819" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,89.000002 h 1 v 1 h -1"
+       id="path8817" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,89.000002 h 1 v 1 h -1"
+       id="path8815" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,89.000002 h 1 v 1 h -1"
+       id="path8813" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,89.000002 h 1 v 1 h -1"
+       id="path8811" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,89.000002 h 1 v 1 h -1"
+       id="path8809" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,89.000002 h 1 v 1 h -1"
+       id="path8807" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,89.000002 h 1 v 1 h -1"
+       id="path8805" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,89.000002 h 1 v 1 h -1"
+       id="path8803" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,89.000002 h 1 v 1 h -1"
+       id="path8801" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,89.000002 h 1 v 1 h -1"
+       id="path8799" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,89.000002 h 1 v 1 h -1"
+       id="path8797" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,89.000002 h 1 v 1 h -1"
+       id="path8795" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,89.000002 h 1 v 1 h -1"
+       id="path8793" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,89.000002 h 1 v 1 h -1"
+       id="path8791" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,89.000002 h 1 v 1 h -1"
+       id="path8789" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,89.000002 h 1 v 1 h -1"
+       id="path8787" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,89.000002 h 1 v 1 h -1"
+       id="path8785" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,88.000002 h 1 v 1 h -1"
+       id="path8783" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,88.000002 h 1 v 1 h -1"
+       id="path8781" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,88.000002 h 1 v 1 h -1"
+       id="path8779" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,88.000002 h 1 v 1 h -1"
+       id="path8777" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,88.000002 h 1 v 1 h -1"
+       id="path8775" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,88.000002 h 1 v 1 h -1"
+       id="path8773" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,88.000002 h 1 v 1 h -1"
+       id="path8771" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,88.000002 h 1 v 1 h -1"
+       id="path8769" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,88.000002 h 1 v 1 h -1"
+       id="path8767" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,88.000002 h 1 v 1 h -1"
+       id="path8765" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,88.000002 h 1 v 1 h -1"
+       id="path8763" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,88.000002 h 1 v 1 h -1"
+       id="path8761" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,88.000002 h 1 v 1 h -1"
+       id="path8759" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,88.000002 h 1 v 1 h -1"
+       id="path8757" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,88.000002 h 1 v 1 h -1"
+       id="path8755" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,88.000002 h 1 v 1 h -1"
+       id="path8753" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,88.000002 h 1 v 1 h -1"
+       id="path8751" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,88.000002 h 1 v 1 h -1"
+       id="path8749" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,88.000002 h 1 v 1 h -1"
+       id="path8747" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,88.000002 h 1 v 1 h -1"
+       id="path8745" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,88.000002 h 1 v 1 h -1"
+       id="path8743" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,88.000002 h 1 v 1 h -1"
+       id="path8741" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,88.000002 h 1 v 1 h -1"
+       id="path8739" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,88.000002 h 1 v 1 h -1"
+       id="path8737" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,88.000002 h 1 v 1 h -1"
+       id="path8735" />
+    <path
+       style="fill:#272727;fill-opacity:0.0509804"
+       d="m 70,88.000002 h 1 v 1 h -1"
+       id="path8733" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 69,88.000002 h 1 v 1 h -1"
+       id="path8731" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 68,88.000002 h 1 v 1 h -1"
+       id="path8729" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,88.000002 h 1 v 1 h -1"
+       id="path8727" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65.75,88.250002 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path8725" />
+    <path
+       style="fill:#400000;fill-opacity:0.0156863"
+       d="m 65,88 h 1 v 1 h -1"
+       id="path8723"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.776471"
+       d="M 64,88.000002 65,88 v 0 1 0 l -1,2e-6"
+       id="path8721"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.772549"
+       d="m 63,88 v 0 l 1,2e-6 v 1 L 63,89 v 0"
+       id="path8719"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#400000;fill-opacity:0.0156863"
+       d="m 62,88 h 1 v 1 h -1"
+       id="path8717"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,88.000002 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path8715" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,88.000002 h 1 v 1 h -1"
+       id="path8713" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 59,88.000002 h 1 v 1 h -1"
+       id="path8711" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 58,88.000002 h 1 v 1 h -1"
+       id="path8709" />
+    <path
+       style="fill:#272727;fill-opacity:0.0509804"
+       d="m 57,88.000002 h 1 v 1 h -1"
+       id="path8707" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,88.000002 h 1 v 1 h -1"
+       id="path8705" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,88.000002 h 1 v 1 h -1"
+       id="path8703" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,88.000002 h 1 v 1 h -1"
+       id="path8701" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,88.000002 h 1 v 1 h -1"
+       id="path8699" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,88.000002 h 1 v 1 h -1"
+       id="path8697" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,88.000002 h 1 v 1 h -1"
+       id="path8695" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,88.000002 h 1 v 1 h -1"
+       id="path8693" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,88.000002 h 1 v 1 h -1"
+       id="path8691" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,88.000002 h 1 v 1 h -1"
+       id="path8689" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,88.000002 h 1 v 1 h -1"
+       id="path8687" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,88.000002 h 1 v 1 h -1"
+       id="path8685" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,88.000002 h 1 v 1 h -1"
+       id="path8683" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,88.000002 h 1 v 1 h -1"
+       id="path8681" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,88.000002 h 1 v 1 h -1"
+       id="path8679" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,88.000002 h 1 v 1 h -1"
+       id="path8677" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,88.000002 h 1 v 1 h -1"
+       id="path8675" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,88.000002 h 1 v 1 h -1"
+       id="path8673" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,88.000002 h 1 v 1 h -1"
+       id="path8671" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,88.000002 h 1 v 1 h -1"
+       id="path8669" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,88.000002 h 1 v 1 h -1"
+       id="path8667" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,88.000002 h 1 v 1 h -1"
+       id="path8665" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,88.000002 h 1 v 1 h -1"
+       id="path8663" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,88.000002 h 1 v 1 h -1"
+       id="path8661" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,88.000002 h 1 v 1 h -1"
+       id="path8659" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,88.000002 h 1 v 1 h -1"
+       id="path8657" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,87.000002 h 1 v 1 h -1"
+       id="path8655" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,87.000002 h 1 v 1 h -1"
+       id="path8653" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,87.000002 h 1 v 1 h -1"
+       id="path8651" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,87.000002 h 1 v 1 h -1"
+       id="path8649" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,87.000002 h 1 v 1 h -1"
+       id="path8647" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,87.000002 h 1 v 1 h -1"
+       id="path8645" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,87.000002 h 1 v 1 h -1"
+       id="path8643" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,87.000002 h 1 v 1 h -1"
+       id="path8641" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,87.000002 h 1 v 1 h -1"
+       id="path8639" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,87.000002 h 1 v 1 h -1"
+       id="path8637" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,87.000002 h 1 v 1 h -1"
+       id="path8635" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,87.000002 h 1 v 1 h -1"
+       id="path8633" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,87.000002 h 1 v 1 h -1"
+       id="path8631" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,87.000002 h 1 v 1 h -1"
+       id="path8629" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,87.000002 h 1 v 1 h -1"
+       id="path8627" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,87.000002 h 1 v 1 h -1"
+       id="path8625" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,87.000002 h 1 v 1 h -1"
+       id="path8623" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,87.000002 h 1 v 1 h -1"
+       id="path8621" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,87.000002 h 1 v 1 h -1"
+       id="path8619" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,87.000002 h 1 v 1 h -1"
+       id="path8617" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,87.000002 h 1 v 1 h -1"
+       id="path8615" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,87.000002 h 1 v 1 h -1"
+       id="path8613" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,87.000002 h 1 v 1 h -1"
+       id="path8611" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,87.000002 h 1 v 1 h -1"
+       id="path8609" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,87.000002 h 1 v 1 h -1"
+       id="path8607" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 70,87.000002 h 1 v 1 h -1"
+       id="path8605" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,87.000002 h 1 v 1 h -1"
+       id="path8603" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.784314"
+       d="m 68,87.000002 h 1 v 1 h -1"
+       id="path8601" />
+    <path
+       style="fill:#1a1a1a;fill-opacity:0.0392157"
+       d="m 67,87.000002 h 1 v 1 h -1"
+       id="path8599" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,87.000002 h 1 v 1 l -0.75,-0.25"
+       id="path8597" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.45098"
+       d="m 65,87.000002 h 1 V 88 88 h -1 v 0"
+       id="path8595"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,87.000002 h 1 V 88 l -1,2e-6"
+       id="path8593"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,87.000002 h 1 v 1 L 63,88"
+       id="path8591"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.447059"
+       d="m 62,87.000002 h 1 V 88 88 h -1 v 0"
+       id="path8589"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,87.000002 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path8587" />
+    <path
+       style="fill:#1a1a1a;fill-opacity:0.0392157"
+       d="m 60,87.000002 h 1 v 1 h -1"
+       id="path8585" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 59,87.000002 h 1 v 1 h -1"
+       id="path8583" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,87.000002 h 1 v 1 h -1"
+       id="path8581" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 57,87.000002 h 1 v 1 h -1"
+       id="path8579" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,87.000002 h 1 v 1 h -1"
+       id="path8577" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,87.000002 h 1 v 1 h -1"
+       id="path8575" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,87.000002 h 1 v 1 h -1"
+       id="path8573" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,87.000002 h 1 v 1 h -1"
+       id="path8571" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,87.000002 h 1 v 1 h -1"
+       id="path8569" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,87.000002 h 1 v 1 h -1"
+       id="path8567" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,87.000002 h 1 v 1 h -1"
+       id="path8565" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,87.000002 h 1 v 1 h -1"
+       id="path8563" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,87.000002 h 1 v 1 h -1"
+       id="path8561" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,87.000002 h 1 v 1 h -1"
+       id="path8559" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,87.000002 h 1 v 1 h -1"
+       id="path8557" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,87.000002 h 1 v 1 h -1"
+       id="path8555" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,87.000002 h 1 v 1 h -1"
+       id="path8553" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,87.000002 h 1 v 1 h -1"
+       id="path8551" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,87.000002 h 1 v 1 h -1"
+       id="path8549" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,87.000002 h 1 v 1 h -1"
+       id="path8547" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,87.000002 h 1 v 1 h -1"
+       id="path8545" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,87.000002 h 1 v 1 h -1"
+       id="path8543" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,87.000002 h 1 v 1 h -1"
+       id="path8541" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,87.000002 h 1 v 1 h -1"
+       id="path8539" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,87.000002 h 1 v 1 h -1"
+       id="path8537" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,87.000002 h 1 v 1 h -1"
+       id="path8535" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,87.000002 h 1 v 1 h -1"
+       id="path8533" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,87.000002 h 1 v 1 h -1"
+       id="path8531" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,87.000002 h 1 v 1 h -1"
+       id="path8529" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,86.000002 h 1 v 1 h -1"
+       id="path8527" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,86.000002 h 1 v 1 h -1"
+       id="path8525" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,86.000002 h 1 v 1 h -1"
+       id="path8523" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,86.000002 h 1 v 1 h -1"
+       id="path8521" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,86.000002 h 1 v 1 h -1"
+       id="path8519" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,86.000002 h 1 v 1 h -1"
+       id="path8517" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,86.000002 h 1 v 1 h -1"
+       id="path8515" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,86.000002 h 1 v 1 h -1"
+       id="path8513" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,86.000002 h 1 v 1 h -1"
+       id="path8511" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,86.000002 h 1 v 1 h -1"
+       id="path8509" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,86.000002 h 1 v 1 h -1"
+       id="path8507" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,86.000002 h 1 v 1 h -1"
+       id="path8505" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,86.000002 h 1 v 1 h -1"
+       id="path8503" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,86.000002 h 1 v 1 h -1"
+       id="path8501" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,86.000002 h 1 v 1 h -1"
+       id="path8499" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,86.000002 h 1 v 1 h -1"
+       id="path8497" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,86.000002 h 1 v 1 h -1"
+       id="path8495" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,86.000002 h 1 v 1 h -1"
+       id="path8493" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,86.000002 h 1 v 1 h -1"
+       id="path8491" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,86.000002 h 1 v 1 h -1"
+       id="path8489" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 75,86.000002 h 1 v 1 h -1"
+       id="path8487" />
+    <path
+       style="fill:#232020;fill-opacity:0.792157"
+       d="m 74,86.000002 h 1 v 1 h -1"
+       id="path8485" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.203922"
+       d="m 73,86.000002 h 1 v 1 h -1"
+       id="path8483" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,86.000002 h 1 v 1 h -1"
+       id="path8481" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,86.000002 h 1 v 1 h -1"
+       id="path8479" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 70,86.000002 h 1 v 1 h -1"
+       id="path8477" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,86.000002 h 1 v 1 h -1"
+       id="path8475" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,86.000002 h 1 v 1 h -1"
+       id="path8473" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.733333"
+       d="m 67,86.000002 h 1 v 1 h -1"
+       id="path8471" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.227451"
+       d="m 66,86.000002 h 1 v 1 h -1"
+       id="path8469" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.956863"
+       d="m 65,86.000002 h 1 v 1 h -1"
+       id="path8467" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,86.000002 h 1 v 1 h -1"
+       id="path8465" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,86.000002 h 1 v 1 h -1"
+       id="path8463" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.952941"
+       d="m 62,86.000002 h 1 v 1 h -1"
+       id="path8461" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.227451"
+       d="m 61,86.000002 h 1 v 1 h -1"
+       id="path8459" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.737255"
+       d="m 60,86.000002 h 1 v 1 h -1"
+       id="path8457" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,86.000002 h 1 v 1 h -1"
+       id="path8455" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,86.000002 h 1 v 1 h -1"
+       id="path8453" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 57,86.000002 h 1 v 1 h -1"
+       id="path8451" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,86.000002 h 1 v 1 h -1"
+       id="path8449" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,86.000002 h 1 v 1 h -1"
+       id="path8447" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.203922"
+       d="m 54,86.000002 h 1 v 1 h -1"
+       id="path8445" />
+    <path
+       style="fill:#232020;fill-opacity:0.792157"
+       d="m 53,86.000002 h 1 v 1 h -1"
+       id="path8443" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 52,86.000002 h 1 v 1 h -1"
+       id="path8441" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,86.000002 h 1 v 1 h -1"
+       id="path8439" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,86.000002 h 1 v 1 h -1"
+       id="path8437" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,86.000002 h 1 v 1 h -1"
+       id="path8435" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,86.000002 h 1 v 1 h -1"
+       id="path8433" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,86.000002 h 1 v 1 h -1"
+       id="path8431" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,86.000002 h 1 v 1 h -1"
+       id="path8429" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,86.000002 h 1 v 1 h -1"
+       id="path8427" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,86.000002 h 1 v 1 h -1"
+       id="path8425" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,86.000002 h 1 v 1 h -1"
+       id="path8423" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,86.000002 h 1 v 1 h -1"
+       id="path8421" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,86.000002 h 1 v 1 h -1"
+       id="path8419" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,86.000002 h 1 v 1 h -1"
+       id="path8417" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,86.000002 h 1 v 1 h -1"
+       id="path8415" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,86.000002 h 1 v 1 h -1"
+       id="path8413" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,86.000002 h 1 v 1 h -1"
+       id="path8411" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,86.000002 h 1 v 1 h -1"
+       id="path8409" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,86.000002 h 1 v 1 h -1"
+       id="path8407" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,86.000002 h 1 v 1 h -1"
+       id="path8405" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,86.000002 h 1 v 1 h -1"
+       id="path8403" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,86.000002 h 1 v 1 h -1"
+       id="path8401" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,85.000002 h 1 v 1 h -1"
+       id="path8399" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,85.000002 h 1 v 1 h -1"
+       id="path8397" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,85.000002 h 1 v 1 h -1"
+       id="path8395" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,85.000002 h 1 v 1 h -1"
+       id="path8393" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,85.000002 h 1 v 1 h -1"
+       id="path8391" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,85.000002 h 1 v 1 h -1"
+       id="path8389" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,85.000002 h 1 v 1 h -1"
+       id="path8387" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,85.000002 h 1 v 1 h -1"
+       id="path8385" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,85.000002 h 1 v 1 h -1"
+       id="path8383" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,85.000002 h 1 v 1 h -1"
+       id="path8381" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,85.000002 h 1 v 1 h -1"
+       id="path8379" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,85.000002 h 1 v 1 h -1"
+       id="path8377" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,85.000002 h 1 v 1 h -1"
+       id="path8375" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,85.000002 h 1 v 1 h -1"
+       id="path8373" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,85.000002 h 1 v 1 h -1"
+       id="path8371" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,85.000002 h 1 v 1 h -1"
+       id="path8369" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,85.000002 h 1 v 1 h -1"
+       id="path8367" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,85.000002 h 1 v 1 h -1"
+       id="path8365" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,85.000002 h 1 v 1 h -1"
+       id="path8363" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,85.000002 h 1 v 1 h -1"
+       id="path8361" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 75,85.000002 h 1 v 1 h -1"
+       id="path8359" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,85.000002 h 1 v 1 h -1"
+       id="path8357" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 73,85.000002 h 1 v 1 h -1"
+       id="path8355" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.462745"
+       d="m 72,85.000002 h 1 v 1 h -1"
+       id="path8353" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.329412"
+       d="m 71,85.000002 h 1 v 1 h -1"
+       id="path8351" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,85.000002 h 1 v 1 h -1"
+       id="path8349" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,85.000002 h 1 v 1 h -1"
+       id="path8347" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,85.000002 h 1 v 1 h -1"
+       id="path8345" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,85.000002 h 1 v 1 h -1"
+       id="path8343" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,85.000002 h 1 v 1 h -1"
+       id="path8341" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,85.000002 h 1 v 1 h -1"
+       id="path8339" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,85.000002 h 1 v 1 h -1"
+       id="path8337" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,85.000002 h 1 v 1 h -1"
+       id="path8335" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,85.000002 h 1 v 1 h -1"
+       id="path8333" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,85.000002 h 1 v 1 h -1"
+       id="path8331" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,85.000002 h 1 v 1 h -1"
+       id="path8329" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,85.000002 h 1 v 1 h -1"
+       id="path8327" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,85.000002 h 1 v 1 h -1"
+       id="path8325" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,85.000002 h 1 v 1 h -1"
+       id="path8323" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.329412"
+       d="m 56,85.000002 h 1 v 1 h -1"
+       id="path8321" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 55,85.000002 h 1 v 1 h -1"
+       id="path8319" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 54,85.000002 h 1 v 1 h -1"
+       id="path8317" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,85.000002 h 1 v 1 h -1"
+       id="path8315" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 52,85.000002 h 1 v 1 h -1"
+       id="path8313" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,85.000002 h 1 v 1 h -1"
+       id="path8311" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,85.000002 h 1 v 1 h -1"
+       id="path8309" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,85.000002 h 1 v 1 h -1"
+       id="path8307" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,85.000002 h 1 v 1 h -1"
+       id="path8305" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,85.000002 h 1 v 1 h -1"
+       id="path8303" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,85.000002 h 1 v 1 h -1"
+       id="path8301" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,85.000002 h 1 v 1 h -1"
+       id="path8299" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,85.000002 h 1 v 1 h -1"
+       id="path8297" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,85.000002 h 1 v 1 h -1"
+       id="path8295" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,85.000002 h 1 v 1 h -1"
+       id="path8293" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,85.000002 h 1 v 1 h -1"
+       id="path8291" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,85.000002 h 1 v 1 h -1"
+       id="path8289" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,85.000002 h 1 v 1 h -1"
+       id="path8287" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,85.000002 h 1 v 1 h -1"
+       id="path8285" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,85.000002 h 1 v 1 h -1"
+       id="path8283" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,85.000002 h 1 v 1 h -1"
+       id="path8281" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,85.000002 h 1 v 1 h -1"
+       id="path8279" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,85.000002 h 1 v 1 h -1"
+       id="path8277" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,85.000002 h 1 v 1 h -1"
+       id="path8275" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,85.000002 h 1 v 1 h -1"
+       id="path8273" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,84.000002 h 1 v 1 h -1"
+       id="path8271" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,84.000002 h 1 v 1 h -1"
+       id="path8269" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,84.000002 h 1 v 1 h -1"
+       id="path8267" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,84.000002 h 1 v 1 h -1"
+       id="path8265" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,84.000002 h 1 v 1 h -1"
+       id="path8263" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,84.000002 h 1 v 1 h -1"
+       id="path8261" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,84.000002 h 1 v 1 h -1"
+       id="path8259" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,84.000002 h 1 v 1 h -1"
+       id="path8257" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,84.000002 h 1 v 1 h -1"
+       id="path8255" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,84.000002 h 1 v 1 h -1"
+       id="path8253" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,84.000002 h 1 v 1 h -1"
+       id="path8251" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,84.000002 h 1 v 1 h -1"
+       id="path8249" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,84.000002 h 1 v 1 h -1"
+       id="path8247" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,84.000002 h 1 v 1 h -1"
+       id="path8245" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,84.000002 h 1 v 1 h -1"
+       id="path8243" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0352941"
+       d="m 80,84.000002 h 1 v 1 h -1"
+       id="path8241" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.223529"
+       d="m 79,84.000002 h 1 v 1 h -1"
+       id="path8239" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 78,84.000002 h 1 v 1 h -1"
+       id="path8237" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,84.000002 h 1 v 1 h -1"
+       id="path8235" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,84.000002 h 1 v 1 h -1"
+       id="path8233" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.913725"
+       d="m 75,84.000002 h 1 v 1 h -1"
+       id="path8231" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,84.000002 h 1 v 1 h -1"
+       id="path8229" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,84.000002 h 1 v 1 h -1"
+       id="path8227" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,84.000002 h 1 v 1 h -1"
+       id="path8225" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,84.000002 h 1 v 1 h -1"
+       id="path8223" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,84.000002 h 1 v 1 h -1"
+       id="path8221" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,84.000002 h 1 v 1 h -1"
+       id="path8219" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,84.000002 h 1 v 1 h -1"
+       id="path8217" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,84.000002 h 1 v 1 h -1"
+       id="path8215" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,84.000002 h 1 v 1 h -1"
+       id="path8213" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,84.000002 h 1 v 1 h -1"
+       id="path8211" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,84.000002 h 1 v 1 h -1"
+       id="path8209" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,84.000002 h 1 v 1 h -1"
+       id="path8207" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,84.000002 h 1 v 1 h -1"
+       id="path8205" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,84.000002 h 1 v 1 h -1"
+       id="path8203" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,84.000002 h 1 v 1 h -1"
+       id="path8201" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,84.000002 h 1 v 1 h -1"
+       id="path8199" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,84.000002 h 1 v 1 h -1"
+       id="path8197" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,84.000002 h 1 v 1 h -1"
+       id="path8195" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,84.000002 h 1 v 1 h -1"
+       id="path8193" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,84.000002 h 1 v 1 h -1"
+       id="path8191" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,84.000002 h 1 v 1 h -1"
+       id="path8189" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,84.000002 h 1 v 1 h -1"
+       id="path8187" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.909804"
+       d="m 52,84.000002 h 1 v 1 h -1"
+       id="path8185" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,84.000002 h 1 v 1 h -1"
+       id="path8183" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,84.000002 h 1 v 1 h -1"
+       id="path8181" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 49,84.000002 h 1 v 1 h -1"
+       id="path8179" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.223529"
+       d="m 48,84.000002 h 1 v 1 h -1"
+       id="path8177" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0352941"
+       d="m 47,84.000002 h 1 v 1 h -1"
+       id="path8175" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,84.000002 h 1 v 1 h -1"
+       id="path8173" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,84.000002 h 1 v 1 h -1"
+       id="path8171" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,84.000002 h 1 v 1 h -1"
+       id="path8169" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,84.000002 h 1 v 1 h -1"
+       id="path8167" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,84.000002 h 1 v 1 h -1"
+       id="path8165" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,84.000002 h 1 v 1 h -1"
+       id="path8163" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,84.000002 h 1 v 1 h -1"
+       id="path8161" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,84.000002 h 1 v 1 h -1"
+       id="path8159" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,84.000002 h 1 v 1 h -1"
+       id="path8157" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,84.000002 h 1 v 1 h -1"
+       id="path8155" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,84.000002 h 1 v 1 h -1"
+       id="path8153" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,84.000002 h 1 v 1 h -1"
+       id="path8151" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,84.000002 h 1 v 1 h -1"
+       id="path8149" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,84.000002 h 1 v 1 h -1"
+       id="path8147" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,84.000002 h 1 v 1 h -1"
+       id="path8145" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,83.000002 h 1 v 1 h -1"
+       id="path8143" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,83.000002 h 1 v 1 h -1"
+       id="path8141" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,83.000002 h 1 v 1 h -1"
+       id="path8139" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,83.000002 h 1 v 1 h -1"
+       id="path8137" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,83.000002 h 1 v 1 h -1"
+       id="path8135" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,83.000002 h 1 v 1 h -1"
+       id="path8133" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,83.000002 h 1 v 1 h -1"
+       id="path8131" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,83.000002 h 1 v 1 h -1"
+       id="path8129" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,83.000002 h 1 v 1 h -1"
+       id="path8127" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,83.000002 h 1 v 1 h -1"
+       id="path8125" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,83.000002 h 1 v 1 h -1"
+       id="path8123" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,83.000002 h 1 v 1 h -1"
+       id="path8121" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,83.000002 h 1 v 1 h -1"
+       id="path8119" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,83.000002 h 1 v 1 h -1"
+       id="path8117" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,83.000002 h 1 v 1 h -1"
+       id="path8115" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 80,83.000002 h 1 v 1 h -1"
+       id="path8113" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,83.000002 h 1 v 1 h -1"
+       id="path8111" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 78,83.000002 h 1 v 1 h -1"
+       id="path8109" />
+    <path
+       style="fill:#232020;fill-opacity:0.403922"
+       d="m 77,83.000002 h 1 v 1 h -1"
+       id="path8107" />
+    <path
+       style="fill:#242020;fill-opacity:0.219608"
+       d="m 76,83.000002 h 1 v 1 h -1"
+       id="path8105" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,83.000002 h 1 v 1 h -1"
+       id="path8103" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,83.000002 h 1 v 1 h -1"
+       id="path8101" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,83.000002 h 1 v 1 h -1"
+       id="path8099" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,83.000002 h 1 v 1 h -1"
+       id="path8097" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,83.000002 h 1 v 1 h -1"
+       id="path8095" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,83.000002 h 1 v 1 h -1"
+       id="path8093" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,83.000002 h 1 v 1 h -1"
+       id="path8091" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,83.000002 h 1 v 1 h -1"
+       id="path8089" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,83.000002 h 1 v 1 h -1"
+       id="path8087" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,83.000002 h 1 v 1 h -1"
+       id="path8085" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,83.000002 h 1 v 1 h -1"
+       id="path8083" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,83.000002 h 1 v 1 h -1"
+       id="path8081" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,83.000002 h 1 v 1 h -1"
+       id="path8079" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,83.000002 h 1 v 1 h -1"
+       id="path8077" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,83.000002 h 1 v 1 h -1"
+       id="path8075" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,83.000002 h 1 v 1 h -1"
+       id="path8073" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,83.000002 h 1 v 1 h -1"
+       id="path8071" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,83.000002 h 1 v 1 h -1"
+       id="path8069" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,83.000002 h 1 v 1 h -1"
+       id="path8067" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,83.000002 h 1 v 1 h -1"
+       id="path8065" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,83.000002 h 1 v 1 h -1"
+       id="path8063" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,83.000002 h 1 v 1 h -1"
+       id="path8061" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,83.000002 h 1 v 1 h -1"
+       id="path8059" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,83.000002 h 1 v 1 h -1"
+       id="path8057" />
+    <path
+       style="fill:#242020;fill-opacity:0.219608"
+       d="m 51,83.000002 h 1 v 1 h -1"
+       id="path8055" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 50,83.000002 h 1 v 1 h -1"
+       id="path8053" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 49,83.000002 h 1 v 1 h -1"
+       id="path8051" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,83.000002 h 1 v 1 h -1"
+       id="path8049" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 47,83.000002 h 1 v 1 h -1"
+       id="path8047" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,83.000002 h 1 v 1 h -1"
+       id="path8045" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,83.000002 h 1 v 1 h -1"
+       id="path8043" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,83.000002 h 1 v 1 h -1"
+       id="path8041" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,83.000002 h 1 v 1 h -1"
+       id="path8039" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,83.000002 h 1 v 1 h -1"
+       id="path8037" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,83.000002 h 1 v 1 h -1"
+       id="path8035" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,83.000002 h 1 v 1 h -1"
+       id="path8033" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,83.000002 h 1 v 1 h -1"
+       id="path8031" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,83.000002 h 1 v 1 h -1"
+       id="path8029" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,83.000002 h 1 v 1 h -1"
+       id="path8027" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,83.000002 h 1 v 1 h -1"
+       id="path8025" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,83.000002 h 1 v 1 h -1"
+       id="path8023" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,83.000002 h 1 v 1 h -1"
+       id="path8021" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,83.000002 h 1 v 1 h -1"
+       id="path8019" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,83.000002 h 1 v 1 h -1"
+       id="path8017" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,82.000002 h 1 v 1 h -1"
+       id="path8015" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,82.000002 h 1 v 1 h -1"
+       id="path8013" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,82.000002 h 1 v 1 h -1"
+       id="path8011" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,82.000002 h 1 v 1 h -1"
+       id="path8009" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,82.000002 h 1 v 1 h -1"
+       id="path8007" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,82.000002 h 1 v 1 h -1"
+       id="path8005" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,82.000002 h 1 v 1 h -1"
+       id="path8003" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,82.000002 h 1 v 1 h -1"
+       id="path8001" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,82.000002 h 1 v 1 h -1"
+       id="path7999" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,82.000002 h 1 v 1 h -1"
+       id="path7997" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,82.000002 h 1 v 1 h -1"
+       id="path7995" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,82.000002 h 1 v 1 h -1"
+       id="path7993" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,82.000002 h 1 v 1 h -1"
+       id="path7991" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,82.000002 h 1 v 1 h -1"
+       id="path7989" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,82.000002 h 1 v 1 h -1"
+       id="path7987" />
+    <path
+       style="fill:#242020;fill-opacity:0.501961"
+       d="m 80,82.000002 h 1 v 1 h -1"
+       id="path7985" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,82.000002 h 1 v 1 h -1"
+       id="path7983" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,82.000002 h 1 v 1 h -1"
+       id="path7981" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,82.000002 h 1 v 1 h -1"
+       id="path7979" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,82.000002 h 1 v 1 h -1"
+       id="path7977" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,82.000002 h 1 v 1 h -1"
+       id="path7975" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,82.000002 h 1 v 1 h -1"
+       id="path7973" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,82.000002 h 1 v 1 h -1"
+       id="path7971" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,82.000002 h 1 v 1 h -1"
+       id="path7969" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,82.000002 h 1 v 1 h -1"
+       id="path7967" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,82.000002 h 1 v 1 h -1"
+       id="path7965" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,82.000002 h 1 v 1 h -1"
+       id="path7963" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,82.000002 h 1 v 1 h -1"
+       id="path7961" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,82.000002 h 1 v 1 h -1"
+       id="path7959" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,82.000002 h 1 v 1 h -1"
+       id="path7957" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,82.000002 h 1 v 1 h -1"
+       id="path7955" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,82.000002 h 1 v 1 h -1"
+       id="path7953" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,82.000002 h 1 v 1 h -1"
+       id="path7951" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,82.000002 h 1 v 1 h -1"
+       id="path7949" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,82.000002 h 1 v 1 h -1"
+       id="path7947" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,82.000002 h 1 v 1 h -1"
+       id="path7945" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,82.000002 h 1 v 1 h -1"
+       id="path7943" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,82.000002 h 1 v 1 h -1"
+       id="path7941" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,82.000002 h 1 v 1 h -1"
+       id="path7939" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,82.000002 h 1 v 1 h -1"
+       id="path7937" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,82.000002 h 1 v 1 h -1"
+       id="path7935" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,82.000002 h 1 v 1 h -1"
+       id="path7933" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,82.000002 h 1 v 1 h -1"
+       id="path7931" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,82.000002 h 1 v 1 h -1"
+       id="path7929" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,82.000002 h 1 v 1 h -1"
+       id="path7927" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,82.000002 h 1 v 1 h -1"
+       id="path7925" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,82.000002 h 1 v 1 h -1"
+       id="path7923" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,82.000002 h 1 v 1 h -1"
+       id="path7921" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.498039"
+       d="m 47,82.000002 h 1 v 1 h -1"
+       id="path7919" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,82.000002 h 1 v 1 h -1"
+       id="path7917" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,82.000002 h 1 v 1 h -1"
+       id="path7915" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,82.000002 h 1 v 1 h -1"
+       id="path7913" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,82.000002 h 1 v 1 h -1"
+       id="path7911" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,82.000002 h 1 v 1 h -1"
+       id="path7909" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,82.000002 h 1 v 1 h -1"
+       id="path7907" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,82.000002 h 1 v 1 h -1"
+       id="path7905" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,82.000002 h 1 v 1 h -1"
+       id="path7903" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,82.000002 h 1 v 1 h -1"
+       id="path7901" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,82.000002 h 1 v 1 h -1"
+       id="path7899" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,82.000002 h 1 v 1 h -1"
+       id="path7897" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,82.000002 h 1 v 1 h -1"
+       id="path7895" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,82.000002 h 1 v 1 h -1"
+       id="path7893" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,82.000002 h 1 v 1 h -1"
+       id="path7891" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,82.000002 h 1 v 1 h -1"
+       id="path7889" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,81.000002 h 1 v 1 h -1"
+       id="path7887" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,81.000002 h 1 v 1 h -1"
+       id="path7885" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,81.000002 h 1 v 1 h -1"
+       id="path7883" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,81.000002 h 1 v 1 h -1"
+       id="path7881" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,81.000002 h 1 v 1 h -1"
+       id="path7879" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,81.000002 h 1 v 1 h -1"
+       id="path7877" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,81.000002 h 1 v 1 h -1"
+       id="path7875" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,81.000002 h 1 v 1 h -1"
+       id="path7873" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,81.000002 h 1 v 1 h -1"
+       id="path7871" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,81.000002 h 1 v 1 h -1"
+       id="path7869" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,81.000002 h 1 v 1 h -1"
+       id="path7867" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,81.000002 h 1 v 1 h -1"
+       id="path7865" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,81.000002 h 1 v 1 h -1"
+       id="path7863" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,81.000002 h 1 v 1 h -1"
+       id="path7861" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,81.000002 h 1 v 1 h -1"
+       id="path7859" />
+    <path
+       style="fill:#222020;fill-opacity:0.439216"
+       d="m 80,81.000002 h 1 v 1 h -1"
+       id="path7857" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,81.000002 h 1 v 1 h -1"
+       id="path7855" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,81.000002 h 1 v 1 h -1"
+       id="path7853" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,81.000002 h 1 v 1 h -1"
+       id="path7851" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,81.000002 h 1 v 1 h -1"
+       id="path7849" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,81.000002 h 1 v 1 h -1"
+       id="path7847" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,81.000002 h 1 v 1 h -1"
+       id="path7845" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,81.000002 h 1 v 1 h -1"
+       id="path7843" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,81.000002 h 1 v 1 h -1"
+       id="path7841" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,81.000002 h 1 v 1 h -1"
+       id="path7839" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,81.000002 h 1 v 1 h -1"
+       id="path7837" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,81.000002 h 1 v 1 h -1"
+       id="path7835" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,81.000002 h 1 v 1 h -1"
+       id="path7833" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,81.000002 h 1 v 1 h -1"
+       id="path7831" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,81.000002 h 1 v 1 h -1"
+       id="path7829" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,81 1,2e-6 v 1 h -1"
+       id="path7827"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="M 64,81.000002 65,81 v 0 1.000002 h -1"
+       id="path7825"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,81 v 0 l 1,2e-6 v 1 h -1"
+       id="path7823"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="M 62,81.000002 63,81 v 1.000002 h -1"
+       id="path7821"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,81.000002 h 1 v 1 h -1"
+       id="path7819" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,81.000002 h 1 v 1 h -1"
+       id="path7817" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,81.000002 h 1 v 1 h -1"
+       id="path7815" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,81.000002 h 1 v 1 h -1"
+       id="path7813" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,81.000002 h 1 v 1 h -1"
+       id="path7811" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,81.000002 h 1 v 1 h -1"
+       id="path7809" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,81.000002 h 1 v 1 h -1"
+       id="path7807" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,81.000002 h 1 v 1 h -1"
+       id="path7805" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,81.000002 h 1 v 1 h -1"
+       id="path7803" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,81.000002 h 1 v 1 h -1"
+       id="path7801" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,81.000002 h 1 v 1 h -1"
+       id="path7799" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,81.000002 h 1 v 1 h -1"
+       id="path7797" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,81.000002 h 1 v 1 h -1"
+       id="path7795" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,81.000002 h 1 v 1 h -1"
+       id="path7793" />
+    <path
+       style="fill:#222020;fill-opacity:0.439216"
+       d="m 47,81.000002 h 1 v 1 h -1"
+       id="path7791" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,81.000002 h 1 v 1 h -1"
+       id="path7789" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,81.000002 h 1 v 1 h -1"
+       id="path7787" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,81.000002 h 1 v 1 h -1"
+       id="path7785" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,81.000002 h 1 v 1 h -1"
+       id="path7783" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,81.000002 h 1 v 1 h -1"
+       id="path7781" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,81.000002 h 1 v 1 h -1"
+       id="path7779" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,81.000002 h 1 v 1 h -1"
+       id="path7777" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,81.000002 h 1 v 1 h -1"
+       id="path7775" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,81.000002 h 1 v 1 h -1"
+       id="path7773" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,81.000002 h 1 v 1 h -1"
+       id="path7771" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,81.000002 h 1 v 1 h -1"
+       id="path7769" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,81.000002 h 1 v 1 h -1"
+       id="path7767" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,81.000002 h 1 v 1 h -1"
+       id="path7765" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,81.000002 h 1 v 1 h -1"
+       id="path7763" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,81.000002 h 1 v 1 h -1"
+       id="path7761" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,80.000002 h 1 v 1 h -1"
+       id="path7759" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,80.000002 h 1 v 1 h -1"
+       id="path7757" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,80.000002 h 1 v 1 h -1"
+       id="path7755" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,80.000002 h 1 v 1 h -1"
+       id="path7753" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,80.000002 h 1 v 1 h -1"
+       id="path7751" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,80.000002 h 1 v 1 h -1"
+       id="path7749" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,80.000002 h 1 v 1 h -1"
+       id="path7747" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,80.000002 h 1 v 1 h -1"
+       id="path7745" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,80.000002 h 1 v 1 h -1"
+       id="path7743" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,80.000002 h 1 v 1 h -1"
+       id="path7741" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,80.000002 h 1 v 1 h -1"
+       id="path7739" />
+    <path
+       style="fill:#242020;fill-opacity:0.443137"
+       d="m 84,80.000002 h 1 v 1 h -1"
+       id="path7737" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.705882"
+       d="m 83,80.000002 h 1 v 1 h -1"
+       id="path7735" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.482353"
+       d="m 82,80.000002 h 1 v 1 h -1"
+       id="path7733" />
+    <path
+       style="fill:#252121;fill-opacity:0.243137"
+       d="m 81,80.000002 h 1 v 1 h -1"
+       id="path7731" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.611765"
+       d="m 80,80.000002 h 1 v 1 h -1"
+       id="path7729" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,80.000002 h 1 v 1 h -1"
+       id="path7727" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,80.000002 h 1 v 1 h -1"
+       id="path7725" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,80.000002 h 1 v 1 h -1"
+       id="path7723" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,80.000002 h 1 v 1 h -1"
+       id="path7721" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,80.000002 h 1 v 1 h -1"
+       id="path7719" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,80.000002 h 1 v 1 h -1"
+       id="path7717" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,80.000002 h 1 v 1 h -1"
+       id="path7715" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,80.000002 h 1 v 1 h -1"
+       id="path7713" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,80.000002 h 1 v 1 h -1"
+       id="path7711" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.992157"
+       d="m 70,80.000002 h 1 v 1 h -1"
+       id="path7709" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.772549"
+       d="m 69,80.000002 h 1 v 1 h -1"
+       id="path7707" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.513725"
+       d="m 68,80.000002 h 1 v 1 h -1"
+       id="path7705" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.333333"
+       d="m 67,80.000002 h 1 v 1 h -1"
+       id="path7703" />
+    <path
+       style="fill:#212121;fill-opacity:0.180392"
+       d="m 66,80.000002 h 1 v 1 h -1"
+       id="path7701" />
+    <path
+       style="fill:#1f1f1f;fill-opacity:0.0980392"
+       d="m 65,80 v 0 l 1,2e-6 v 1 L 65,81 v 0"
+       id="path7699"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#2e1717;fill-opacity:0.0431373"
+       d="M 64,80.000002 65,80 v 1 l -1,2e-6"
+       id="path7697"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#2e1717;fill-opacity:0.0431373"
+       d="m 63,80 1,2e-6 v 1 L 63,81"
+       id="path7695"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#1f1f1f;fill-opacity:0.0980392"
+       d="M 62,80.000002 63,80 v 0 1 0 l -1,2e-6"
+       id="path7693"
+       sodipodi:nodetypes="ccccac" />
+    <path
+       style="fill:#212121;fill-opacity:0.180392"
+       d="m 61,80.000002 h 1 v 1 h -1"
+       id="path7691" />
+    <path
+       style="fill:#232020;fill-opacity:0.345098"
+       d="m 60,80.000002 h 1 v 1 h -1"
+       id="path7689" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.517647"
+       d="m 59,80.000002 h 1 v 1 h -1"
+       id="path7687" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.776471"
+       d="m 58,80.000002 h 1 v 1 h -1"
+       id="path7685" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.992157"
+       d="m 57,80.000002 h 1 v 1 h -1"
+       id="path7683" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,80.000002 h 1 v 1 h -1"
+       id="path7681" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,80.000002 h 1 v 1 h -1"
+       id="path7679" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,80.000002 h 1 v 1 h -1"
+       id="path7677" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,80.000002 h 1 v 1 h -1"
+       id="path7675" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,80.000002 h 1 v 1 h -1"
+       id="path7673" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,80.000002 h 1 v 1 h -1"
+       id="path7671" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,80.000002 h 1 v 1 h -1"
+       id="path7669" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,80.000002 h 1 v 1 h -1"
+       id="path7667" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,80.000002 h 1 v 1 h -1"
+       id="path7665" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.611765"
+       d="m 47,80.000002 h 1 v 1 h -1"
+       id="path7663" />
+    <path
+       style="fill:#252121;fill-opacity:0.243137"
+       d="m 46,80.000002 h 1 v 1 h -1"
+       id="path7661" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.482353"
+       d="m 45,80.000002 h 1 v 1 h -1"
+       id="path7659" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.705882"
+       d="m 44,80.000002 h 1 v 1 h -1"
+       id="path7657" />
+    <path
+       style="fill:#242020;fill-opacity:0.443137"
+       d="m 43,80.000002 h 1 v 1 h -1"
+       id="path7655" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,80.000002 h 1 v 1 h -1"
+       id="path7653" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,80.000002 h 1 v 1 h -1"
+       id="path7651" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,80.000002 h 1 v 1 h -1"
+       id="path7649" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,80.000002 h 1 v 1 h -1"
+       id="path7647" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,80.000002 h 1 v 1 h -1"
+       id="path7645" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,80.000002 h 1 v 1 h -1"
+       id="path7643" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,80.000002 h 1 v 1 h -1"
+       id="path7641" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,80.000002 h 1 v 1 h -1"
+       id="path7639" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,80.000002 h 1 v 1 h -1"
+       id="path7637" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,80.000002 h 1 v 1 h -1"
+       id="path7635" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,80.000002 h 1 v 1 h -1"
+       id="path7633" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,79.000002 h 1 v 1 h -1"
+       id="path7631" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,79.000002 h 1 v 1 h -1"
+       id="path7629" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,79.000002 h 1 v 1 h -1"
+       id="path7627" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,79.000002 h 1 v 1 h -1"
+       id="path7625" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,79.000002 h 1 v 1 h -1"
+       id="path7623" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,79.000002 h 1 v 1 h -1"
+       id="path7621" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,79.000002 h 1 v 1 h -1"
+       id="path7619" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,79.000002 h 1 v 1 h -1"
+       id="path7617" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,79.000002 h 1 v 1 h -1"
+       id="path7615" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,79.000002 h 1 v 1 h -1"
+       id="path7613" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,79.000002 h 1 v 1 h -1"
+       id="path7611" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.705882"
+       d="m 84,79.000002 h 1 v 1 h -1"
+       id="path7609" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,79.000002 h 1 v 1 h -1"
+       id="path7607" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,79.000002 h 1 v 1 h -1"
+       id="path7605" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,79.000002 h 1 v 1 h -1"
+       id="path7603" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,79.000002 h 1 v 1 h -1"
+       id="path7601" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,79.000002 h 1 v 1 h -1"
+       id="path7599" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,79.000002 h 1 v 1 h -1"
+       id="path7597" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 77,79.000002 h 1 v 1 h -1"
+       id="path7595" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.584314"
+       d="m 76,79.000002 h 1 v 1 h -1"
+       id="path7593" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.917647"
+       d="m 75,79.000002 h 1 v 1 h -1"
+       id="path7591" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,79.000002 h 1 v 1 h -1"
+       id="path7589" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,79.000002 h 1 v 1 h -1"
+       id="path7587" />
+    <path
+       style="fill:#232020;fill-opacity:0.823529"
+       d="m 72,79.000002 h 1 v 1 h -1"
+       id="path7585" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.423529"
+       d="m 71,79.000002 h 1 v 1 h -1"
+       id="path7583" />
+    <path
+       style="fill:#1e1e1e;fill-opacity:0.0666667"
+       d="m 70,79.000002 h 1 v 1 h -1"
+       id="path7581" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,79.000002 h 1 v 1 h -1"
+       id="path7579" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,79.000002 h 1 v 1 h -1"
+       id="path7577" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,79.000002 h 1 v 1 h -1"
+       id="path7575" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,79.000002 h 1 v 1 h -1"
+       id="path7573" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,79.000002 h 1 v 1 l -0.75,-0.25"
+       id="path7571" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,79.000002 h 1 l 0.25,0.75 -0.5,0.5 -0.75,-0.25"
+       id="path7569" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,79.000002 h 1 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path7567" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,79.000002 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path7565" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,79.000002 h 1 v 1 h -1"
+       id="path7563" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,79.000002 h 1 v 1 h -1"
+       id="path7561" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,79.000002 h 1 v 1 h -1"
+       id="path7559" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,79.000002 h 1 v 1 h -1"
+       id="path7557" />
+    <path
+       style="fill:#1e1e1e;fill-opacity:0.0666667"
+       d="m 57,79.000002 h 1 v 1 h -1"
+       id="path7555" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.423529"
+       d="m 56,79.000002 h 1 v 1 h -1"
+       id="path7553" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 55,79.000002 h 1 v 1 h -1"
+       id="path7551" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,79.000002 h 1 v 1 h -1"
+       id="path7549" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,79.000002 h 1 v 1 h -1"
+       id="path7547" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 52,79.000002 h 1 v 1 h -1"
+       id="path7545" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.686275"
+       d="m 51,79.000002 h 1 v 1 h -1"
+       id="path7543" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.780392"
+       d="m 50,79.000002 h 1 v 1 h -1"
+       id="path7541" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,79.000002 h 1 v 1 h -1"
+       id="path7539" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,79.000002 h 1 v 1 h -1"
+       id="path7537" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,79.000002 h 1 v 1 h -1"
+       id="path7535" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,79.000002 h 1 v 1 h -1"
+       id="path7533" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,79.000002 h 1 v 1 h -1"
+       id="path7531" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,79.000002 h 1 v 1 h -1"
+       id="path7529" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.705882"
+       d="m 43,79.000002 h 1 v 1 h -1"
+       id="path7527" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,79.000002 h 1 v 1 h -1"
+       id="path7525" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,79.000002 h 1 v 1 h -1"
+       id="path7523" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,79.000002 h 1 v 1 h -1"
+       id="path7521" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,79.000002 h 1 v 1 h -1"
+       id="path7519" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,79.000002 h 1 v 1 h -1"
+       id="path7517" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,79.000002 h 1 v 1 h -1"
+       id="path7515" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,79.000002 h 1 v 1 h -1"
+       id="path7513" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,79.000002 h 1 v 1 h -1"
+       id="path7511" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,79.000002 h 1 v 1 h -1"
+       id="path7509" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,79.000002 h 1 v 1 h -1"
+       id="path7507" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,79.000002 h 1 v 1 h -1"
+       id="path7505" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,78.000002 h 1 v 1 h -1"
+       id="path7503" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,78.000002 h 1 v 1 h -1"
+       id="path7501" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,78.000002 h 1 v 1 h -1"
+       id="path7499" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,78.000002 h 1 v 1 h -1"
+       id="path7497" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,78.000002 h 1 v 1 h -1"
+       id="path7495" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,78.000002 h 1 v 1 h -1"
+       id="path7493" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,78.000002 h 1 v 1 h -1"
+       id="path7491" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,78.000002 h 1 v 1 h -1"
+       id="path7489" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,78.000002 h 1 v 1 h -1"
+       id="path7487" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,78.000002 h 1 v 1 h -1"
+       id="path7485" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,78.000002 h 1 v 1 h -1"
+       id="path7483" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.482353"
+       d="m 84,78.000002 h 1 v 1 h -1"
+       id="path7481" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,78.000002 h 1 v 1 h -1"
+       id="path7479" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,78.000002 h 1 v 1 h -1"
+       id="path7477" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,78.000002 h 1 v 1 h -1"
+       id="path7475" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,78.000002 h 1 v 1 h -1"
+       id="path7473" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,78.000002 h 1 v 1 h -1"
+       id="path7471" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.847059"
+       d="m 78,78.000002 h 1 v 1 h -1"
+       id="path7469" />
+    <path
+       style="fill:#2b2b2b;fill-opacity:0.0235294"
+       d="m 77,78.000002 h 1 v 1 h -1"
+       id="path7467" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,78.000002 h 1 v 1 h -1"
+       id="path7465" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.196078"
+       d="m 75,78.000002 h 1 v 1 h -1"
+       id="path7463" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,78.000002 h 1 v 1 h -1"
+       id="path7461" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,78.000002 h 1 v 1 h -1"
+       id="path7459" />
+    <path
+       style="fill:#212121;fill-opacity:0.152941"
+       d="m 72,78.000002 h 1 v 1 h -1"
+       id="path7457" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,78.000002 h 1 v 1 h -1"
+       id="path7455" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,78.000002 h 1 v 1 h -1"
+       id="path7453" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,78.000002 h 1 v 1 h -1"
+       id="path7451" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,78.000002 h 1 v 1 h -1"
+       id="path7449" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,78.000002 h 1 v 1 h -1"
+       id="path7447" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,78.000002 h 1 v 1 h -1"
+       id="path7445" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,78.000002 h 1 v 1 h -1"
+       id="path7443" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,78.000002 h 1 v 1 h -1"
+       id="path7441" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,78.000002 h 1 v 1 h -1"
+       id="path7439" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,78.000002 h 1 v 1 h -1"
+       id="path7437" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,78.000002 h 1 v 1 h -1"
+       id="path7435" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,78.000002 h 1 v 1 h -1"
+       id="path7433" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,78.000002 h 1 v 1 h -1"
+       id="path7431" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,78.000002 h 1 v 1 h -1"
+       id="path7429" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,78.000002 h 1 v 1 h -1"
+       id="path7427" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55.75,78.250002 0.5,-0.5 0.75,0.25 v 1 h -1"
+       id="path7425" />
+    <path
+       style="fill:#333333;fill-opacity:0.0196078"
+       d="m 55,78.000002 0.75,0.25 0.25,0.75 h -1"
+       id="path7423" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.968627"
+       d="m 54,78.000002 h 1 v 1 h -1"
+       id="path7421" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,78.000002 h 1 v 1 h -1"
+       id="path7419" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 52,78.000002 h 1 v 1 h -1"
+       id="path7417" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,78.000002 h 1 v 1 h -1"
+       id="path7415" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 50,78.000002 h 1 v 1 h -1"
+       id="path7413" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.721569"
+       d="m 49,78.000002 h 1 v 1 h -1"
+       id="path7411" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,78.000002 h 1 v 1 h -1"
+       id="path7409" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,78.000002 h 1 v 1 h -1"
+       id="path7407" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,78.000002 h 1 v 1 h -1"
+       id="path7405" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,78.000002 h 1 v 1 h -1"
+       id="path7403" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,78.000002 h 1 v 1 h -1"
+       id="path7401" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.482353"
+       d="m 43,78.000002 h 1 v 1 h -1"
+       id="path7399" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,78.000002 h 1 v 1 h -1"
+       id="path7397" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,78.000002 h 1 v 1 h -1"
+       id="path7395" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,78.000002 h 1 v 1 h -1"
+       id="path7393" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,78.000002 h 1 v 1 h -1"
+       id="path7391" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,78.000002 h 1 v 1 h -1"
+       id="path7389" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,78.000002 h 1 v 1 h -1"
+       id="path7387" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,78.000002 h 1 v 1 h -1"
+       id="path7385" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,78.000002 h 1 v 1 h -1"
+       id="path7383" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,78.000002 h 1 v 1 h -1"
+       id="path7381" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,78.000002 h 1 v 1 h -1"
+       id="path7379" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,78.000002 h 1 v 1 h -1"
+       id="path7377" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,77.000002 h 1 v 1 h -1"
+       id="path7375" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,77.000002 h 1 v 1 h -1"
+       id="path7373" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,77.000002 h 1 v 1 h -1"
+       id="path7371" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,77.000002 h 1 v 1 h -1"
+       id="path7369" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,77.000002 h 1 v 1 h -1"
+       id="path7367" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,77.000002 h 1 v 1 h -1"
+       id="path7365" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,77.000002 h 1 v 1 h -1"
+       id="path7363" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,77.000002 h 1 v 1 h -1"
+       id="path7361" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,77.000002 h 1 v 1 h -1"
+       id="path7359" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,77.000002 h 1 v 1 h -1"
+       id="path7357" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,77.000002 h 1 v 1 h -1"
+       id="path7355" />
+    <path
+       style="fill:#242020;fill-opacity:0.247059"
+       d="m 84,77.000002 h 1 v 1 h -1"
+       id="path7353" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,77.000002 h 1 v 1 h -1"
+       id="path7351" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,77.000002 h 1 v 1 h -1"
+       id="path7349" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,77.000002 h 1 v 1 h -1"
+       id="path7347" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,77.000002 h 1 v 1 h -1"
+       id="path7345" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,77.000002 h 1 v 1 h -1"
+       id="path7343" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.733333"
+       d="m 78,77.000002 h 1 v 1 h -1"
+       id="path7341" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,77.000002 h 1 v 1 h -1"
+       id="path7339" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,77.000002 h 1 v 1 h -1"
+       id="path7337" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 75,77.000002 h 1 v 1 h -1"
+       id="path7335" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,77.000002 h 1 v 1 h -1"
+       id="path7333" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.937255"
+       d="m 73,77.000002 h 1 v 1 h -1"
+       id="path7331" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 72,77.000002 h 1 v 1 h -1"
+       id="path7329" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,77.000002 h 1 v 1 h -1"
+       id="path7327" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,77.000002 h 1 v 1 h -1"
+       id="path7325" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,77.000002 h 1 v 1 h -1"
+       id="path7323" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,77.000002 h 1 v 1 h -1"
+       id="path7321" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,77.000002 h 1 v 1 h -1"
+       id="path7319" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,77.000002 h 1 v 1 h -1"
+       id="path7317" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,77.000002 h 1 v 1 h -1"
+       id="path7315" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,77.000002 h 1 v 1 h -1"
+       id="path7313" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,77.000002 h 1 v 1 h -1"
+       id="path7311" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,77.000002 h 1 v 1 h -1"
+       id="path7309" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,77.000002 h 1 v 1 h -1"
+       id="path7307" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,77.000002 h 1 v 1 h -1"
+       id="path7305" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,77.000002 h 1 v 1 h -1"
+       id="path7303" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,77.000002 h 1 v 1 h -1"
+       id="path7301" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,77.000002 h 1 v 1 h -1"
+       id="path7299" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,77.000002 h 1 v 1 l -0.75,-0.25"
+       id="path7297" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,77.000002 h 1 l 0.25,0.75 -0.5,0.5 -0.75,-0.25"
+       id="path7295" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.776471"
+       d="m 54,77.000002 h 1 v 1 h -1"
+       id="path7293" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,77.000002 h 1 v 1 h -1"
+       id="path7291" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.223529"
+       d="m 52,77.000002 h 1 v 1 h -1"
+       id="path7289" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,77.000002 h 1 v 1 h -1"
+       id="path7287" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,77.000002 h 1 v 1 h -1"
+       id="path7285" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 49,77.000002 h 1 v 1 h -1"
+       id="path7283" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,77.000002 h 1 v 1 h -1"
+       id="path7281" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,77.000002 h 1 v 1 h -1"
+       id="path7279" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,77.000002 h 1 v 1 h -1"
+       id="path7277" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,77.000002 h 1 v 1 h -1"
+       id="path7275" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,77.000002 h 1 v 1 h -1"
+       id="path7273" />
+    <path
+       style="fill:#242020;fill-opacity:0.247059"
+       d="m 43,77.000002 h 1 v 1 h -1"
+       id="path7271" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,77.000002 h 1 v 1 h -1"
+       id="path7269" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,77.000002 h 1 v 1 h -1"
+       id="path7267" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,77.000002 h 1 v 1 h -1"
+       id="path7265" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,77.000002 h 1 v 1 h -1"
+       id="path7263" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,77.000002 h 1 v 1 h -1"
+       id="path7261" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,77.000002 h 1 v 1 h -1"
+       id="path7259" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,77.000002 h 1 v 1 h -1"
+       id="path7257" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,77.000002 h 1 v 1 h -1"
+       id="path7255" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,77.000002 h 1 v 1 h -1"
+       id="path7253" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,77.000002 h 1 v 1 h -1"
+       id="path7251" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,77.000002 h 1 v 1 h -1"
+       id="path7249" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,76.000002 h 1 v 1 h -1"
+       id="path7247" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,76.000002 h 1 v 1 h -1"
+       id="path7245" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,76.000002 h 1 v 1 h -1"
+       id="path7243" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,76.000002 h 1 v 1 h -1"
+       id="path7241" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,76.000002 h 1 v 1 h -1"
+       id="path7239" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,76.000002 h 1 v 1 h -1"
+       id="path7237" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,76.000002 h 1 v 1 h -1"
+       id="path7235" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0352941"
+       d="m 88,76.000002 h 1 v 1 h -1"
+       id="path7233" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 87,76.000002 h 1 v 1 h -1"
+       id="path7231" />
+    <path
+       style="fill:#242020;fill-opacity:0.501961"
+       d="m 86,76.000002 h 1 v 1 h -1"
+       id="path7229" />
+    <path
+       style="fill:#222020;fill-opacity:0.439216"
+       d="m 85,76.000002 h 1 v 1 h -1"
+       id="path7227" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.611765"
+       d="m 84,76.000002 h 1 v 1 h -1"
+       id="path7225" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,76.000002 h 1 v 1 h -1"
+       id="path7223" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,76.000002 h 1 v 1 h -1"
+       id="path7221" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,76.000002 h 1 v 1 h -1"
+       id="path7219" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,76.000002 h 1 v 1 h -1"
+       id="path7217" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,76.000002 h 1 v 1 h -1"
+       id="path7215" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.988235"
+       d="m 78,76.000002 h 1 v 1 h -1"
+       id="path7213" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.4"
+       d="m 77,76.000002 h 1 v 1 h -1"
+       id="path7211" />
+    <path
+       style="fill:#202020;fill-opacity:0.156863"
+       d="m 76,76.000002 h 1 v 1 h -1"
+       id="path7209" />
+    <path
+       style="fill:#232020;fill-opacity:0.666667"
+       d="m 75,76.000002 h 1 v 1 h -1"
+       id="path7207" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,76.000002 h 1 v 1 h -1"
+       id="path7205" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.72549"
+       d="m 73,76.000002 h 1 v 1 h -1"
+       id="path7203" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,76.000002 h 1 v 1 h -1"
+       id="path7201" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,76.000002 h 1 v 1 h -1"
+       id="path7199" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,76.000002 h 1 v 1 h -1"
+       id="path7197" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,76.000002 h 1 v 1 h -1"
+       id="path7195" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,76.000002 h 1 v 1 h -1"
+       id="path7193" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,76.000002 h 1 v 1 h -1"
+       id="path7191" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,76.000002 h 1 v 1 h -1"
+       id="path7189" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,76.000002 h 1 v 1 h -1"
+       id="path7187" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,76.000002 h 1 v 1 h -1"
+       id="path7185" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,76.000002 h 1 v 1 h -1"
+       id="path7183" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,76.000002 h 1 v 1 h -1"
+       id="path7181" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,76.000002 h 1 v 1 h -1"
+       id="path7179" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,76.000002 h 1 v 1 h -1"
+       id="path7177" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,76.000002 h 1 v 1 h -1"
+       id="path7175" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,76.000002 h 1 v 1 h -1"
+       id="path7173" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,76.000002 h 1 v 1 h -1"
+       id="path7171" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,76.000002 h 1 v 1 h -1"
+       id="path7169" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,76.000002 h 1 v 1 h -1"
+       id="path7167" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.560784"
+       d="m 54,76.000002 h 1 v 1 h -1"
+       id="path7165" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,76.000002 h 1 v 1 h -1"
+       id="path7163" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.721569"
+       d="m 52,76.000002 h 1 v 1 h -1"
+       id="path7161" />
+    <path
+       style="fill:#222222;fill-opacity:0.117647"
+       d="m 51,76.000002 h 1 v 1 h -1"
+       id="path7159" />
+    <path
+       style="fill:#242020;fill-opacity:0.219608"
+       d="m 50,76.000002 h 1 v 1 h -1"
+       id="path7157" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.909804"
+       d="m 49,76.000002 h 1 v 1 h -1"
+       id="path7155" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,76.000002 h 1 v 1 h -1"
+       id="path7153" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,76.000002 h 1 v 1 h -1"
+       id="path7151" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,76.000002 h 1 v 1 h -1"
+       id="path7149" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,76.000002 h 1 v 1 h -1"
+       id="path7147" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,76.000002 h 1 v 1 h -1"
+       id="path7145" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.611765"
+       d="m 43,76.000002 h 1 v 1 h -1"
+       id="path7143" />
+    <path
+       style="fill:#222020;fill-opacity:0.439216"
+       d="m 42,76.000002 h 1 v 1 h -1"
+       id="path7141" />
+    <path
+       style="fill:#242020;fill-opacity:0.501961"
+       d="m 41,76.000002 h 1 v 1 h -1"
+       id="path7139" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 40,76.000002 h 1 v 1 h -1"
+       id="path7137" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0352941"
+       d="m 39,76.000002 h 1 v 1 h -1"
+       id="path7135" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,76.000002 h 1 v 1 h -1"
+       id="path7133" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,76.000002 h 1 v 1 h -1"
+       id="path7131" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,76.000002 h 1 v 1 h -1"
+       id="path7129" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,76.000002 h 1 v 1 h -1"
+       id="path7127" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,76.000002 h 1 v 1 h -1"
+       id="path7125" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,76.000002 h 1 v 1 h -1"
+       id="path7123" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,76.000002 h 1 v 1 h -1"
+       id="path7121" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,75.000002 h 1 v 1 h -1"
+       id="path7119" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,75.000002 h 1 v 1 h -1"
+       id="path7117" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,75.000002 h 1 v 1 h -1"
+       id="path7115" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,75.000002 h 1 v 1 h -1"
+       id="path7113" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,75.000002 h 1 v 1 h -1"
+       id="path7111" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,75.000002 h 1 v 1 h -1"
+       id="path7109" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,75.000002 h 1 v 1 h -1"
+       id="path7107" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.223529"
+       d="m 88,75.000002 h 1 v 1 h -1"
+       id="path7105" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,75.000002 h 1 v 1 h -1"
+       id="path7103" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,75.000002 h 1 v 1 h -1"
+       id="path7101" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,75.000002 h 1 v 1 h -1"
+       id="path7099" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,75.000002 h 1 v 1 h -1"
+       id="path7097" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,75.000002 h 1 v 1 h -1"
+       id="path7095" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,75.000002 h 1 v 1 h -1"
+       id="path7093" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,75.000002 h 1 v 1 h -1"
+       id="path7091" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,75.000002 h 1 v 1 h -1"
+       id="path7089" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,75.000002 h 1 v 1 h -1"
+       id="path7087" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,75.000002 h 1 v 1 h -1"
+       id="path7085" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,75.000002 h 1 v 1 h -1"
+       id="path7083" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,75.000002 h 1 v 1 h -1"
+       id="path7081" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,75.000002 h 1 v 1 h -1"
+       id="path7079" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,75.000002 h 1 v 1 h -1"
+       id="path7077" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.509804"
+       d="m 73,75.000002 h 1 v 1 h -1"
+       id="path7075" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,75.000002 h 1 v 1 h -1"
+       id="path7073" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,75.000002 h 1 v 1 h -1"
+       id="path7071" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,75.000002 h 1 v 1 h -1"
+       id="path7069" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,75.000002 h 1 v 1 h -1"
+       id="path7067" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,75.000002 h 1 v 1 h -1"
+       id="path7065" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,75.000002 h 1 v 1 h -1"
+       id="path7063" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,75.000002 h 1 v 1 h -1"
+       id="path7061" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,75.000002 h 1 v 1 h -1"
+       id="path7059" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,75.000002 h 1 v 1 h -1"
+       id="path7057" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,75.000002 h 1 v 1 h -1"
+       id="path7055" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,75.000002 h 1 v 1 h -1"
+       id="path7053" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,75.000002 h 1 v 1 h -1"
+       id="path7051" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,75.000002 h 1 v 1 h -1"
+       id="path7049" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,75.000002 h 1 v 1 h -1"
+       id="path7047" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,75.000002 h 1 v 1 h -1"
+       id="path7045" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,75.000002 h 1 v 1 h -1"
+       id="path7043" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,75.000002 h 1 v 1 h -1"
+       id="path7041" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,75.000002 h 1 v 1 h -1"
+       id="path7039" />
+    <path
+       style="fill:#232020;fill-opacity:0.345098"
+       d="m 54,75.000002 h 1 v 1 h -1"
+       id="path7037" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,75.000002 h 1 v 1 h -1"
+       id="path7035" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,75.000002 h 1 v 1 h -1"
+       id="path7033" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,75.000002 h 1 v 1 h -1"
+       id="path7031" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,75.000002 h 1 v 1 h -1"
+       id="path7029" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,75.000002 h 1 v 1 h -1"
+       id="path7027" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,75.000002 h 1 v 1 h -1"
+       id="path7025" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,75.000002 h 1 v 1 h -1"
+       id="path7023" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,75.000002 h 1 v 1 h -1"
+       id="path7021" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,75.000002 h 1 v 1 h -1"
+       id="path7019" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,75.000002 h 1 v 1 h -1"
+       id="path7017" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,75.000002 h 1 v 1 h -1"
+       id="path7015" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,75.000002 h 1 v 1 h -1"
+       id="path7013" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,75.000002 h 1 v 1 h -1"
+       id="path7011" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,75.000002 h 1 v 1 h -1"
+       id="path7009" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.223529"
+       d="m 39,75.000002 h 1 v 1 h -1"
+       id="path7007" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,75.000002 h 1 v 1 h -1"
+       id="path7005" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,75.000002 h 1 v 1 h -1"
+       id="path7003" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,75.000002 h 1 v 1 h -1"
+       id="path7001" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,75.000002 h 1 v 1 h -1"
+       id="path6999" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,75.000002 h 1 v 1 h -1"
+       id="path6997" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,75.000002 h 1 v 1 h -1"
+       id="path6995" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,75.000002 h 1 v 1 h -1"
+       id="path6993" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,74.000002 h 1 v 1 h -1"
+       id="path6991" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,74.000002 h 1 v 1 h -1"
+       id="path6989" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,74.000002 h 1 v 1 h -1"
+       id="path6987" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,74.000002 h 1 v 1 h -1"
+       id="path6985" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,74.000002 h 1 v 1 h -1"
+       id="path6983" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,74.000002 h 1 v 1 h -1"
+       id="path6981" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,74.000002 h 1 v 1 h -1"
+       id="path6979" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 88,74.000002 h 1 v 1 h -1"
+       id="path6977" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 87,74.000002 h 1 v 1 h -1"
+       id="path6975" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,74.000002 h 1 v 1 h -1"
+       id="path6973" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,74.000002 h 1 v 1 h -1"
+       id="path6971" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,74.000002 h 1 v 1 h -1"
+       id="path6969" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,74.000002 h 1 v 1 h -1"
+       id="path6967" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,74.000002 h 1 v 1 h -1"
+       id="path6965" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,74.000002 h 1 v 1 h -1"
+       id="path6963" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,74.000002 h 1 v 1 h -1"
+       id="path6961" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 79,74.000002 h 1 v 1 h -1"
+       id="path6959" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.498039"
+       d="m 78,74.000002 h 1 v 1 h -1"
+       id="path6957" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.713725"
+       d="m 77,74.000002 h 1 v 1 h -1"
+       id="path6955" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.929412"
+       d="m 76,74.000002 h 1 v 1 h -1"
+       id="path6953" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,74.000002 h 1 v 1 h -1"
+       id="path6951" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.941176"
+       d="m 74,74.000002 h 1 v 1 h -1"
+       id="path6949" />
+    <path
+       style="fill:#212121;fill-opacity:0.152941"
+       d="m 73,74.000002 h 1 v 1 h -1"
+       id="path6947" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,74.000002 h 1 v 1 h -1"
+       id="path6945" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,74.000002 h 1 v 1 h -1"
+       id="path6943" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,74.000002 h 1 v 1 h -1"
+       id="path6941" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,74.000002 h 1 v 1 h -1"
+       id="path6939" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,74.000002 h 1 v 1 h -1"
+       id="path6937" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,74.000002 h 1 v 1 h -1"
+       id="path6935" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,74.000002 h 1 v 1 h -1"
+       id="path6933" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,74.000002 h 1 v 1 h -1"
+       id="path6931" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,74.000002 h 1 v 1 h -1"
+       id="path6929" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,74.000002 h 1 v 1 h -1"
+       id="path6927" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,74.000002 h 1 v 1 h -1"
+       id="path6925" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,74.000002 h 1 v 1 h -1"
+       id="path6923" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,74.000002 h 1 v 1 h -1"
+       id="path6921" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,74.000002 h 1 v 1 h -1"
+       id="path6919" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,74.000002 h 1 v 1 h -1"
+       id="path6917" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,74.000002 h 1 v 1 h -1"
+       id="path6915" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,74.000002 h 1 v 1 h -1"
+       id="path6913" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,74.000002 h 1 v 1 h -1"
+       id="path6911" />
+    <path
+       style="fill:#1e1e1e;fill-opacity:0.0666667"
+       d="m 54,74.000002 h 1 v 1 h -1"
+       id="path6909" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.913725"
+       d="m 53,74.000002 h 1 v 1 h -1"
+       id="path6907" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,74.000002 h 1 v 1 h -1"
+       id="path6905" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 51,74.000002 h 1 v 1 h -1"
+       id="path6903" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.839216"
+       d="m 50,74.000002 h 1 v 1 h -1"
+       id="path6901" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.623529"
+       d="m 49,74.000002 h 1 v 1 h -1"
+       id="path6899" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.772549"
+       d="m 48,74.000002 h 1 v 1 h -1"
+       id="path6897" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,74.000002 h 1 v 1 h -1"
+       id="path6895" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,74.000002 h 1 v 1 h -1"
+       id="path6893" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,74.000002 h 1 v 1 h -1"
+       id="path6891" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,74.000002 h 1 v 1 h -1"
+       id="path6889" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,74.000002 h 1 v 1 h -1"
+       id="path6887" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,74.000002 h 1 v 1 h -1"
+       id="path6885" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,74.000002 h 1 v 1 h -1"
+       id="path6883" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 40,74.000002 h 1 v 1 h -1"
+       id="path6881" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 39,74.000002 h 1 v 1 h -1"
+       id="path6879" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,74.000002 h 1 v 1 h -1"
+       id="path6877" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,74.000002 h 1 v 1 h -1"
+       id="path6875" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,74.000002 h 1 v 1 h -1"
+       id="path6873" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,74.000002 h 1 v 1 h -1"
+       id="path6871" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,74.000002 h 1 v 1 h -1"
+       id="path6869" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,74.000002 h 1 v 1 h -1"
+       id="path6867" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,74.000002 h 1 v 1 h -1"
+       id="path6865" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,73.000002 h 1 v 1 h -1"
+       id="path6863" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,73.000002 h 1 v 1 h -1"
+       id="path6861" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,73.000002 h 1 v 1 h -1"
+       id="path6859" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,73.000002 h 1 v 1 h -1"
+       id="path6857" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,73.000002 h 1 v 1 h -1"
+       id="path6855" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,73.000002 h 1 v 1 h -1"
+       id="path6853" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,73.000002 h 1 v 1 h -1"
+       id="path6851" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,73.000002 h 1 v 1 h -1"
+       id="path6849" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 87,73.000002 h 1 v 1 h -1"
+       id="path6847" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,73.000002 h 1 v 1 h -1"
+       id="path6845" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,73.000002 h 1 v 1 h -1"
+       id="path6843" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,73.000002 h 1 v 1 h -1"
+       id="path6841" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,73.000002 h 1 v 1 h -1"
+       id="path6839" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,73.000002 h 1 v 1 h -1"
+       id="path6837" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,73.000002 h 1 v 1 h -1"
+       id="path6835" />
+    <path
+       style="fill:#232020;fill-opacity:0.823529"
+       d="m 80,73.000002 h 1 v 1 h -1"
+       id="path6833" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,73.000002 h 1 v 1 h -1"
+       id="path6831" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,73.000002 h 1 v 1 h -1"
+       id="path6829" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,73.000002 h 1 v 1 h -1"
+       id="path6827" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,73.000002 h 1 v 1 h -1"
+       id="path6825" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,73.000002 h 1 v 1 h -1"
+       id="path6823" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,73.000002 h 1 v 1 h -1"
+       id="path6821" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,73.000002 h 1 v 1 h -1"
+       id="path6819" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,73.000002 h 1 v 1 h -1"
+       id="path6817" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,73.000002 h 1 v 1 h -1"
+       id="path6815" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,73.000002 h 1 v 1 h -1"
+       id="path6813" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,73.000002 h 1 v 1 h -1"
+       id="path6811" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,73.000002 h 1 v 1 h -1"
+       id="path6809" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,73.000002 h 1 v 1 h -1"
+       id="path6807" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,73.000002 h 1 v 1 h -1"
+       id="path6805" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,73.000002 h 1 v 1 h -1"
+       id="path6803" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,73.000002 h 1 v 1 h -1"
+       id="path6801" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,73.000002 h 1 v 1 h -1"
+       id="path6799" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,73.000002 h 1 v 1 h -1"
+       id="path6797" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,73.000002 h 1 v 1 h -1"
+       id="path6795" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,73.000002 h 1 v 1 h -1"
+       id="path6793" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,73.000002 h 1 v 1 h -1"
+       id="path6791" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,73.000002 h 1 v 1 h -1"
+       id="path6789" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,73.000002 h 1 v 1 h -1"
+       id="path6787" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,73.000002 h 1 v 1 h -1"
+       id="path6785" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,73.000002 h 1 v 1 h -1"
+       id="path6783" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,73.000002 h 1 v 1 h -1"
+       id="path6781" />
+    <path
+       style="fill:#202020;fill-opacity:0.0627451"
+       d="m 53,73.000002 h 1 v 1 h -1"
+       id="path6779" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.231373"
+       d="m 52,73.000002 h 1 v 1 h -1"
+       id="path6777" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 51,73.000002 h 1 v 1 h -1"
+       id="path6775" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,73.000002 h 1 v 1 h -1"
+       id="path6773" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,73.000002 h 1 v 1 h -1"
+       id="path6771" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 48,73.000002 h 1 v 1 h -1"
+       id="path6769" />
+    <path
+       style="fill:#232020;fill-opacity:0.823529"
+       d="m 47,73.000002 h 1 v 1 h -1"
+       id="path6767" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,73.000002 h 1 v 1 h -1"
+       id="path6765" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,73.000002 h 1 v 1 h -1"
+       id="path6763" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,73.000002 h 1 v 1 h -1"
+       id="path6761" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,73.000002 h 1 v 1 h -1"
+       id="path6759" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,73.000002 h 1 v 1 h -1"
+       id="path6757" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,73.000002 h 1 v 1 h -1"
+       id="path6755" />
+    <path
+       style="fill:#232020;fill-opacity:0.403922"
+       d="m 40,73.000002 h 1 v 1 h -1"
+       id="path6753" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,73.000002 h 1 v 1 h -1"
+       id="path6751" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,73.000002 h 1 v 1 h -1"
+       id="path6749" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,73.000002 h 1 v 1 h -1"
+       id="path6747" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,73.000002 h 1 v 1 h -1"
+       id="path6745" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,73.000002 h 1 v 1 h -1"
+       id="path6743" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,73.000002 h 1 v 1 h -1"
+       id="path6741" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,73.000002 h 1 v 1 h -1"
+       id="path6739" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,73.000002 h 1 v 1 h -1"
+       id="path6737" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,72.000002 h 1 v 1 h -1"
+       id="path6735" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,72.000002 h 1 v 1 h -1"
+       id="path6733" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,72.000002 h 1 v 1 h -1"
+       id="path6731" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,72.000002 h 1 v 1 h -1"
+       id="path6729" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,72.000002 h 1 v 1 h -1"
+       id="path6727" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,72.000002 h 1 v 1 h -1"
+       id="path6725" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,72.000002 h 1 v 1 h -1"
+       id="path6723" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,72.000002 h 1 v 1 h -1"
+       id="path6721" />
+    <path
+       style="fill:#242020;fill-opacity:0.219608"
+       d="m 87,72.000002 h 1 v 1 h -1"
+       id="path6719" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,72.000002 h 1 v 1 h -1"
+       id="path6717" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,72.000002 h 1 v 1 h -1"
+       id="path6715" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,72.000002 h 1 v 1 h -1"
+       id="path6713" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,72.000002 h 1 v 1 h -1"
+       id="path6711" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,72.000002 h 1 v 1 h -1"
+       id="path6709" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,72.000002 h 1 v 1 h -1"
+       id="path6707" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,72.000002 h 1 v 1 h -1"
+       id="path6705" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,72.000002 h 1 v 1 h -1"
+       id="path6703" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,72.000002 h 1 v 1 h -1"
+       id="path6701" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,72.000002 h 1 v 1 h -1"
+       id="path6699" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,72.000002 h 1 v 1 h -1"
+       id="path6697" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,72.000002 h 1 v 1 h -1"
+       id="path6695" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,72.000002 h 1 v 1 h -1"
+       id="path6693" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,72.000002 h 1 v 1 h -1"
+       id="path6691" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,72.000002 h 1 v 1 h -1"
+       id="path6689" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,72.000002 h 1 v 1 h -1"
+       id="path6687" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,72.000002 h 1 v 1 h -1"
+       id="path6685" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,72.000002 h 1 v 1 h -1"
+       id="path6683" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,72.000002 h 1 v 1 h -1"
+       id="path6681" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,72.000002 h 1 v 1 h -1"
+       id="path6679" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,72.000002 h 1 v 1 h -1"
+       id="path6677" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,72.000002 h 1 v 1 h -1"
+       id="path6675" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,72.000002 h 1 v 1 h -1"
+       id="path6673" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,72.000002 h 1 v 1 h -1"
+       id="path6671" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,72.000002 h 1 v 1 h -1"
+       id="path6669" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,72.000002 h 1 v 1 h -1"
+       id="path6667" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,72.000002 h 1 v 1 h -1"
+       id="path6665" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,72.000002 h 1 v 1 h -1"
+       id="path6663" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,72.000002 h 1 v 1 h -1"
+       id="path6661" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,72.000002 h 1 v 1 h -1"
+       id="path6659" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,72.000002 h 1 v 1 h -1"
+       id="path6657" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,72.000002 h 1 v 1 h -1"
+       id="path6655" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,72.000002 h 1 v 1 h -1"
+       id="path6653" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,72.000002 h 1 v 1 h -1"
+       id="path6651" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,72.000002 h 1 v 1 h -1"
+       id="path6649" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,72.000002 h 1 v 1 h -1"
+       id="path6647" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,72.000002 h 1 v 1 h -1"
+       id="path6645" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,72.000002 h 1 v 1 h -1"
+       id="path6643" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,72.000002 h 1 v 1 h -1"
+       id="path6641" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,72.000002 h 1 v 1 h -1"
+       id="path6639" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,72.000002 h 1 v 1 h -1"
+       id="path6637" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,72.000002 h 1 v 1 h -1"
+       id="path6635" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,72.000002 h 1 v 1 h -1"
+       id="path6633" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,72.000002 h 1 v 1 h -1"
+       id="path6631" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,72.000002 h 1 v 1 h -1"
+       id="path6629" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,72.000002 h 1 v 1 h -1"
+       id="path6627" />
+    <path
+       style="fill:#242020;fill-opacity:0.219608"
+       d="m 40,72.000002 h 1 v 1 h -1"
+       id="path6625" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,72.000002 h 1 v 1 h -1"
+       id="path6623" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,72.000002 h 1 v 1 h -1"
+       id="path6621" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,72.000002 h 1 v 1 h -1"
+       id="path6619" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,72.000002 h 1 v 1 h -1"
+       id="path6617" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,72.000002 h 1 v 1 h -1"
+       id="path6615" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,72.000002 h 1 v 1 h -1"
+       id="path6613" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,72.000002 h 1 v 1 h -1"
+       id="path6611" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,72.000002 h 1 v 1 h -1"
+       id="path6609" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,71.000002 h 1 v 1 h -1"
+       id="path6607" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,71.000002 h 1 v 1 h -1"
+       id="path6605" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,71.000002 h 1 v 1 h -1"
+       id="path6603" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,71.000002 h 1 v 1 h -1"
+       id="path6601" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,71.000002 h 1 v 1 h -1"
+       id="path6599" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 90,71.000002 h 1 v 1 h -1"
+       id="path6597" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 89,71.000002 h 1 v 1 h -1"
+       id="path6595" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.913725"
+       d="m 88,71.000002 h 1 v 1 h -1"
+       id="path6593" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,71.000002 h 1 v 1 h -1"
+       id="path6591" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,71.000002 h 1 v 1 h -1"
+       id="path6589" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,71.000002 h 1 v 1 h -1"
+       id="path6587" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,71.000002 h 1 v 1 h -1"
+       id="path6585" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,71.000002 h 1 v 1 h -1"
+       id="path6583" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,71.000002 h 1 v 1 h -1"
+       id="path6581" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,71.000002 h 1 v 1 h -1"
+       id="path6579" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,71.000002 h 1 v 1 h -1"
+       id="path6577" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,71.000002 h 1 v 1 h -1"
+       id="path6575" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,71.000002 h 1 v 1 h -1"
+       id="path6573" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,71.000002 h 1 v 1 h -1"
+       id="path6571" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,71.000002 h 1 v 1 h -1"
+       id="path6569" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,71.000002 h 1 v 1 h -1"
+       id="path6567" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,71.000002 h 1 v 1 h -1"
+       id="path6565" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,71.000002 h 1 v 1 h -1"
+       id="path6563" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,71.000002 h 1 v 1 h -1"
+       id="path6561" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,71.000002 h 1 v 1 h -1"
+       id="path6559" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 70,71.000002 h 1 v 1 h -1"
+       id="path6557" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 69,71.000002 h 1 v 1 h -1"
+       id="path6555" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,71.000002 h 1 v 1 h -1"
+       id="path6553" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,71.000002 h 1 v 1 h -1"
+       id="path6551" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,71.000002 h 1 v 1 h -1"
+       id="path6549" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,71.000002 h 1 v 1 h -1"
+       id="path6547" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,71.000002 h 1 v 1 h -1"
+       id="path6545" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,71.000002 h 1 v 1 h -1"
+       id="path6543" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,71.000002 h 1 v 1 h -1"
+       id="path6541" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,71.000002 h 1 v 1 h -1"
+       id="path6539" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,71.000002 h 1 v 1 h -1"
+       id="path6537" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,71.000002 h 1 v 1 h -1"
+       id="path6535" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,71.000002 h 1 v 1 h -1"
+       id="path6533" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,71.000002 h 1 v 1 h -1"
+       id="path6531" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,71.000002 h 1 v 1 h -1"
+       id="path6529" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,71.000002 h 1 v 1 h -1"
+       id="path6527" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,71.000002 h 1 v 1 h -1"
+       id="path6525" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,71.000002 h 1 v 1 h -1"
+       id="path6523" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,71.000002 h 1 v 1 h -1"
+       id="path6521" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,71.000002 h 1 v 1 h -1"
+       id="path6519" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,71.000002 h 1 v 1 h -1"
+       id="path6517" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,71.000002 h 1 v 1 h -1"
+       id="path6515" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,71.000002 h 1 v 1 h -1"
+       id="path6513" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,71.000002 h 1 v 1 h -1"
+       id="path6511" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,71.000002 h 1 v 1 h -1"
+       id="path6509" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,71.000002 h 1 v 1 h -1"
+       id="path6507" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,71.000002 h 1 v 1 h -1"
+       id="path6505" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,71.000002 h 1 v 1 h -1"
+       id="path6503" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,71.000002 h 1 v 1 h -1"
+       id="path6501" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,71.000002 h 1 v 1 h -1"
+       id="path6499" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,71.000002 h 1 v 1 h -1"
+       id="path6497" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.913725"
+       d="m 39,71.000002 h 1 v 1 h -1"
+       id="path6495" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 38,71.000002 h 1 v 1 h -1"
+       id="path6493" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 37,71.000002 h 1 v 1 h -1"
+       id="path6491" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,71.000002 h 1 v 1 h -1"
+       id="path6489" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,71.000002 h 1 v 1 h -1"
+       id="path6487" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,71.000002 h 1 v 1 h -1"
+       id="path6485" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,71.000002 h 1 v 1 h -1"
+       id="path6483" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,71.000002 h 1 v 1 h -1"
+       id="path6481" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,70.000002 h 1 v 1 h -1"
+       id="path6479" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,70.000002 h 1 v 1 h -1"
+       id="path6477" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,70.000002 h 1 v 1 h -1"
+       id="path6475" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,70.000002 h 1 v 1 h -1"
+       id="path6473" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,70.000002 h 1 v 1 h -1"
+       id="path6471" />
+    <path
+       style="fill:#232020;fill-opacity:0.792157"
+       d="m 90,70.000002 h 1 v 1 h -1"
+       id="path6469" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,70.000002 h 1 v 1 h -1"
+       id="path6467" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,70.000002 h 1 v 1 h -1"
+       id="path6465" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,70.000002 h 1 v 1 h -1"
+       id="path6463" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,70.000002 h 1 v 1 h -1"
+       id="path6461" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,70.000002 h 1 v 1 h -1"
+       id="path6459" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,70.000002 h 1 v 1 h -1"
+       id="path6457" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,70.000002 h 1 v 1 h -1"
+       id="path6455" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,70.000002 h 1 v 1 h -1"
+       id="path6453" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,70.000002 h 1 v 1 h -1"
+       id="path6451" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,70.000002 h 1 v 1 h -1"
+       id="path6449" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,70.000002 h 1 v 1 h -1"
+       id="path6447" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,70.000002 h 1 v 1 h -1"
+       id="path6445" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,70.000002 h 1 v 1 h -1"
+       id="path6443" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,70.000002 h 1 v 1 h -1"
+       id="path6441" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,70.000002 h 1 v 1 h -1"
+       id="path6439" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,70.000002 h 1 v 1 h -1"
+       id="path6437" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,70.000002 h 1 v 1 h -1"
+       id="path6435" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,70.000002 h 1 v 1 h -1"
+       id="path6433" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,70.000002 h 1 v 1 h -1"
+       id="path6431" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,70.000002 h 1 v 1 h -1"
+       id="path6429" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.4"
+       d="m 69,70.000002 h 1 v 1 h -1"
+       id="path6427" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,70.000002 h 1 v 1 h -1"
+       id="path6425" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,70.000002 h 1 v 1 h -1"
+       id="path6423" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,70.000002 h 1 v 1 h -1"
+       id="path6421" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,70.000002 h 1 v 1 h -1"
+       id="path6419" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,70.000002 h 1 v 1 h -1"
+       id="path6417" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,70.000002 h 1 v 1 h -1"
+       id="path6415" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,70.000002 h 1 v 1 h -1"
+       id="path6413" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,70.000002 h 1 v 1 h -1"
+       id="path6411" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,70.000002 h 1 v 1 h -1"
+       id="path6409" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,70.000002 h 1 v 1 h -1"
+       id="path6407" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,70.000002 h 1 v 1 h -1"
+       id="path6405" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,70.000002 h 1 v 1 h -1"
+       id="path6403" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,70.000002 h 1 v 1 h -1"
+       id="path6401" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,70.000002 h 1 v 1 h -1"
+       id="path6399" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,70.000002 h 1 v 1 h -1"
+       id="path6397" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,70.000002 h 1 v 1 h -1"
+       id="path6395" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,70.000002 h 1 v 1 h -1"
+       id="path6393" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,70.000002 h 1 v 1 h -1"
+       id="path6391" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,70.000002 h 1 v 1 h -1"
+       id="path6389" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,70.000002 h 1 v 1 h -1"
+       id="path6387" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,70.000002 h 1 v 1 h -1"
+       id="path6385" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,70.000002 h 1 v 1 h -1"
+       id="path6383" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,70.000002 h 1 v 1 h -1"
+       id="path6381" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,70.000002 h 1 v 1 h -1"
+       id="path6379" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,70.000002 h 1 v 1 h -1"
+       id="path6377" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,70.000002 h 1 v 1 h -1"
+       id="path6375" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,70.000002 h 1 v 1 h -1"
+       id="path6373" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,70.000002 h 1 v 1 h -1"
+       id="path6371" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,70.000002 h 1 v 1 h -1"
+       id="path6369" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,70.000002 h 1 v 1 h -1"
+       id="path6367" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,70.000002 h 1 v 1 h -1"
+       id="path6365" />
+    <path
+       style="fill:#232020;fill-opacity:0.792157"
+       d="m 37,70.000002 h 1 v 1 h -1"
+       id="path6363" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,70.000002 h 1 v 1 h -1"
+       id="path6361" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,70.000002 h 1 v 1 h -1"
+       id="path6359" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,70.000002 h 1 v 1 h -1"
+       id="path6357" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,70.000002 h 1 v 1 h -1"
+       id="path6355" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,70.000002 h 1 v 1 h -1"
+       id="path6353" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,69.000002 h 1 v 1 h -1"
+       id="path6351" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,69.000002 h 1 v 1 h -1"
+       id="path6349" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,69.000002 h 1 v 1 h -1"
+       id="path6347" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,69.000002 h 1 v 1 h -1"
+       id="path6345" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,69.000002 h 1 v 1 h -1"
+       id="path6343" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.203922"
+       d="m 90,69.000002 h 1 v 1 h -1"
+       id="path6341" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 89,69.000002 h 1 v 1 h -1"
+       id="path6339" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,69.000002 h 1 v 1 h -1"
+       id="path6337" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,69.000002 h 1 v 1 h -1"
+       id="path6335" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,69.000002 h 1 v 1 h -1"
+       id="path6333" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,69.000002 h 1 v 1 h -1"
+       id="path6331" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,69.000002 h 1 v 1 h -1"
+       id="path6329" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,69.000002 h 1 v 1 h -1"
+       id="path6327" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,69.000002 h 1 v 1 h -1"
+       id="path6325" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,69.000002 h 1 v 1 h -1"
+       id="path6323" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,69.000002 h 1 v 1 h -1"
+       id="path6321" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,69.000002 h 1 v 1 h -1"
+       id="path6319" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,69.000002 h 1 v 1 h -1"
+       id="path6317" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,69.000002 h 1 v 1 h -1"
+       id="path6315" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,69.000002 h 1 v 1 h -1"
+       id="path6313" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,69.000002 h 1 v 1 h -1"
+       id="path6311" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,69.000002 h 1 v 1 h -1"
+       id="path6309" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,69.000002 h 1 v 1 h -1"
+       id="path6307" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,69.000002 h 1 v 1 h -1"
+       id="path6305" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,69.000002 h 1 v 1 h -1"
+       id="path6303" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,69.000002 h 1 v 1 h -1"
+       id="path6301" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.901961"
+       d="m 69,69.000002 h 1 v 1 h -1"
+       id="path6299" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 68,69.000002 h 1 v 1 h -1"
+       id="path6297" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,69.000002 h 1 v 1 h -1"
+       id="path6295" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,69.000002 h 1 v 1 h -1"
+       id="path6293" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,69.000002 h 1 v 1 h -1"
+       id="path6291" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,69.000002 h 1 v 1 h -1"
+       id="path6289" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,69.000002 h 1 v 1 h -1"
+       id="path6287" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,69.000002 h 1 v 1 h -1"
+       id="path6285" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,69.000002 h 1 v 1 h -1"
+       id="path6283" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,69.000002 h 1 v 1 h -1"
+       id="path6281" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,69.000002 h 1 v 1 h -1"
+       id="path6279" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,69.000002 h 1 v 1 h -1"
+       id="path6277" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,69.000002 h 1 v 1 h -1"
+       id="path6275" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,69.000002 h 1 v 1 h -1"
+       id="path6273" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,69.000002 h 1 v 1 h -1"
+       id="path6271" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,69.000002 h 1 v 1 h -1"
+       id="path6269" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,69.000002 h 1 v 1 h -1"
+       id="path6267" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,69.000002 h 1 v 1 h -1"
+       id="path6265" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,69.000002 h 1 v 1 h -1"
+       id="path6263" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,69.000002 h 1 v 1 h -1"
+       id="path6261" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,69.000002 h 1 v 1 h -1"
+       id="path6259" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,69.000002 h 1 v 1 h -1"
+       id="path6257" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,69.000002 h 1 v 1 h -1"
+       id="path6255" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,69.000002 h 1 v 1 h -1"
+       id="path6253" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,69.000002 h 1 v 1 h -1"
+       id="path6251" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,69.000002 h 1 v 1 h -1"
+       id="path6249" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,69.000002 h 1 v 1 h -1"
+       id="path6247" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,69.000002 h 1 v 1 h -1"
+       id="path6245" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,69.000002 h 1 v 1 h -1"
+       id="path6243" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,69.000002 h 1 v 1 h -1"
+       id="path6241" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,69.000002 h 1 v 1 h -1"
+       id="path6239" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 38,69.000002 h 1 v 1 h -1"
+       id="path6237" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.203922"
+       d="m 37,69.000002 h 1 v 1 h -1"
+       id="path6235" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,69.000002 h 1 v 1 h -1"
+       id="path6233" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,69.000002 h 1 v 1 h -1"
+       id="path6231" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,69.000002 h 1 v 1 h -1"
+       id="path6229" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,69.000002 h 1 v 1 h -1"
+       id="path6227" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,69.000002 h 1 v 1 h -1"
+       id="path6225" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,68.000002 h 1 v 1 h -1"
+       id="path6223" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,68.000002 h 1 v 1 h -1"
+       id="path6221" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,68.000002 h 1 v 1 h -1"
+       id="path6219" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,68.000002 h 1 v 1 h -1"
+       id="path6217" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,68.000002 h 1 v 1 h -1"
+       id="path6215" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,68.000002 h 1 v 1 h -1"
+       id="path6213" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 89,68.000002 h 1 v 1 h -1"
+       id="path6211" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,68.000002 h 1 v 1 h -1"
+       id="path6209" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,68.000002 h 1 v 1 h -1"
+       id="path6207" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,68.000002 h 1 v 1 h -1"
+       id="path6205" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,68.000002 h 1 v 1 h -1"
+       id="path6203" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,68.000002 h 1 v 1 h -1"
+       id="path6201" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,68.000002 h 1 v 1 h -1"
+       id="path6199" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,68.000002 h 1 v 1 h -1"
+       id="path6197" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,68.000002 h 1 v 1 h -1"
+       id="path6195" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,68.000002 h 1 v 1 h -1"
+       id="path6193" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,68.000002 h 1 v 1 h -1"
+       id="path6191" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,68.000002 h 1 v 1 h -1"
+       id="path6189" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,68.000002 h 1 v 1 h -1"
+       id="path6187" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,68.000002 h 1 v 1 h -1"
+       id="path6185" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,68.000002 h 1 v 1 h -1"
+       id="path6183" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,68.000002 h 1 v 1 h -1"
+       id="path6181" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,68.000002 h 1 v 1 h -1"
+       id="path6179" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,68.000002 h 1 v 1 h -1"
+       id="path6177" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,68.000002 h 1 v 1 h -1"
+       id="path6175" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,68.000002 h 1 v 1 h -1"
+       id="path6173" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,68.000002 h 1 v 1 h -1"
+       id="path6171" />
+    <path
+       style="fill:#252020;fill-opacity:0.188235"
+       d="m 68,68.000002 h 1 v 1 h -1"
+       id="path6169" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,68.000002 h 1 v 1 h -1"
+       id="path6167" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,68.000002 h 1 v 1 h -1"
+       id="path6165" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,68.000002 h 1 v 1 h -1"
+       id="path6163" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,68.000002 h 1 v 1 h -1"
+       id="path6161" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,68.000002 h 1 v 1 h -1"
+       id="path6159" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,68.000002 h 1 v 1 h -1"
+       id="path6157" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,68.000002 h 1 v 1 h -1"
+       id="path6155" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,68.000002 h 1 v 1 h -1"
+       id="path6153" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,68.000002 h 1 v 1 h -1"
+       id="path6151" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,68.000002 h 1 v 1 h -1"
+       id="path6149" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,68.000002 h 1 v 1 h -1"
+       id="path6147" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,68.000002 h 1 v 1 h -1"
+       id="path6145" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,68.000002 h 1 v 1 h -1"
+       id="path6143" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,68.000002 h 1 v 1 h -1"
+       id="path6141" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,68.000002 h 1 v 1 h -1"
+       id="path6139" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,68.000002 h 1 v 1 h -1"
+       id="path6137" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,68.000002 h 1 v 1 h -1"
+       id="path6135" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,68.000002 h 1 v 1 h -1"
+       id="path6133" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,68.000002 h 1 v 1 h -1"
+       id="path6131" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,68.000002 h 1 v 1 h -1"
+       id="path6129" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,68.000002 h 1 v 1 h -1"
+       id="path6127" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,68.000002 h 1 v 1 h -1"
+       id="path6125" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,68.000002 h 1 v 1 h -1"
+       id="path6123" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,68.000002 h 1 v 1 h -1"
+       id="path6121" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,68.000002 h 1 v 1 h -1"
+       id="path6119" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,68.000002 h 1 v 1 h -1"
+       id="path6117" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,68.000002 h 1 v 1 h -1"
+       id="path6115" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,68.000002 h 1 v 1 h -1"
+       id="path6113" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,68.000002 h 1 v 1 h -1"
+       id="path6111" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 38,68.000002 h 1 v 1 h -1"
+       id="path6109" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,68.000002 h 1 v 1 h -1"
+       id="path6107" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,68.000002 h 1 v 1 h -1"
+       id="path6105" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,68.000002 h 1 v 1 h -1"
+       id="path6103" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,68.000002 h 1 v 1 h -1"
+       id="path6101" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,68.000002 h 1 v 1 h -1"
+       id="path6099" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,68.000002 h 1 v 1 h -1"
+       id="path6097" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,67.000002 h 1 v 1 h -1"
+       id="path6095" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,67.000002 h 1 v 1 h -1"
+       id="path6093" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,67.000002 h 1 v 1 h -1"
+       id="path6091" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,67.000002 h 1 v 1 h -1"
+       id="path6089" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,67.000002 h 1 v 1 h -1"
+       id="path6087" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,67.000002 h 1 v 1 h -1"
+       id="path6085" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.329412"
+       d="m 89,67.000002 h 1 v 1 h -1"
+       id="path6083" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,67.000002 h 1 v 1 h -1"
+       id="path6081" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,67.000002 h 1 v 1 h -1"
+       id="path6079" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,67.000002 h 1 v 1 h -1"
+       id="path6077" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,67.000002 h 1 v 1 h -1"
+       id="path6075" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,67.000002 h 1 v 1 h -1"
+       id="path6073" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,67.000002 h 1 v 1 h -1"
+       id="path6071" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,67.000002 h 1 v 1 h -1"
+       id="path6069" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,67.000002 h 1 v 1 h -1"
+       id="path6067" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,67.000002 h 1 v 1 h -1"
+       id="path6065" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,67.000002 h 1 v 1 h -1"
+       id="path6063" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,67.000002 h 1 v 1 h -1"
+       id="path6061" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,67.000002 h 1 v 1 h -1"
+       id="path6059" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,67.000002 h 1 v 1 h -1"
+       id="path6057" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,67.000002 h 1 v 1 h -1"
+       id="path6055" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,67.000002 h 1 v 1 h -1"
+       id="path6053" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,67.000002 h 1 v 1 h -1"
+       id="path6051" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,67.000002 h 1 v 1 h -1"
+       id="path6049" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,67.000002 h 1 v 1 h -1"
+       id="path6047" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,67.000002 h 1 v 1 h -1"
+       id="path6045" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,67.000002 h 1 v 1 h -1"
+       id="path6043" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.431373"
+       d="m 68,67.000002 h 1 v 1 h -1"
+       id="path6041" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,67.000002 h 1 v 1 h -1"
+       id="path6039" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,67.000002 h 1 v 1 h -1"
+       id="path6037" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,67.000002 h 1 v 1 h -1"
+       id="path6035" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,67.000002 h 1 v 1 h -1"
+       id="path6033" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,67.000002 h 1 v 1 h -1"
+       id="path6031" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,67.000002 h 1 v 1 h -1"
+       id="path6029" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,67.000002 h 1 v 1 h -1"
+       id="path6027" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,67.000002 h 1 v 1 h -1"
+       id="path6025" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,67.000002 h 1 v 1 h -1"
+       id="path6023" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,67.000002 h 1 v 1 h -1"
+       id="path6021" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,67.000002 h 1 v 1 h -1"
+       id="path6019" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,67.000002 h 1 v 1 h -1"
+       id="path6017" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,67.000002 h 1 v 1 h -1"
+       id="path6015" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,67.000002 h 1 v 1 h -1"
+       id="path6013" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,67.000002 h 1 v 1 h -1"
+       id="path6011" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,67.000002 h 1 v 1 h -1"
+       id="path6009" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,67.000002 h 1 v 1 h -1"
+       id="path6007" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,67.000002 h 1 v 1 h -1"
+       id="path6005" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,67.000002 h 1 v 1 h -1"
+       id="path6003" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,67.000002 h 1 v 1 h -1"
+       id="path6001" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,67.000002 h 1 v 1 h -1"
+       id="path5999" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,67.000002 h 1 v 1 h -1"
+       id="path5997" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,67.000002 h 1 v 1 h -1"
+       id="path5995" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,67.000002 h 1 v 1 h -1"
+       id="path5993" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,67.000002 h 1 v 1 h -1"
+       id="path5991" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,67.000002 h 1 v 1 h -1"
+       id="path5989" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,67.000002 h 1 v 1 h -1"
+       id="path5987" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,67.000002 h 1 v 1 h -1"
+       id="path5985" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,67.000002 h 1 v 1 h -1"
+       id="path5983" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.329412"
+       d="m 38,67.000002 h 1 v 1 h -1"
+       id="path5981" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,67.000002 h 1 v 1 h -1"
+       id="path5979" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,67.000002 h 1 v 1 h -1"
+       id="path5977" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,67.000002 h 1 v 1 h -1"
+       id="path5975" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,67.000002 h 1 v 1 h -1"
+       id="path5973" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,67.000002 h 1 v 1 h -1"
+       id="path5971" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,67.000002 h 1 v 1 h -1"
+       id="path5969" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,66.000002 h 1 v 1 h -1"
+       id="path5967" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,66.000002 h 1 v 1 h -1"
+       id="path5965" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,66.000002 h 1 v 1 h -1"
+       id="path5963" />
+    <path
+       style="fill:#272727;fill-opacity:0.0509804"
+       d="m 92,66.000002 h 1 v 1 h -1"
+       id="path5961" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 91,66.000002 h 1 v 1 h -1"
+       id="path5959" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 90,66.000002 h 1 v 1 h -1"
+       id="path5957" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,66.000002 h 1 v 1 h -1"
+       id="path5955" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,66.000002 h 1 v 1 h -1"
+       id="path5953" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,66.000002 h 1 v 1 h -1"
+       id="path5951" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,66.000002 h 1 v 1 h -1"
+       id="path5949" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,66.000002 h 1 v 1 h -1"
+       id="path5947" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,66.000002 h 1 v 1 h -1"
+       id="path5945" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,66.000002 h 1 v 1 h -1"
+       id="path5943" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,66.000002 h 1 v 1 h -1"
+       id="path5941" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,66.000002 h 1 v 1 h -1"
+       id="path5939" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,66.000002 h 1 v 1 h -1"
+       id="path5937" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,66.000002 h 1 v 1 h -1"
+       id="path5935" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,66.000002 h 1 v 1 h -1"
+       id="path5933" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,66.000002 h 1 v 1 h -1"
+       id="path5931" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,66.000002 h 1 v 1 h -1"
+       id="path5929" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,66.000002 h 1 v 1 h -1"
+       id="path5927" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,66.000002 h 1 v 1 h -1"
+       id="path5925" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,66.000002 h 1 v 1 h -1"
+       id="path5923" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,66.000002 h 1 v 1 h -1"
+       id="path5921" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,66.000002 h 1 v 1 h -1"
+       id="path5919" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,66.000002 h 1 v 1 h -1"
+       id="path5917" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,66.000002 h 1 v 1 h -1"
+       id="path5915" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 68,66.000002 h 1 v 1 h -1"
+       id="path5913" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,66.000002 h 1 v 1 h -1"
+       id="path5911" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,66.000002 h 1 v 1 h -1"
+       id="path5909" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,66.000002 h 1 v 1 h -1"
+       id="path5907" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,66.000002 h 1 v 1 h -1"
+       id="path5905" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,66.000002 h 1 v 1 h -1"
+       id="path5903" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,66.000002 h 1 v 1 h -1"
+       id="path5901" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,66.000002 h 1 v 1 h -1"
+       id="path5899" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,66.000002 h 1 v 1 h -1"
+       id="path5897" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,66.000002 h 1 v 1 h -1"
+       id="path5895" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,66.000002 h 1 v 1 h -1"
+       id="path5893" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,66.000002 h 1 v 1 h -1"
+       id="path5891" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,66.000002 h 1 v 1 h -1"
+       id="path5889" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,66.000002 h 1 v 1 h -1"
+       id="path5887" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,66.000002 h 1 v 1 h -1"
+       id="path5885" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,66.000002 h 1 v 1 h -1"
+       id="path5883" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,66.000002 h 1 v 1 h -1"
+       id="path5881" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,66.000002 h 1 v 1 h -1"
+       id="path5879" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,66.000002 h 1 v 1 h -1"
+       id="path5877" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,66.000002 h 1 v 1 h -1"
+       id="path5875" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,66.000002 h 1 v 1 h -1"
+       id="path5873" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,66.000002 h 1 v 1 h -1"
+       id="path5871" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,66.000002 h 1 v 1 h -1"
+       id="path5869" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,66.000002 h 1 v 1 h -1"
+       id="path5867" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,66.000002 h 1 v 1 h -1"
+       id="path5865" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,66.000002 h 1 v 1 h -1"
+       id="path5863" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,66.000002 h 1 v 1 h -1"
+       id="path5861" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,66.000002 h 1 v 1 h -1"
+       id="path5859" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,66.000002 h 1 v 1 h -1"
+       id="path5857" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,66.000002 h 1 v 1 h -1"
+       id="path5855" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,66.000002 h 1 v 1 h -1"
+       id="path5853" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 37,66.000002 h 1 v 1 h -1"
+       id="path5851" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 36,66.000002 h 1 v 1 h -1"
+       id="path5849" />
+    <path
+       style="fill:#272727;fill-opacity:0.0509804"
+       d="m 35,66.000002 h 1 v 1 h -1"
+       id="path5847" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,66.000002 h 1 v 1 h -1"
+       id="path5845" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,66.000002 h 1 v 1 h -1"
+       id="path5843" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,66.000002 h 1 v 1 h -1"
+       id="path5841" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,65.000002 h 1 v 1 h -1"
+       id="path5839" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,65.000002 h 1 v 1 h -1"
+       id="path5837" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,65.000002 h 1 v 1 h -1"
+       id="path5835" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 92,65.000002 h 1 v 1 h -1"
+       id="path5833" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 91,65.000002 h 1 v 1 h -1"
+       id="path5831" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 90,65.000002 h 1 v 1 h -1"
+       id="path5829" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,65.000002 h 1 v 1 h -1"
+       id="path5827" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,65.000002 h 1 v 1 h -1"
+       id="path5825" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,65.000002 h 1 v 1 h -1"
+       id="path5823" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,65.000002 h 1 v 1 h -1"
+       id="path5821" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,65.000002 h 1 v 1 h -1"
+       id="path5819" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,65.000002 h 1 v 1 h -1"
+       id="path5817" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,65.000002 h 1 v 1 h -1"
+       id="path5815" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,65.000002 h 1 v 1 h -1"
+       id="path5813" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.74902"
+       d="m 81,65.000002 h 1 v 1 h -1"
+       id="path5811" />
+    <path
+       style="fill:#232020;fill-opacity:0.376471"
+       d="m 80,65.000002 h 1 v 1 h -1"
+       id="path5809" />
+    <path
+       style="fill:#232020;fill-opacity:0.341176"
+       d="m 79,65.000002 h 1 v 1 h -1"
+       id="path5807" />
+    <path
+       style="fill:#232020;fill-opacity:0.662745"
+       d="m 78,65.000002 h 1 v 1 h -1"
+       id="path5805" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,65.000002 h 1 v 1 h -1"
+       id="path5803" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,65.000002 h 1 v 1 h -1"
+       id="path5801" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,65.000002 h 1 v 1 h -1"
+       id="path5799" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,65.000002 h 1 v 1 h -1"
+       id="path5797" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,65.000002 h 1 v 1 h -1"
+       id="path5795" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,65.000002 h 1 v 1 h -1"
+       id="path5793" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,65.000002 h 1 v 1 h -1"
+       id="path5791" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,65.000002 h 1 v 1 h -1"
+       id="path5789" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,65.000002 h 1 v 1 h -1"
+       id="path5787" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.858824"
+       d="m 68,65.000002 h 1 v 1 h -1"
+       id="path5785" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,65.000002 h 1 v 1 h -1"
+       id="path5783" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,65.000002 h 1 v 1 h -1"
+       id="path5781" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,65.000002 h 1 v 1 h -1"
+       id="path5779" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,65.000002 h 1 v 1 h -1"
+       id="path5777" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,65.000002 h 1 v 1 h -1"
+       id="path5775" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,65.000002 h 1 v 1 h -1"
+       id="path5773" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,65.000002 h 1 v 1 h -1"
+       id="path5771" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,65.000002 h 1 v 1 h -1"
+       id="path5769" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,65.000002 h 1 v 1 h -1"
+       id="path5767" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,65.000002 h 1 v 1 h -1"
+       id="path5765" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,65.000002 h 1 v 1 h -1"
+       id="path5763" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,65.000002 h 1 v 1 h -1"
+       id="path5761" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,65.000002 h 1 v 1 h -1"
+       id="path5759" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,65.000002 h 1 v 1 h -1"
+       id="path5757" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,65.000002 h 1 v 1 h -1"
+       id="path5755" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,65.000002 h 1 v 1 h -1"
+       id="path5753" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,65.000002 h 1 v 1 h -1"
+       id="path5751" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,65.000002 h 1 v 1 h -1"
+       id="path5749" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,65.000002 h 1 v 1 h -1"
+       id="path5747" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,65.000002 h 1 v 1 h -1"
+       id="path5745" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,65.000002 h 1 v 1 h -1"
+       id="path5743" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,65.000002 h 1 v 1 h -1"
+       id="path5741" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,65.000002 h 1 v 1 h -1"
+       id="path5739" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,65.000002 h 1 v 1 h -1"
+       id="path5737" />
+    <path
+       style="fill:#242020;fill-opacity:0.729412"
+       d="m 43,65.000002 h 1 v 1 h -1"
+       id="path5735" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,65.000002 h 1 v 1 h -1"
+       id="path5733" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,65.000002 h 1 v 1 h -1"
+       id="path5731" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,65.000002 h 1 v 1 h -1"
+       id="path5729" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,65.000002 h 1 v 1 h -1"
+       id="path5727" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,65.000002 h 1 v 1 h -1"
+       id="path5725" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,65.000002 h 1 v 1 h -1"
+       id="path5723" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,65.000002 h 1 v 1 h -1"
+       id="path5721" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 35,65.000002 h 1 v 1 h -1"
+       id="path5719" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,65.000002 h 1 v 1 h -1"
+       id="path5717" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,65.000002 h 1 v 1 h -1"
+       id="path5715" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,65.000002 h 1 v 1 h -1"
+       id="path5713" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,64.000002 h 1 v 1 h -1"
+       id="path5711" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,64.000002 h 1 v 1 h -1"
+       id="path5709" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,64.000002 h 1 v 1 h -1"
+       id="path5707" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 92,64.000002 h 1 v 1 h -1"
+       id="path5705" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 91,64.000002 h 1 v 1 h -1"
+       id="path5703" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 90,64.000002 h 1 v 1 h -1"
+       id="path5701" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,64.000002 h 1 v 1 h -1"
+       id="path5699" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,64.000002 h 1 v 1 h -1"
+       id="path5697" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,64.000002 h 1 v 1 h -1"
+       id="path5695" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,64.000002 h 1 v 1 h -1"
+       id="path5693" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,64.000002 h 1 v 1 h -1"
+       id="path5691" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,64.000002 h 1 v 1 h -1"
+       id="path5689" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,64.000002 h 1 v 1 h -1"
+       id="path5687" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.776471"
+       d="m 82,64.000002 h 1 v 1 h -1"
+       id="path5685" />
+    <path
+       style="fill:#000000;fill-opacity:0.0117647"
+       d="m 81,64.000002 h 1 v 1 h -1"
+       id="path5683" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,64.000002 h 1 v 1 h -1"
+       id="path5681" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,64.000002 h 1 v 1 h -1"
+       id="path5679" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,64.000002 h 1 v 1 h -1"
+       id="path5677" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.737255"
+       d="m 77,64.000002 h 1 v 1 h -1"
+       id="path5675" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,64.000002 h 1 v 1 h -1"
+       id="path5673" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,64.000002 h 1 v 1 h -1"
+       id="path5671" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,64.000002 h 1 v 1 h -1"
+       id="path5669" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,64.000002 h 1 v 1 h -1"
+       id="path5667" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,64.000002 h 1 v 1 h -1"
+       id="path5665" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,64.000002 h 1 v 1 h -1"
+       id="path5663" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,64.000002 h 1 v 1 h -1"
+       id="path5661" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,64.000002 h 1 v 1 h -1"
+       id="path5659" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,64.000002 h 1 v 1 h -1"
+       id="path5657" />
+    <path
+       style="fill:#261e1e;fill-opacity:0.133333"
+       d="m 67,64.000002 h 1 v 1 h -1"
+       id="path5655" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,64.000002 h 1 v 1 h -1"
+       id="path5653" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,64.000002 h 1 v 1 h -1"
+       id="path5651" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,64.000002 h 1 v 1 h -1"
+       id="path5649" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,64.000002 h 1 v 1 h -1"
+       id="path5647" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,64.000002 h 1 v 1 h -1"
+       id="path5645" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,64.000002 h 1 v 1 h -1"
+       id="path5643" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,64.000002 h 1 v 1 h -1"
+       id="path5641" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,64.000002 h 1 v 1 h -1"
+       id="path5639" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,64.000002 h 1 v 1 h -1"
+       id="path5637" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,64.000002 h 1 v 1 h -1"
+       id="path5635" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,64.000002 h 1 v 1 h -1"
+       id="path5633" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,64.000002 h 1 v 1 h -1"
+       id="path5631" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,64.000002 h 1 v 1 h -1"
+       id="path5629" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,64.000002 h 1 v 1 h -1"
+       id="path5627" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,64.000002 h 1 v 1 h -1"
+       id="path5625" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,64.000002 h 1 v 1 h -1"
+       id="path5623" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,64.000002 h 1 v 1 h -1"
+       id="path5621" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,64.000002 h 1 v 1 h -1"
+       id="path5619" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,64.000002 h 1 v 1 h -1"
+       id="path5617" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,64.000002 h 1 v 1 h -1"
+       id="path5615" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,64.000002 h 1 v 1 h -1"
+       id="path5613" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,64.000002 h 1 v 1 h -1"
+       id="path5611" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,64.000002 h 1 v 1 h -1"
+       id="path5609" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.360784"
+       d="m 43,64.000002 h 1 v 1 h -1"
+       id="path5607" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,64.000002 h 1 v 1 h -1"
+       id="path5605" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,64.000002 h 1 v 1 h -1"
+       id="path5603" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,64.000002 h 1 v 1 h -1"
+       id="path5601" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,64.000002 h 1 v 1 h -1"
+       id="path5599" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,64.000002 h 1 v 1 h -1"
+       id="path5597" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,64.000002 h 1 v 1 h -1"
+       id="path5595" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 36,64.000002 h 1 v 1 h -1"
+       id="path5593" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 35,64.000002 h 1 v 1 h -1"
+       id="path5591" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,64.000002 h 1 v 1 h -1"
+       id="path5589" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,64.000002 h 1 v 1 h -1"
+       id="path5587" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,64.000002 h 1 v 1 h -1"
+       id="path5585" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,63.000002 h 1 v 1 h -1"
+       id="path5583" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,63.000002 h 1 v 1 h -1"
+       id="path5581" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,63.000002 h 1 v 1 h -1"
+       id="path5579" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,63.000002 h 1 v 1 h -1"
+       id="path5577" />
+    <path
+       style="fill:#1a1a1a;fill-opacity:0.0392157"
+       d="m 91,63.000002 h 1 v 1 h -1"
+       id="path5575" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.737255"
+       d="m 90,63.000002 h 1 v 1 h -1"
+       id="path5573" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,63.000002 h 1 v 1 h -1"
+       id="path5571" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,63.000002 h 1 v 1 h -1"
+       id="path5569" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,63.000002 h 1 v 1 h -1"
+       id="path5567" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,63.000002 h 1 v 1 h -1"
+       id="path5565" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,63.000002 h 1 v 1 h -1"
+       id="path5563" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,63.000002 h 1 v 1 h -1"
+       id="path5561" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,63.000002 h 1 v 1 h -1"
+       id="path5559" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.447059"
+       d="m 82,63.000002 h 1 v 1 h -1"
+       id="path5557" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,63.000002 h 1 v 1 h -1"
+       id="path5555" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,63.000002 h 1 v 1 h -1"
+       id="path5553" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,63.000002 h 1 v 1 h -1"
+       id="path5551" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,63.000002 h 1 v 1 h -1"
+       id="path5549" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.494118"
+       d="m 77,63.000002 h 1 v 1 h -1"
+       id="path5547" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,63.000002 h 1 v 1 h -1"
+       id="path5545" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,63.000002 h 1 v 1 h -1"
+       id="path5543" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,63.000002 h 1 v 1 h -1"
+       id="path5541" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,63.000002 h 1 v 1 h -1"
+       id="path5539" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,63.000002 h 1 v 1 h -1"
+       id="path5537" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,63.000002 h 1 v 1 h -1"
+       id="path5535" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,63.000002 h 1 v 1 h -1"
+       id="path5533" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,63.000002 h 1 v 1 h -1"
+       id="path5531" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,63.000002 h 1 v 1 h -1"
+       id="path5529" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 67,63.000002 h 1 v 1 h -1"
+       id="path5527" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,63.000002 h 1 v 1 h -1"
+       id="path5525" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,63.000002 h 1 v 1 h -1"
+       id="path5523" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,63.000002 h 1 v 1 h -1"
+       id="path5521" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,63.000002 h 1 v 1 h -1"
+       id="path5519" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,63.000002 h 1 v 1 h -1"
+       id="path5517" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,63.000002 h 1 v 1 h -1"
+       id="path5515" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,63.000002 h 1 v 1 h -1"
+       id="path5513" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,63.000002 h 1 v 1 h -1"
+       id="path5511" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,63.000002 h 1 v 1 h -1"
+       id="path5509" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,63.000002 h 1 v 1 h -1"
+       id="path5507" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,63.000002 h 1 v 1 h -1"
+       id="path5505" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,63.000002 h 1 v 1 h -1"
+       id="path5503" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,63.000002 h 1 v 1 h -1"
+       id="path5501" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,63.000002 h 1 v 1 h -1"
+       id="path5499" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,63.000002 h 1 v 1 h -1"
+       id="path5497" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,63.000002 h 1 v 1 h -1"
+       id="path5495" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,63.000002 h 1 v 1 h -1"
+       id="path5493" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,63.000002 h 1 v 1 h -1"
+       id="path5491" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,63.000002 h 1 v 1 h -1"
+       id="path5489" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,63.000002 h 1 v 1 h -1"
+       id="path5487" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,63.000002 h 1 v 1 h -1"
+       id="path5485" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,63.000002 h 1 v 1 h -1"
+       id="path5483" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44.25,63.250002 0.75,-0.25 v 1 h -1"
+       id="path5481" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.164706"
+       d="m 43,63 v 0 h 1 v 0 1.000002 h -1"
+       id="path5479"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="M 42,63.000002 43,63 v 1.000002 h -1"
+       id="path5477"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,63.000002 h 1 v 1 h -1"
+       id="path5475" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,63.000002 h 1 v 1 h -1"
+       id="path5473" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,63.000002 h 1 v 1 h -1"
+       id="path5471" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,63.000002 h 1 v 1 h -1"
+       id="path5469" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.737255"
+       d="m 37,63.000002 h 1 v 1 h -1"
+       id="path5467" />
+    <path
+       style="fill:#1a1a1a;fill-opacity:0.0392157"
+       d="m 36,63.000002 h 1 v 1 h -1"
+       id="path5465" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,63.000002 h 1 v 1 h -1"
+       id="path5463" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,63.000002 h 1 v 1 h -1"
+       id="path5461" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,63.000002 h 1 v 1 h -1"
+       id="path5459" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,63.000002 h 1 v 1 h -1"
+       id="path5457" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,62.000002 h 1 v 1 h -1"
+       id="path5455" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,62.000002 h 1 v 1 h -1"
+       id="path5453" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93.25,62.250002 0.75,-0.25 v 1 h -1"
+       id="path5451" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91.75,62.250002 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path5449" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,62.000002 0.75,0.25 0.25,0.75 h -1"
+       id="path5447" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.227451"
+       d="m 90,62.000002 h 1 v 1 h -1"
+       id="path5445" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,62.000002 h 1 v 1 h -1"
+       id="path5443" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,62.000002 h 1 v 1 h -1"
+       id="path5441" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,62.000002 h 1 v 1 h -1"
+       id="path5439" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,62.000002 h 1 v 1 h -1"
+       id="path5437" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,62.000002 h 1 v 1 h -1"
+       id="path5435" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,62.000002 h 1 v 1 h -1"
+       id="path5433" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,62.000002 h 1 v 1 h -1"
+       id="path5431" />
+    <path
+       style="fill:#232020;fill-opacity:0.376471"
+       d="m 82,62.000002 h 1 v 1 h -1"
+       id="path5429" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,62.000002 h 1 v 1 h -1"
+       id="path5427" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,62.000002 h 1 v 1 h -1"
+       id="path5425" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,62.000002 h 1 v 1 h -1"
+       id="path5423" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,62.000002 h 1 v 1 h -1"
+       id="path5421" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.207843"
+       d="m 77,62.000002 h 1 v 1 h -1"
+       id="path5419" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,62.000002 h 1 v 1 h -1"
+       id="path5417" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,62.000002 h 1 v 1 h -1"
+       id="path5415" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,62.000002 h 1 v 1 h -1"
+       id="path5413" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,62.000002 h 1 v 1 h -1"
+       id="path5411" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,62.000002 h 1 v 1 h -1"
+       id="path5409" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,62.000002 h 1 v 1 h -1"
+       id="path5407" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,62.000002 h 1 v 1 h -1"
+       id="path5405" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,62.000002 h 1 v 1 h -1"
+       id="path5403" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,62.000002 h 1 v 1 h -1"
+       id="path5401" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,62.000002 h 1 v 1 h -1"
+       id="path5399" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.588235"
+       d="m 66,62.000002 h 1 v 1 h -1"
+       id="path5397" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,62.000002 h 1 v 1 h -1"
+       id="path5395" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,62.000002 h 1 v 1 h -1"
+       id="path5393" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,62.000002 h 1 v 1 h -1"
+       id="path5391" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,62.000002 h 1 v 1 h -1"
+       id="path5389" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,62.000002 h 1 v 1 h -1"
+       id="path5387" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,62.000002 h 1 v 1 h -1"
+       id="path5385" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,62.000002 h 1 v 1 h -1"
+       id="path5383" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,62.000002 h 1 v 1 h -1"
+       id="path5381" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,62.000002 h 1 v 1 h -1"
+       id="path5379" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,62.000002 h 1 v 1 h -1"
+       id="path5377" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,62.000002 h 1 v 1 h -1"
+       id="path5375" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,62.000002 h 1 v 1 h -1"
+       id="path5373" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,62.000002 h 1 v 1 h -1"
+       id="path5371" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,62.000002 h 1 v 1 h -1"
+       id="path5369" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,62.000002 h 1 v 1 h -1"
+       id="path5367" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,62.000002 h 1 v 1 h -1"
+       id="path5365" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,62.000002 h 1 v 1 h -1"
+       id="path5363" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,62.000002 h 1 v 1 h -1"
+       id="path5361" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,62.000002 h 1 v 1 h -1"
+       id="path5359" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,62.000002 h 1 v 1 h -1"
+       id="path5357" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,62.000002 h 1 v 1 h -1"
+       id="path5355" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43.75,62.250002 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path5353" />
+    <path
+       style="fill:#400000;fill-opacity:0.0156863"
+       d="m 43,62 h 1 v 1 h -1"
+       id="path5351"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="M 42,62.000002 43,62 v 0 1 0 l -1,2e-6"
+       id="path5349"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,62.000002 h 1 v 1 h -1"
+       id="path5347" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,62.000002 h 1 v 1 h -1"
+       id="path5345" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,62.000002 h 1 v 1 h -1"
+       id="path5343" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,62.000002 h 1 v 1 h -1"
+       id="path5341" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.227451"
+       d="m 37,62.000002 h 1 v 1 h -1"
+       id="path5339" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36.25,62.250002 0.75,-0.25 v 1 h -1"
+       id="path5337" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34.75,62.250002 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path5335" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,62.000002 0.75,0.25 0.25,0.75 h -1"
+       id="path5333" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,62.000002 h 1 v 1 h -1"
+       id="path5331" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,62.000002 h 1 v 1 h -1"
+       id="path5329" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,61.000002 h 1 v 1 h -1"
+       id="path5327" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,61.000002 h 1 v 1 h -1"
+       id="path5325" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92.75,61.250002 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path5323" />
+    <path
+       style="fill:#400000;fill-opacity:0.0156863"
+       d="m 92,61 h 1 v 1 h -1"
+       id="path5321"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.45098"
+       d="M 91,61.000002 92,61 v 0 1 0 l -1,2e-6"
+       id="path5319"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.956863"
+       d="m 90,61.000002 h 1 v 1 h -1"
+       id="path5317" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,61.000002 h 1 v 1 h -1"
+       id="path5315" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,61.000002 h 1 v 1 h -1"
+       id="path5313" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,61.000002 h 1 v 1 h -1"
+       id="path5311" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,61.000002 h 1 v 1 h -1"
+       id="path5309" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.956863"
+       d="m 85,61.000002 h 1 v 1 h -1"
+       id="path5307" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 84,61.000002 h 1 v 1 h -1"
+       id="path5305" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 83,61.000002 h 1 v 1 h -1"
+       id="path5303" />
+    <path
+       style="fill:#212121;fill-opacity:0.211765"
+       d="m 82,61.000002 h 1 v 1 h -1"
+       id="path5301" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,61.000002 h 1 v 1 h -1"
+       id="path5299" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,61.000002 h 1 v 1 h -1"
+       id="path5297" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,61.000002 h 1 v 1 h -1"
+       id="path5295" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,61.000002 h 1 v 1 h -1"
+       id="path5293" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,61.000002 h 1 v 1 h -1"
+       id="path5291" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.796078"
+       d="m 76,61.000002 h 1 v 1 h -1"
+       id="path5289" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,61.000002 h 1 v 1 h -1"
+       id="path5287" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,61.000002 h 1 v 1 h -1"
+       id="path5285" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,61.000002 h 1 v 1 h -1"
+       id="path5283" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,61.000002 h 1 v 1 h -1"
+       id="path5281" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,61.000002 h 1 v 1 h -1"
+       id="path5279" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,61.000002 h 1 v 1 h -1"
+       id="path5277" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,61.000002 h 1 v 1 h -1"
+       id="path5275" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,61.000002 h 1 v 1 h -1"
+       id="path5273" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,61.000002 h 1 v 1 h -1"
+       id="path5271" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,61.000002 h 1 v 1 h -1"
+       id="path5269" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,61.000002 h 1 v 1 h -1"
+       id="path5267" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,61.000002 h 1 v 1 h -1"
+       id="path5265" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,61.000002 h 1 v 1 h -1"
+       id="path5263" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,61.000002 h 1 v 1 h -1"
+       id="path5261" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,61.000002 h 1 v 1 h -1"
+       id="path5259" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,61.000002 h 1 v 1 h -1"
+       id="path5257" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,61.000002 h 1 v 1 h -1"
+       id="path5255" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,61.000002 h 1 v 1 h -1"
+       id="path5253" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,61.000002 h 1 v 1 h -1"
+       id="path5251" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,61.000002 h 1 v 1 h -1"
+       id="path5249" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,61.000002 h 1 v 1 h -1"
+       id="path5247" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,61.000002 h 1 v 1 h -1"
+       id="path5245" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,61.000002 h 1 v 1 h -1"
+       id="path5243" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,61.000002 h 1 v 1 h -1"
+       id="path5241" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,61.000002 h 1 v 1 h -1"
+       id="path5239" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,61.000002 h 1 v 1 h -1"
+       id="path5237" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,61.000002 h 1 v 1 h -1"
+       id="path5235" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,61.000002 h 1 v 1 h -1"
+       id="path5233" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,61.000002 h 1 v 1 h -1"
+       id="path5231" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,61.000002 h 1 v 1 h -1"
+       id="path5229" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,61.000002 h 1 v 1 h -1"
+       id="path5227" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,61.000002 h 1 v 1 l -0.75,-0.25"
+       id="path5225" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,61.000002 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path5223" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.905882"
+       d="m 42,61.000002 h 1 V 62 l -1,2e-6"
+       id="path5221"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,61.000002 h 1 v 1 h -1"
+       id="path5219" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,61.000002 h 1 v 1 h -1"
+       id="path5217" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,61.000002 h 1 v 1 h -1"
+       id="path5215" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,61.000002 h 1 v 1 h -1"
+       id="path5213" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.956863"
+       d="m 37,61.000002 h 1 v 1 h -1"
+       id="path5211" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.45098"
+       d="m 36,61 v 0 l 1,2e-6 v 1 L 36,62 v 0"
+       id="path5209"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#400000;fill-opacity:0.0156863"
+       d="m 35,61 h 1 v 1 h -1"
+       id="path5207"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,61.000002 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path5205" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,61.000002 h 1 v 1 h -1"
+       id="path5203" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,61.000002 h 1 v 1 h -1"
+       id="path5201" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,60.000002 h 1 v 1 h -1"
+       id="path5199" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,60.000002 h 1 v 1 h -1"
+       id="path5197" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,60.000002 h 1 v 1 l -0.75,-0.25"
+       id="path5195" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.776471"
+       d="m 92,60.000002 h 1 V 61 61 h -1 v 0"
+       id="path5193"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 91,60.000002 h 1 V 61 l -1,2e-6"
+       id="path5191"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 90,60.000002 h 1 v 1 h -1"
+       id="path5189" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,60.000002 h 1 v 1 h -1"
+       id="path5187" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,60.000002 h 1 v 1 h -1"
+       id="path5185" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,60.000002 h 1 v 1 h -1"
+       id="path5183" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,60.000002 h 1 v 1 h -1"
+       id="path5181" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.862745"
+       d="m 85,60.000002 h 1 v 1 h -1"
+       id="path5179" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,60.000002 h 1 v 1 h -1"
+       id="path5177" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,60.000002 h 1 v 1 h -1"
+       id="path5175" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,60.000002 h 1 v 1 h -1"
+       id="path5173" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,60.000002 h 1 v 1 h -1"
+       id="path5171" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,60.000002 h 1 v 1 h -1"
+       id="path5169" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,60.000002 h 1 v 1 h -1"
+       id="path5167" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,60.000002 h 1 v 1 h -1"
+       id="path5165" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,60.000002 h 1 v 1 h -1"
+       id="path5163" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.192157"
+       d="m 76,60.000002 h 1 v 1 h -1"
+       id="path5161" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.964706"
+       d="m 75,60.000002 h 1 v 1 h -1"
+       id="path5159" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,60.000002 h 1 v 1 h -1"
+       id="path5157" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,60.000002 h 1 v 1 h -1"
+       id="path5155" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,60.000002 h 1 v 1 h -1"
+       id="path5153" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,60.000002 h 1 v 1 h -1"
+       id="path5151" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,60.000002 h 1 v 1 h -1"
+       id="path5149" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,60.000002 h 1 v 1 h -1"
+       id="path5147" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,60.000002 h 1 v 1 h -1"
+       id="path5145" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,60.000002 h 1 v 1 h -1"
+       id="path5143" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,60.000002 h 1 v 1 h -1"
+       id="path5141" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,60.000002 h 1 v 1 h -1"
+       id="path5139" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,60.000002 h 1 v 1 h -1"
+       id="path5137" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,60.000002 h 1 v 1 h -1"
+       id="path5135" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,60.000002 h 1 v 1 h -1"
+       id="path5133" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,60.000002 h 1 v 1 h -1"
+       id="path5131" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,60.000002 h 1 v 1 h -1"
+       id="path5129" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,60.000002 h 1 v 1 h -1"
+       id="path5127" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,60.000002 h 1 v 1 h -1"
+       id="path5125" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,60.000002 h 1 v 1 h -1"
+       id="path5123" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,60.000002 h 1 v 1 h -1"
+       id="path5121" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,60.000002 h 1 v 1 h -1"
+       id="path5119" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,60.000002 h 1 v 1 h -1"
+       id="path5117" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,60.000002 h 1 v 1 h -1"
+       id="path5115" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,60.000002 h 1 v 1 h -1"
+       id="path5113" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,60.000002 h 1 v 1 h -1"
+       id="path5111" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,60.000002 h 1 v 1 h -1"
+       id="path5109" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,60.000002 h 1 v 1 h -1"
+       id="path5107" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,60.000002 h 1 v 1 h -1"
+       id="path5105" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,60.000002 h 1 v 1 h -1"
+       id="path5103" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,60.000002 h 1 v 1 h -1"
+       id="path5101" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,60.000002 h 1 v 1 h -1"
+       id="path5099" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,60.000002 h 1 v 1 h -1"
+       id="path5097" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,60.000002 h 1 v 1 h -1"
+       id="path5095" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.862745"
+       d="m 42,60.000002 h 1 v 1 h -1"
+       id="path5093" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,60.000002 h 1 v 1 h -1"
+       id="path5091" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,60.000002 h 1 v 1 h -1"
+       id="path5089" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,60.000002 h 1 v 1 h -1"
+       id="path5087" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,60.000002 h 1 v 1 h -1"
+       id="path5085" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,60.000002 h 1 v 1 h -1"
+       id="path5083" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,60.000002 h 1 v 1 L 36,61"
+       id="path5081"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.776471"
+       d="m 35,60.000002 h 1 V 61 61 h -1 v 0"
+       id="path5079"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,60.000002 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path5077" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,60.000002 h 1 v 1 h -1"
+       id="path5075" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,60.000002 h 1 v 1 h -1"
+       id="path5073" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,59.000002 h 1 v 1 h -1"
+       id="path5071" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,59.000002 h 1 v 1 h -1"
+       id="path5069" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93.25,59.250002 0.75,-0.25 v 1 h -1"
+       id="path5067" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.772549"
+       d="m 92,59 v 0 h 1 v 0 1.000002 h -1"
+       id="path5065"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="M 91,59.000002 92,59 v 1.000002 h -1"
+       id="path5063"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 90,59.000002 h 1 v 1 h -1"
+       id="path5061" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,59.000002 h 1 v 1 h -1"
+       id="path5059" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,59.000002 h 1 v 1 h -1"
+       id="path5057" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,59.000002 h 1 v 1 h -1"
+       id="path5055" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,59.000002 h 1 v 1 h -1"
+       id="path5053" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.847059"
+       d="m 85,59.000002 h 1 v 1 h -1"
+       id="path5051" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,59.000002 h 1 v 1 h -1"
+       id="path5049" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,59.000002 h 1 v 1 h -1"
+       id="path5047" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,59.000002 h 1 v 1 h -1"
+       id="path5045" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,59.000002 h 1 v 1 h -1"
+       id="path5043" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,59.000002 h 1 v 1 h -1"
+       id="path5041" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,59.000002 h 1 v 1 h -1"
+       id="path5039" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,59.000002 h 1 v 1 h -1"
+       id="path5037" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,59.000002 h 1 v 1 h -1"
+       id="path5035" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,59.000002 h 1 v 1 h -1"
+       id="path5033" />
+    <path
+       style="fill:#252121;fill-opacity:0.243137"
+       d="m 75,59.000002 h 1 v 1 h -1"
+       id="path5031" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.929412"
+       d="m 74,59.000002 h 1 v 1 h -1"
+       id="path5029" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,59.000002 h 1 v 1 h -1"
+       id="path5027" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,59.000002 h 1 v 1 h -1"
+       id="path5025" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,59.000002 h 1 v 1 h -1"
+       id="path5023" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,59.000002 h 1 v 1 h -1"
+       id="path5021" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,59.000002 h 1 v 1 h -1"
+       id="path5019" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,59.000002 h 1 v 1 h -1"
+       id="path5017" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,59.000002 h 1 v 1 h -1"
+       id="path5015" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,59.000002 h 1 v 1 h -1"
+       id="path5013" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,59.000002 h 1 v 1 h -1"
+       id="path5011" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,59.000002 h 1 v 1 h -1"
+       id="path5009" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,59.000002 h 1 v 1 h -1"
+       id="path5007" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,59.000002 h 1 v 1 h -1"
+       id="path5005" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,59.000002 h 1 v 1 h -1"
+       id="path5003" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,59.000002 h 1 v 1 h -1"
+       id="path5001" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,59.000002 h 1 v 1 h -1"
+       id="path4999" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,59.000002 h 1 v 1 h -1"
+       id="path4997" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,59.000002 h 1 v 1 h -1"
+       id="path4995" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,59.000002 h 1 v 1 h -1"
+       id="path4993" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,59.000002 h 1 v 1 h -1"
+       id="path4991" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,59.000002 h 1 v 1 h -1"
+       id="path4989" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,59.000002 h 1 v 1 h -1"
+       id="path4987" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,59.000002 h 1 v 1 h -1"
+       id="path4985" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,59.000002 h 1 v 1 h -1"
+       id="path4983" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,59.000002 h 1 v 1 h -1"
+       id="path4981" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,59.000002 h 1 v 1 h -1"
+       id="path4979" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,59.000002 h 1 v 1 h -1"
+       id="path4977" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,59.000002 h 1 v 1 h -1"
+       id="path4975" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,59.000002 h 1 v 1 h -1"
+       id="path4973" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,59.000002 h 1 v 1 h -1"
+       id="path4971" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,59.000002 h 1 v 1 h -1"
+       id="path4969" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,59.000002 h 1 v 1 h -1"
+       id="path4967" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.847059"
+       d="m 42,59.000002 h 1 v 1 h -1"
+       id="path4965" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,59.000002 h 1 v 1 h -1"
+       id="path4963" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,59.000002 h 1 v 1 h -1"
+       id="path4961" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,59.000002 h 1 v 1 h -1"
+       id="path4959" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,59.000002 h 1 v 1 h -1"
+       id="path4957" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,59.000002 h 1 v 1 h -1"
+       id="path4955" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,59 1,2e-6 v 1 h -1"
+       id="path4953"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.772549"
+       d="m 35,59 v 0 h 1 v 0 1.000002 h -1"
+       id="path4951"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,59.000002 0.75,0.25 0.25,0.75 h -1"
+       id="path4949" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,59.000002 h 1 v 1 h -1"
+       id="path4947" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,59.000002 h 1 v 1 h -1"
+       id="path4945" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,58.000002 h 1 v 1 h -1"
+       id="path4943" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,58.000002 h 1 v 1 h -1"
+       id="path4941" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92.75,58.250002 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path4939" />
+    <path
+       style="fill:#400000;fill-opacity:0.0156863"
+       d="m 92,58 h 1 v 1 h -1"
+       id="path4937"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.447059"
+       d="M 91,58.000002 92,58 v 0 1 0 l -1,2e-6"
+       id="path4935"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.952941"
+       d="m 90,58.000002 h 1 v 1 h -1"
+       id="path4933" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,58.000002 h 1 v 1 h -1"
+       id="path4931" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,58.000002 h 1 v 1 h -1"
+       id="path4929" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,58.000002 h 1 v 1 h -1"
+       id="path4927" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,58.000002 h 1 v 1 h -1"
+       id="path4925" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.890196"
+       d="m 85,58.000002 h 1 v 1 h -1"
+       id="path4923" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,58.000002 h 1 v 1 h -1"
+       id="path4921" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,58.000002 h 1 v 1 h -1"
+       id="path4919" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,58.000002 h 1 v 1 h -1"
+       id="path4917" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,58.000002 h 1 v 1 h -1"
+       id="path4915" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,58.000002 h 1 v 1 h -1"
+       id="path4913" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,58.000002 h 1 v 1 h -1"
+       id="path4911" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,58.000002 h 1 v 1 h -1"
+       id="path4909" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,58.000002 h 1 v 1 h -1"
+       id="path4907" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,58.000002 h 1 v 1 h -1"
+       id="path4905" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 75,58.000002 h 1 v 1 h -1"
+       id="path4903" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.705882"
+       d="m 74,58.000002 h 1 v 1 h -1"
+       id="path4901" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,58.000002 h 1 v 1 h -1"
+       id="path4899" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,58.000002 h 1 v 1 h -1"
+       id="path4897" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,58.000002 h 1 v 1 h -1"
+       id="path4895" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,58.000002 h 1 v 1 h -1"
+       id="path4893" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,58.000002 h 1 v 1 h -1"
+       id="path4891" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,58.000002 h 1 v 1 h -1"
+       id="path4889" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,58.000002 h 1 v 1 h -1"
+       id="path4887" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,58.000002 h 1 v 1 h -1"
+       id="path4885" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,58.000002 h 1 v 1 h -1"
+       id="path4883" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,58.000002 h 1 v 1 h -1"
+       id="path4881" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,58.000002 h 1 v 1 h -1"
+       id="path4879" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,58.000002 h 1 v 1 h -1"
+       id="path4877" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,58.000002 h 1 v 1 h -1"
+       id="path4875" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,58.000002 h 1 v 1 h -1"
+       id="path4873" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,58.000002 h 1 v 1 h -1"
+       id="path4871" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,58.000002 h 1 v 1 h -1"
+       id="path4869" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,58.000002 h 1 v 1 h -1"
+       id="path4867" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,58.000002 h 1 v 1 h -1"
+       id="path4865" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,58.000002 h 1 v 1 h -1"
+       id="path4863" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,58.000002 h 1 v 1 h -1"
+       id="path4861" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,58.000002 h 1 v 1 h -1"
+       id="path4859" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,58.000002 h 1 v 1 h -1"
+       id="path4857" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,58.000002 h 1 v 1 h -1"
+       id="path4855" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,58.000002 h 1 v 1 h -1"
+       id="path4853" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,58.000002 h 1 v 1 h -1"
+       id="path4851" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,58.000002 h 1 v 1 h -1"
+       id="path4849" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,58.000002 h 1 v 1 h -1"
+       id="path4847" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,58.000002 h 1 v 1 h -1"
+       id="path4845" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,58.000002 h 1 v 1 h -1"
+       id="path4843" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,58.000002 h 1 v 1 h -1"
+       id="path4841" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,58.000002 h 1 v 1 h -1"
+       id="path4839" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.901961"
+       d="m 42,58.000002 h 1 v 1 h -1"
+       id="path4837" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,58.000002 h 1 v 1 h -1"
+       id="path4835" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,58.000002 h 1 v 1 h -1"
+       id="path4833" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,58.000002 h 1 v 1 h -1"
+       id="path4831" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,58.000002 h 1 v 1 h -1"
+       id="path4829" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.952941"
+       d="m 37,58.000002 h 1 v 1 h -1"
+       id="path4827" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.447059"
+       d="m 36,58 v 0 l 1,2e-6 v 1 L 36,59 v 0"
+       id="path4825"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#400000;fill-opacity:0.0156863"
+       d="m 35,58 h 1 v 1 h -1"
+       id="path4823"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,58.000002 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path4821" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,58.000002 h 1 v 1 h -1"
+       id="path4819" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,58.000002 h 1 v 1 h -1"
+       id="path4817" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,57.000002 h 1 v 1 h -1"
+       id="path4815" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,57.000002 h 1 v 1 h -1"
+       id="path4813" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,57.000002 h 1 v 1 l -0.75,-0.25"
+       id="path4811" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,57.000002 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path4809" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,57.000002 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path4807" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.227451"
+       d="m 90,57.000002 h 1 v 1 h -1"
+       id="path4805" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,57.000002 h 1 v 1 h -1"
+       id="path4803" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,57.000002 h 1 v 1 h -1"
+       id="path4801" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,57.000002 h 1 v 1 h -1"
+       id="path4799" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,57.000002 h 1 v 1 h -1"
+       id="path4797" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.988235"
+       d="m 85,57.000002 h 1 v 1 h -1"
+       id="path4795" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.486275"
+       d="m 84,57.000002 h 1 v 1 h -1"
+       id="path4793" />
+    <path
+       style="fill:#261a1a;fill-opacity:0.0784314"
+       d="m 83,57.000002 h 1 v 1 h -1"
+       id="path4791" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,57.000002 h 1 v 1 h -1"
+       id="path4789" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,57.000002 h 1 v 1 h -1"
+       id="path4787" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,57.000002 h 1 v 1 h -1"
+       id="path4785" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,57.000002 h 1 v 1 h -1"
+       id="path4783" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,57.000002 h 1 v 1 h -1"
+       id="path4781" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,57.000002 h 1 v 1 h -1"
+       id="path4779" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.164706"
+       d="m 76,57.000002 h 1 v 1 h -1"
+       id="path4777" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 75,57.000002 h 1 v 1 h -1"
+       id="path4775" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,57.000002 h 1 v 1 h -1"
+       id="path4773" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,57.000002 h 1 v 1 h -1"
+       id="path4771" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,57.000002 h 1 v 1 h -1"
+       id="path4769" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,57.000002 h 1 v 1 h -1"
+       id="path4767" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,57.000002 h 1 v 1 h -1"
+       id="path4765" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,57.000002 h 1 v 1 h -1"
+       id="path4763" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,57.000002 h 1 v 1 h -1"
+       id="path4761" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,57.000002 h 1 v 1 h -1"
+       id="path4759" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,57.000002 h 1 v 1 h -1"
+       id="path4757" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,57.000002 h 1 v 1 h -1"
+       id="path4755" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,57.000002 h 1 v 1 h -1"
+       id="path4753" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,57.000002 h 1 v 1 h -1"
+       id="path4751" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,57.000002 h 1 v 1 h -1"
+       id="path4749" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,57.000002 h 1 v 1 h -1"
+       id="path4747" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,57.000002 h 1 v 1 h -1"
+       id="path4745" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,57.000002 h 1 v 1 h -1"
+       id="path4743" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,57.000002 h 1 v 1 h -1"
+       id="path4741" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,57.000002 h 1 v 1 h -1"
+       id="path4739" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,57.000002 h 1 v 1 h -1"
+       id="path4737" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,57.000002 h 1 v 1 h -1"
+       id="path4735" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,57.000002 h 1 v 1 h -1"
+       id="path4733" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,57.000002 h 1 v 1 h -1"
+       id="path4731" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,57.000002 h 1 v 1 h -1"
+       id="path4729" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,57.000002 h 1 v 1 h -1"
+       id="path4727" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,57.000002 h 1 v 1 h -1"
+       id="path4725" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,57.000002 h 1 v 1 h -1"
+       id="path4723" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,57.000002 h 1 v 1 h -1"
+       id="path4721" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47.25,57.250002 0.75,-0.25 v 1 h -1"
+       id="path4719" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45.75,57.250002 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path4717" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,57.000002 0.75,0.25 0.25,0.75 h -1"
+       id="path4715" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 44,57.000002 h 1 v 1 h -1"
+       id="path4713" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.321569"
+       d="m 43,57.000002 h 1 v 1 h -1"
+       id="path4711" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.976471"
+       d="m 42,57.000002 h 1 v 1 h -1"
+       id="path4709" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,57.000002 h 1 v 1 h -1"
+       id="path4707" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,57.000002 h 1 v 1 h -1"
+       id="path4705" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,57.000002 h 1 v 1 h -1"
+       id="path4703" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,57.000002 h 1 v 1 h -1"
+       id="path4701" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.227451"
+       d="m 37,57.000002 h 1 v 1 h -1"
+       id="path4699" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,57.000002 h 1 v 1 l -0.75,-0.25"
+       id="path4697" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,57.000002 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path4695" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,57.000002 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path4693" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,57.000002 h 1 v 1 h -1"
+       id="path4691" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,57.000002 h 1 v 1 h -1"
+       id="path4689" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,56.000002 h 1 v 1 h -1"
+       id="path4687" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,56.000002 h 1 v 1 h -1"
+       id="path4685" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,56.000002 h 1 v 1 h -1"
+       id="path4683" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,56.000002 h 1 v 1 h -1"
+       id="path4681" />
+    <path
+       style="fill:#1a1a1a;fill-opacity:0.0392157"
+       d="m 91,56.000002 h 1 v 1 h -1"
+       id="path4679" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.737255"
+       d="m 90,56.000002 h 1 v 1 h -1"
+       id="path4677" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,56.000002 h 1 v 1 h -1"
+       id="path4675" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,56.000002 h 1 v 1 h -1"
+       id="path4673" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,56.000002 h 1 v 1 h -1"
+       id="path4671" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,56.000002 h 1 v 1 h -1"
+       id="path4669" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,56.000002 h 1 v 1 h -1"
+       id="path4667" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,56.000002 h 1 v 1 h -1"
+       id="path4665" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.968627"
+       d="m 83,56.000002 h 1 v 1 h -1"
+       id="path4663" />
+    <path
+       style="fill:#232020;fill-opacity:0.6"
+       d="m 82,56.000002 h 1 v 1 h -1"
+       id="path4661" />
+    <path
+       style="fill:#202020;fill-opacity:0.156863"
+       d="m 81,56.000002 h 1 v 1 h -1"
+       id="path4659" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,56.000002 h 1 v 1 h -1"
+       id="path4657" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,56.000002 h 1 v 1 h -1"
+       id="path4655" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,56.000002 h 1 v 1 h -1"
+       id="path4653" />
+    <path
+       style="fill:#271f1f;fill-opacity:0.129412"
+       d="m 77,56.000002 h 1 v 1 h -1"
+       id="path4651" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.921569"
+       d="m 76,56.000002 h 1 v 1 h -1"
+       id="path4649" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,56.000002 h 1 v 1 h -1"
+       id="path4647" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,56.000002 h 1 v 1 h -1"
+       id="path4645" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,56.000002 h 1 v 1 h -1"
+       id="path4643" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,56.000002 h 1 v 1 h -1"
+       id="path4641" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,56.000002 h 1 v 1 h -1"
+       id="path4639" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,56.000002 h 1 v 1 h -1"
+       id="path4637" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,56.000002 h 1 v 1 h -1"
+       id="path4635" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,56.000002 h 1 v 1 h -1"
+       id="path4633" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,56.000002 h 1 v 1 h -1"
+       id="path4631" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.882353"
+       d="m 66,56.000002 h 1 v 1 h -1"
+       id="path4629" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,56.000002 h 1 v 1 h -1"
+       id="path4627" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,56.000002 h 1 v 1 h -1"
+       id="path4625" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,56.000002 h 1 v 1 h -1"
+       id="path4623" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,56.000002 h 1 v 1 h -1"
+       id="path4621" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,56.000002 h 1 v 1 h -1"
+       id="path4619" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,56.000002 h 1 v 1 h -1"
+       id="path4617" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,56.000002 h 1 v 1 h -1"
+       id="path4615" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,56.000002 h 1 v 1 h -1"
+       id="path4613" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,56.000002 h 1 v 1 h -1"
+       id="path4611" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,56.000002 h 1 v 1 h -1"
+       id="path4609" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,56.000002 h 1 v 1 h -1"
+       id="path4607" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,56.000002 h 1 v 1 h -1"
+       id="path4605" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,56.000002 h 1 v 1 h -1"
+       id="path4603" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,56.000002 h 1 v 1 h -1"
+       id="path4601" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,56.000002 h 1 v 1 h -1"
+       id="path4599" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,56.000002 h 1 v 1 h -1"
+       id="path4597" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,56.000002 h 1 v 1 h -1"
+       id="path4595" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,56.000002 h 1 v 1 h -1"
+       id="path4593" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46.75,56.250002 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path4591" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 46,56 h 1 v 1 h -1"
+       id="path4589"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.431373"
+       d="M 45,56.000002 46,56 v 0 1 0 l -1,2e-6"
+       id="path4587"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.870588"
+       d="m 44,56.000002 h 1 v 1 h -1"
+       id="path4585" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,56.000002 h 1 v 1 h -1"
+       id="path4583" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,56.000002 h 1 v 1 h -1"
+       id="path4581" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,56.000002 h 1 v 1 h -1"
+       id="path4579" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,56.000002 h 1 v 1 h -1"
+       id="path4577" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,56.000002 h 1 v 1 h -1"
+       id="path4575" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,56.000002 h 1 v 1 h -1"
+       id="path4573" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.737255"
+       d="m 37,56.000002 h 1 v 1 h -1"
+       id="path4571" />
+    <path
+       style="fill:#1a1a1a;fill-opacity:0.0392157"
+       d="m 36,56.000002 h 1 v 1 h -1"
+       id="path4569" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,56.000002 h 1 v 1 h -1"
+       id="path4567" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,56.000002 h 1 v 1 h -1"
+       id="path4565" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,56.000002 h 1 v 1 h -1"
+       id="path4563" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,56.000002 h 1 v 1 h -1"
+       id="path4561" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,55.000002 h 1 v 1 h -1"
+       id="path4559" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,55.000002 h 1 v 1 h -1"
+       id="path4557" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,55.000002 h 1 v 1 h -1"
+       id="path4555" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 92,55.000002 h 1 v 1 h -1"
+       id="path4553" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 91,55.000002 h 1 v 1 h -1"
+       id="path4551" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 90,55.000002 h 1 v 1 h -1"
+       id="path4549" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,55.000002 h 1 v 1 h -1"
+       id="path4547" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,55.000002 h 1 v 1 h -1"
+       id="path4545" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,55.000002 h 1 v 1 h -1"
+       id="path4543" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,55.000002 h 1 v 1 h -1"
+       id="path4541" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.988235"
+       d="m 85,55.000002 h 1 v 1 h -1"
+       id="path4539" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.839216"
+       d="m 84,55.000002 h 1 v 1 h -1"
+       id="path4537" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 83,55.000002 h 1 v 1 h -1"
+       id="path4535" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,55.000002 h 1 v 1 h -1"
+       id="path4533" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 81,55.000002 h 1 v 1 h -1"
+       id="path4531" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.392157"
+       d="m 80,55.000002 h 1 v 1 h -1"
+       id="path4529" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,55.000002 h 1 v 1 h -1"
+       id="path4527" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 78,55.000002 h 1 v 1 h -1"
+       id="path4525" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 77,55.000002 h 1 v 1 h -1"
+       id="path4523" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,55.000002 h 1 v 1 h -1"
+       id="path4521" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,55.000002 h 1 v 1 h -1"
+       id="path4519" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,55.000002 h 1 v 1 h -1"
+       id="path4517" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,55.000002 h 1 v 1 h -1"
+       id="path4515" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,55.000002 h 1 v 1 h -1"
+       id="path4513" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,55.000002 h 1 v 1 h -1"
+       id="path4511" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,55.000002 h 1 v 1 h -1"
+       id="path4509" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,55.000002 h 1 v 1 h -1"
+       id="path4507" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.686275"
+       d="m 68,55.000002 h 1 v 1 h -1"
+       id="path4505" />
+    <path
+       style="fill:#232323;fill-opacity:0.113725"
+       d="m 67,55.000002 h 1 v 1 h -1"
+       id="path4503" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,55.000002 h 1 v 1 h -1"
+       id="path4501" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,55.000002 h 1 v 1 h -1"
+       id="path4499" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,55.000002 h 1 v 1 h -1"
+       id="path4497" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,55.000002 h 1 v 1 h -1"
+       id="path4495" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,55.000002 h 1 v 1 h -1"
+       id="path4493" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,55.000002 h 1 v 1 h -1"
+       id="path4491" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,55.000002 h 1 v 1 h -1"
+       id="path4489" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,55.000002 h 1 v 1 h -1"
+       id="path4487" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,55.000002 h 1 v 1 h -1"
+       id="path4485" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,55.000002 h 1 v 1 h -1"
+       id="path4483" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,55.000002 h 1 v 1 h -1"
+       id="path4481" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,55.000002 h 1 v 1 h -1"
+       id="path4479" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,55.000002 h 1 v 1 h -1"
+       id="path4477" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,55.000002 h 1 v 1 h -1"
+       id="path4475" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,55.000002 h 1 v 1 h -1"
+       id="path4473" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,55.000002 h 1 v 1 h -1"
+       id="path4471" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,55.000002 h 1 v 1 h -1"
+       id="path4469" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,55.000002 h 1 v 1 h -1"
+       id="path4467" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,55.000002 h 1 v 1 h -1"
+       id="path4465" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.2"
+       d="m 47,55.000002 h 1 v 1 L 47,56"
+       id="path4463"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.929412"
+       d="m 46,55.000002 h 1 V 56 56 h -1 v 0"
+       id="path4461"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,55.000002 h 1 V 56 l -1,2e-6"
+       id="path4459"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,55.000002 h 1 v 1 h -1"
+       id="path4457" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.92549"
+       d="m 43,55.000002 h 1 v 1 h -1"
+       id="path4455" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.992157"
+       d="m 42,55.000002 h 1 v 1 h -1"
+       id="path4453" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,55.000002 h 1 v 1 h -1"
+       id="path4451" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,55.000002 h 1 v 1 h -1"
+       id="path4449" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,55.000002 h 1 v 1 h -1"
+       id="path4447" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,55.000002 h 1 v 1 h -1"
+       id="path4445" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,55.000002 h 1 v 1 h -1"
+       id="path4443" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 36,55.000002 h 1 v 1 h -1"
+       id="path4441" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 35,55.000002 h 1 v 1 h -1"
+       id="path4439" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,55.000002 h 1 v 1 h -1"
+       id="path4437" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,55.000002 h 1 v 1 h -1"
+       id="path4435" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,55.000002 h 1 v 1 h -1"
+       id="path4433" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,54.000002 h 1 v 1 h -1"
+       id="path4431" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,54.000002 h 1 v 1 h -1"
+       id="path4429" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,54.000002 h 1 v 1 h -1"
+       id="path4427" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 92,54.000002 h 1 v 1 h -1"
+       id="path4425" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 91,54.000002 h 1 v 1 h -1"
+       id="path4423" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 90,54.000002 h 1 v 1 h -1"
+       id="path4421" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,54.000002 h 1 v 1 h -1"
+       id="path4419" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,54.000002 h 1 v 1 h -1"
+       id="path4417" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,54.000002 h 1 v 1 h -1"
+       id="path4415" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,54.000002 h 1 v 1 h -1"
+       id="path4413" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.258824"
+       d="m 85,54.000002 h 1 v 1 h -1"
+       id="path4411" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,54.000002 h 1 v 1 h -1"
+       id="path4409" />
+    <path
+       style="fill:#252020;fill-opacity:0.188235"
+       d="m 83,54.000002 h 1 v 1 h -1"
+       id="path4407" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.976471"
+       d="m 82,54.000002 h 1 v 1 h -1"
+       id="path4405" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,54.000002 h 1 v 1 h -1"
+       id="path4403" />
+    <path
+       style="fill:#242020;fill-opacity:0.729412"
+       d="m 80,54.000002 h 1 v 1 h -1"
+       id="path4401" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,54.000002 h 1 v 1 h -1"
+       id="path4399" />
+    <path
+       style="fill:#242121;fill-opacity:0.27451"
+       d="m 78,54.000002 h 1 v 1 h -1"
+       id="path4397" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,54.000002 h 1 v 1 h -1"
+       id="path4395" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,54.000002 h 1 v 1 h -1"
+       id="path4393" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,54.000002 h 1 v 1 h -1"
+       id="path4391" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,54.000002 h 1 v 1 h -1"
+       id="path4389" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,54.000002 h 1 v 1 h -1"
+       id="path4387" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,54.000002 h 1 v 1 h -1"
+       id="path4385" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,54.000002 h 1 v 1 h -1"
+       id="path4383" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,54.000002 h 1 v 1 h -1"
+       id="path4381" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,54.000002 h 1 v 1 h -1"
+       id="path4379" />
+    <path
+       style="fill:#202020;fill-opacity:0.12549"
+       d="m 68,54.000002 h 1 v 1 h -1"
+       id="path4377" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,54.000002 h 1 v 1 h -1"
+       id="path4375" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,54.000002 h 1 v 1 h -1"
+       id="path4373" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,54.000002 h 1 v 1 h -1"
+       id="path4371" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,54.000002 h 1 v 1 h -1"
+       id="path4369" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,54.000002 h 1 v 1 h -1"
+       id="path4367" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,54.000002 h 1 v 1 h -1"
+       id="path4365" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,54.000002 h 1 v 1 h -1"
+       id="path4363" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,54.000002 h 1 v 1 h -1"
+       id="path4361" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,54.000002 h 1 v 1 h -1"
+       id="path4359" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,54.000002 h 1 v 1 h -1"
+       id="path4357" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,54.000002 h 1 v 1 h -1"
+       id="path4355" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,54.000002 h 1 v 1 h -1"
+       id="path4353" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,54.000002 h 1 v 1 h -1"
+       id="path4351" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,54.000002 h 1 v 1 h -1"
+       id="path4349" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,54.000002 h 1 v 1 h -1"
+       id="path4347" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,54.000002 h 1 v 1 h -1"
+       id="path4345" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,54.000002 h 1 v 1 h -1"
+       id="path4343" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,54.000002 h 1 v 1 h -1"
+       id="path4341" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,54.000002 h 1 v 1 h -1"
+       id="path4339" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,54.000002 h 1 v 1 h -1"
+       id="path4337" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 47,54.000002 h 1 v 1 h -1"
+       id="path4335" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,54.000002 h 1 v 1 h -1"
+       id="path4333" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,54.000002 h 1 v 1 h -1"
+       id="path4331" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 44,54.000002 h 1 v 1 h -1"
+       id="path4329" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,54.000002 h 1 v 1 h -1"
+       id="path4327" />
+    <path
+       style="fill:#252020;fill-opacity:0.188235"
+       d="m 42,54.000002 h 1 v 1 h -1"
+       id="path4325" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.960784"
+       d="m 41,54.000002 h 1 v 1 h -1"
+       id="path4323" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,54.000002 h 1 v 1 h -1"
+       id="path4321" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,54.000002 h 1 v 1 h -1"
+       id="path4319" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,54.000002 h 1 v 1 h -1"
+       id="path4317" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,54.000002 h 1 v 1 h -1"
+       id="path4315" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,54.000002 h 1 v 1 h -1"
+       id="path4313" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 35,54.000002 h 1 v 1 h -1"
+       id="path4311" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,54.000002 h 1 v 1 h -1"
+       id="path4309" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,54.000002 h 1 v 1 h -1"
+       id="path4307" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,54.000002 h 1 v 1 h -1"
+       id="path4305" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,53.000002 h 1 v 1 h -1"
+       id="path4303" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,53.000002 h 1 v 1 h -1"
+       id="path4301" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,53.000002 h 1 v 1 h -1"
+       id="path4299" />
+    <path
+       style="fill:#272727;fill-opacity:0.0509804"
+       d="m 92,53.000002 h 1 v 1 h -1"
+       id="path4297" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 91,53.000002 h 1 v 1 h -1"
+       id="path4295" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 90,53.000002 h 1 v 1 h -1"
+       id="path4293" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,53.000002 h 1 v 1 h -1"
+       id="path4291" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,53.000002 h 1 v 1 h -1"
+       id="path4289" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,53.000002 h 1 v 1 h -1"
+       id="path4287" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.913725"
+       d="m 86,53.000002 h 1 v 1 h -1"
+       id="path4285" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,53.000002 h 1 v 1 h -1"
+       id="path4283" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,53.000002 h 1 v 1 h -1"
+       id="path4281" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,53.000002 h 1 v 1 h -1"
+       id="path4279" />
+    <path
+       style="fill:#232020;fill-opacity:0.823529"
+       d="m 82,53.000002 h 1 v 1 h -1"
+       id="path4277" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,53.000002 h 1 v 1 h -1"
+       id="path4275" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 80,53.000002 h 1 v 1 h -1"
+       id="path4273" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,53.000002 h 1 v 1 h -1"
+       id="path4271" />
+    <path
+       style="fill:#232020;fill-opacity:0.537255"
+       d="m 78,53.000002 h 1 v 1 h -1"
+       id="path4269" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,53.000002 h 1 v 1 h -1"
+       id="path4267" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,53.000002 h 1 v 1 h -1"
+       id="path4265" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,53.000002 h 1 v 1 h -1"
+       id="path4263" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,53.000002 h 1 v 1 h -1"
+       id="path4261" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,53.000002 h 1 v 1 h -1"
+       id="path4259" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,53.000002 h 1 v 1 h -1"
+       id="path4257" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,53.000002 h 1 v 1 h -1"
+       id="path4255" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,53.000002 h 1 v 1 h -1"
+       id="path4253" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,53.000002 h 1 v 1 h -1"
+       id="path4251" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.360784"
+       d="m 68,53.000002 h 1 v 1 h -1"
+       id="path4249" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,53.000002 h 1 v 1 h -1"
+       id="path4247" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,53.000002 h 1 v 1 h -1"
+       id="path4245" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,53.000002 h 1 v 1 h -1"
+       id="path4243" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,53.000002 h 1 v 1 h -1"
+       id="path4241" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,53.000002 h 1 v 1 h -1"
+       id="path4239" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,53.000002 h 1 v 1 h -1"
+       id="path4237" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,53.000002 h 1 v 1 h -1"
+       id="path4235" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,53.000002 h 1 v 1 h -1"
+       id="path4233" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,53.000002 h 1 v 1 h -1"
+       id="path4231" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,53.000002 h 1 v 1 h -1"
+       id="path4229" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,53.000002 h 1 v 1 h -1"
+       id="path4227" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,53.000002 h 1 v 1 h -1"
+       id="path4225" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,53.000002 h 1 v 1 h -1"
+       id="path4223" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,53.000002 h 1 v 1 h -1"
+       id="path4221" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,53.000002 h 1 v 1 h -1"
+       id="path4219" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,53.000002 h 1 v 1 h -1"
+       id="path4217" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,53.000002 h 1 v 1 h -1"
+       id="path4215" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,53.000002 h 1 v 1 h -1"
+       id="path4213" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,53.000002 h 1 v 1 h -1"
+       id="path4211" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,53.000002 h 1 v 1 h -1"
+       id="path4209" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.329412"
+       d="m 47,53.000002 h 1 v 1 h -1"
+       id="path4207" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,53.000002 h 1 v 1 h -1"
+       id="path4205" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 45,53.000002 h 1 v 1 h -1"
+       id="path4203" />
+    <path
+       style="fill:#000000;fill-opacity:0.0117647"
+       d="m 44,53.000002 h 1 v 1 h -1"
+       id="path4201" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,53.000002 h 1 v 1 h -1"
+       id="path4199" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,53.000002 h 1 v 1 h -1"
+       id="path4197" />
+    <path
+       style="fill:#242020;fill-opacity:0.729412"
+       d="m 41,53.000002 h 1 v 1 h -1"
+       id="path4195" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,53.000002 h 1 v 1 h -1"
+       id="path4193" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,53.000002 h 1 v 1 h -1"
+       id="path4191" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,53.000002 h 1 v 1 h -1"
+       id="path4189" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 37,53.000002 h 1 v 1 h -1"
+       id="path4187" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 36,53.000002 h 1 v 1 h -1"
+       id="path4185" />
+    <path
+       style="fill:#272727;fill-opacity:0.0509804"
+       d="m 35,53.000002 h 1 v 1 h -1"
+       id="path4183" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,53.000002 h 1 v 1 h -1"
+       id="path4181" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,53.000002 h 1 v 1 h -1"
+       id="path4179" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,53.000002 h 1 v 1 h -1"
+       id="path4177" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,52.000002 h 1 v 1 h -1"
+       id="path4175" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,52.000002 h 1 v 1 h -1"
+       id="path4173" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,52.000002 h 1 v 1 h -1"
+       id="path4171" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,52.000002 h 1 v 1 h -1"
+       id="path4169" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,52.000002 h 1 v 1 h -1"
+       id="path4167" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,52.000002 h 1 v 1 h -1"
+       id="path4165" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.329412"
+       d="m 89,52.000002 h 1 v 1 h -1"
+       id="path4163" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,52.000002 h 1 v 1 h -1"
+       id="path4161" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,52.000002 h 1 v 1 h -1"
+       id="path4159" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,52.000002 h 1 v 1 h -1"
+       id="path4157" />
+    <path
+       style="fill:#241d1d;fill-opacity:0.305882"
+       d="m 85,52.000002 h 1 v 1 h -1"
+       id="path4155" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,52.000002 h 1 v 1 h -1"
+       id="path4153" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.231373"
+       d="m 83,52.000002 h 1 v 1 h -1"
+       id="path4151" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 82,52.000002 h 1 v 1 h -1"
+       id="path4149" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.964706"
+       d="m 81,52.000002 h 1 v 1 h -1"
+       id="path4147" />
+    <path
+       style="fill:#281b1b;fill-opacity:0.0745098"
+       d="m 80,52.000002 h 1 v 1 h -1"
+       id="path4145" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,52.000002 h 1 v 1 h -1"
+       id="path4143" />
+    <path
+       style="fill:#232020;fill-opacity:0.6"
+       d="m 78,52.000002 h 1 v 1 h -1"
+       id="path4141" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,52.000002 h 1 v 1 h -1"
+       id="path4139" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,52.000002 h 1 v 1 h -1"
+       id="path4137" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,52.000002 h 1 v 1 h -1"
+       id="path4135" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,52.000002 h 1 v 1 h -1"
+       id="path4133" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,52.000002 h 1 v 1 h -1"
+       id="path4131" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,52.000002 h 1 v 1 h -1"
+       id="path4129" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,52.000002 h 1 v 1 h -1"
+       id="path4127" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,52.000002 h 1 v 1 h -1"
+       id="path4125" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,52.000002 h 1 v 1 h -1"
+       id="path4123" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 68,52.000002 h 1 v 1 h -1"
+       id="path4121" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.588235"
+       d="m 67,52.000002 h 1 v 1 h -1"
+       id="path4119" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,52.000002 h 1 v 1 h -1"
+       id="path4117" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,52.000002 h 1 v 1 h -1"
+       id="path4115" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,52.000002 h 1 v 1 h -1"
+       id="path4113" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,52.000002 h 1 v 1 h -1"
+       id="path4111" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,52.000002 h 1 v 1 h -1"
+       id="path4109" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,52.000002 h 1 v 1 h -1"
+       id="path4107" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,52.000002 h 1 v 1 h -1"
+       id="path4105" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,52.000002 h 1 v 1 h -1"
+       id="path4103" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,52.000002 h 1 v 1 h -1"
+       id="path4101" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,52.000002 h 1 v 1 h -1"
+       id="path4099" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,52.000002 h 1 v 1 h -1"
+       id="path4097" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,52.000002 h 1 v 1 h -1"
+       id="path4095" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,52.000002 h 1 v 1 h -1"
+       id="path4093" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,52.000002 h 1 v 1 h -1"
+       id="path4091" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,52.000002 h 1 v 1 h -1"
+       id="path4089" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,52.000002 h 1 v 1 h -1"
+       id="path4087" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,52.000002 h 1 v 1 h -1"
+       id="path4085" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,52.000002 h 1 v 1 h -1"
+       id="path4083" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,52.000002 h 1 v 1 h -1"
+       id="path4081" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,52.000002 h 1 v 1 h -1"
+       id="path4079" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.917647"
+       d="m 46,52.000002 h 1 v 1 h -1"
+       id="path4077" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,52.000002 h 1 v 1 h -1"
+       id="path4075" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.321569"
+       d="m 44,52.000002 h 1 v 1 h -1"
+       id="path4073" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,52.000002 h 1 v 1 h -1"
+       id="path4071" />
+    <path
+       style="fill:#222222;fill-opacity:0.117647"
+       d="m 42,52.000002 h 1 v 1 h -1"
+       id="path4069" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.933333"
+       d="m 41,52.000002 h 1 v 1 h -1"
+       id="path4067" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,52.000002 h 1 v 1 h -1"
+       id="path4065" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,52.000002 h 1 v 1 h -1"
+       id="path4063" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.329412"
+       d="m 38,52.000002 h 1 v 1 h -1"
+       id="path4061" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,52.000002 h 1 v 1 h -1"
+       id="path4059" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,52.000002 h 1 v 1 h -1"
+       id="path4057" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,52.000002 h 1 v 1 h -1"
+       id="path4055" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,52.000002 h 1 v 1 h -1"
+       id="path4053" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,52.000002 h 1 v 1 h -1"
+       id="path4051" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,52.000002 h 1 v 1 h -1"
+       id="path4049" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,51.000002 h 1 v 1 h -1"
+       id="path4047" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,51.000002 h 1 v 1 h -1"
+       id="path4045" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,51.000002 h 1 v 1 h -1"
+       id="path4043" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,51.000002 h 1 v 1 h -1"
+       id="path4041" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,51.000002 h 1 v 1 h -1"
+       id="path4039" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,51.000002 h 1 v 1 h -1"
+       id="path4037" />
+    <path
+       style="fill:#222020;fill-opacity:0.470588"
+       d="m 89,51.000002 h 1 v 1 h -1"
+       id="path4035" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,51.000002 h 1 v 1 h -1"
+       id="path4033" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,51.000002 h 1 v 1 h -1"
+       id="path4031" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,51.000002 h 1 v 1 h -1"
+       id="path4029" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,51.000002 h 1 v 1 h -1"
+       id="path4027" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.901961"
+       d="m 84,51.000002 h 1 v 1 h -1"
+       id="path4025" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.992157"
+       d="m 83,51.000002 h 1 v 1 h -1"
+       id="path4023" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,51.000002 h 1 v 1 h -1"
+       id="path4021" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.592157"
+       d="m 81,51.000002 h 1 v 1 h -1"
+       id="path4019" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,51.000002 h 1 v 1 h -1"
+       id="path4017" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,51.000002 h 1 v 1 h -1"
+       id="path4015" />
+    <path
+       style="fill:#242020;fill-opacity:0.47451"
+       d="m 78,51.000002 h 1 v 1 h -1"
+       id="path4013" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,51.000002 h 1 v 1 h -1"
+       id="path4011" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,51.000002 h 1 v 1 h -1"
+       id="path4009" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,51.000002 h 1 v 1 h -1"
+       id="path4007" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,51.000002 h 1 v 1 h -1"
+       id="path4005" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,51.000002 h 1 v 1 h -1"
+       id="path4003" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,51.000002 h 1 v 1 h -1"
+       id="path4001" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,51.000002 h 1 v 1 h -1"
+       id="path3999" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,51.000002 h 1 v 1 h -1"
+       id="path3997" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,51.000002 h 1 v 1 h -1"
+       id="path3995" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,51.000002 h 1 v 1 h -1"
+       id="path3993" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,51.000002 h 1 v 1 h -1"
+       id="path3991" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,51.000002 h 1 v 1 h -1"
+       id="path3989" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,51.000002 h 1 v 1 h -1"
+       id="path3987" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,51.000002 h 1 v 1 h -1"
+       id="path3985" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,51.000002 h 1 v 1 h -1"
+       id="path3983" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,51.000002 h 1 v 1 h -1"
+       id="path3981" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,51.000002 h 1 v 1 h -1"
+       id="path3979" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,51.000002 h 1 v 1 h -1"
+       id="path3977" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,51.000002 h 1 v 1 h -1"
+       id="path3975" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,51.000002 h 1 v 1 h -1"
+       id="path3973" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,51.000002 h 1 v 1 h -1"
+       id="path3971" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,51.000002 h 1 v 1 h -1"
+       id="path3969" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,51.000002 h 1 v 1 h -1"
+       id="path3967" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,51.000002 h 1 v 1 h -1"
+       id="path3965" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,51.000002 h 1 v 1 h -1"
+       id="path3963" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,51.000002 h 1 v 1 h -1"
+       id="path3961" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,51.000002 h 1 v 1 h -1"
+       id="path3959" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,51.000002 h 1 v 1 h -1"
+       id="path3957" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,51.000002 h 1 v 1 h -1"
+       id="path3955" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,51.000002 h 1 v 1 h -1"
+       id="path3953" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,51.000002 h 1 v 1 h -1"
+       id="path3951" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,51.000002 h 1 v 1 h -1"
+       id="path3949" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,51.000002 h 1 v 1 h -1"
+       id="path3947" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 44,51.000002 h 1 v 1 h -1"
+       id="path3945" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.815686"
+       d="m 43,51.000002 h 1 v 1 h -1"
+       id="path3943" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.956863"
+       d="m 42,51.000002 h 1 v 1 h -1"
+       id="path3941" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,51.000002 h 1 v 1 h -1"
+       id="path3939" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,51.000002 h 1 v 1 h -1"
+       id="path3937" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,51.000002 h 1 v 1 h -1"
+       id="path3935" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 38,51.000002 h 1 v 1 h -1"
+       id="path3933" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,51.000002 h 1 v 1 h -1"
+       id="path3931" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,51.000002 h 1 v 1 h -1"
+       id="path3929" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,51.000002 h 1 v 1 h -1"
+       id="path3927" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,51.000002 h 1 v 1 h -1"
+       id="path3925" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,51.000002 h 1 v 1 h -1"
+       id="path3923" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,51.000002 h 1 v 1 h -1"
+       id="path3921" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,50.000002 h 1 v 1 h -1"
+       id="path3919" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,50.000002 h 1 v 1 h -1"
+       id="path3917" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,50.000002 h 1 v 1 h -1"
+       id="path3915" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,50.000002 h 1 v 1 h -1"
+       id="path3913" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,50.000002 h 1 v 1 h -1"
+       id="path3911" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.207843"
+       d="m 90,50.000002 h 1 v 1 h -1"
+       id="path3909" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 89,50.000002 h 1 v 1 h -1"
+       id="path3907" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,50.000002 h 1 v 1 h -1"
+       id="path3905" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,50.000002 h 1 v 1 h -1"
+       id="path3903" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,50.000002 h 1 v 1 h -1"
+       id="path3901" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,50.000002 h 1 v 1 h -1"
+       id="path3899" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,50.000002 h 1 v 1 h -1"
+       id="path3897" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,50.000002 h 1 v 1 h -1"
+       id="path3895" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,50.000002 h 1 v 1 h -1"
+       id="path3893" />
+    <path
+       style="fill:#202020;fill-opacity:0.156863"
+       d="m 81,50.000002 h 1 v 1 h -1"
+       id="path3891" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,50.000002 h 1 v 1 h -1"
+       id="path3889" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,50.000002 h 1 v 1 h -1"
+       id="path3887" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.168627"
+       d="m 78,50.000002 h 1 v 1 h -1"
+       id="path3885" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,50.000002 h 1 v 1 h -1"
+       id="path3883" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,50.000002 h 1 v 1 h -1"
+       id="path3881" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,50.000002 h 1 v 1 h -1"
+       id="path3879" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,50.000002 h 1 v 1 h -1"
+       id="path3877" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,50.000002 h 1 v 1 h -1"
+       id="path3875" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,50.000002 h 1 v 1 h -1"
+       id="path3873" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,50.000002 h 1 v 1 h -1"
+       id="path3871" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,50.000002 h 1 v 1 h -1"
+       id="path3869" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,50.000002 h 1 v 1 h -1"
+       id="path3867" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,50.000002 h 1 v 1 h -1"
+       id="path3865" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,50.000002 h 1 v 1 h -1"
+       id="path3863" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,50.000002 h 1 v 1 h -1"
+       id="path3861" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,50.000002 h 1 v 1 h -1"
+       id="path3859" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,50.000002 h 1 v 1 h -1"
+       id="path3857" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,50.000002 h 1 v 1 h -1"
+       id="path3855" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,50.000002 h 1 v 1 h -1"
+       id="path3853" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,50.000002 h 1 v 1 h -1"
+       id="path3851" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,50.000002 h 1 v 1 h -1"
+       id="path3849" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,50.000002 h 1 v 1 h -1"
+       id="path3847" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,50.000002 h 1 v 1 h -1"
+       id="path3845" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,50.000002 h 1 v 1 h -1"
+       id="path3843" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,50.000002 h 1 v 1 h -1"
+       id="path3841" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,50.000002 h 1 v 1 h -1"
+       id="path3839" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,50.000002 h 1 v 1 h -1"
+       id="path3837" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,50.000002 h 1 v 1 h -1"
+       id="path3835" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,50.000002 h 1 v 1 h -1"
+       id="path3833" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,50.000002 h 1 v 1 h -1"
+       id="path3831" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,50.000002 h 1 v 1 h -1"
+       id="path3829" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,50.000002 h 1 v 1 h -1"
+       id="path3827" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,50.000002 h 1 v 1 h -1"
+       id="path3825" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,50.000002 h 1 v 1 h -1"
+       id="path3823" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,50.000002 h 1 v 1 h -1"
+       id="path3821" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,50.000002 h 1 v 1 h -1"
+       id="path3819" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,50.000002 h 1 v 1 h -1"
+       id="path3817" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,50.000002 h 1 v 1 h -1"
+       id="path3815" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,50.000002 h 1 v 1 h -1"
+       id="path3813" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,50.000002 h 1 v 1 h -1"
+       id="path3811" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,50.000002 h 1 v 1 h -1"
+       id="path3809" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,50.000002 h 1 v 1 h -1"
+       id="path3807" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 38,50.000002 h 1 v 1 h -1"
+       id="path3805" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.203922"
+       d="m 37,50.000002 h 1 v 1 h -1"
+       id="path3803" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,50.000002 h 1 v 1 h -1"
+       id="path3801" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,50.000002 h 1 v 1 h -1"
+       id="path3799" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,50.000002 h 1 v 1 h -1"
+       id="path3797" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,50.000002 h 1 v 1 h -1"
+       id="path3795" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,50.000002 h 1 v 1 h -1"
+       id="path3793" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,49.000002 h 1 v 1 h -1"
+       id="path3791" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,49.000002 h 1 v 1 h -1"
+       id="path3789" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,49.000002 h 1 v 1 h -1"
+       id="path3787" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,49.000002 h 1 v 1 h -1"
+       id="path3785" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,49.000002 h 1 v 1 h -1"
+       id="path3783" />
+    <path
+       style="fill:#232020;fill-opacity:0.792157"
+       d="m 90,49.000002 h 1 v 1 h -1"
+       id="path3781" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 89,49.000002 h 1 v 1 h -1"
+       id="path3779" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 88,49.000002 h 1 v 1 h -1"
+       id="path3777" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,49.000002 h 1 v 1 h -1"
+       id="path3775" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,49.000002 h 1 v 1 h -1"
+       id="path3773" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,49.000002 h 1 v 1 h -1"
+       id="path3771" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,49.000002 h 1 v 1 h -1"
+       id="path3769" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,49.000002 h 1 v 1 h -1"
+       id="path3767" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.764706"
+       d="m 82,49.000002 h 1 v 1 h -1"
+       id="path3765" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,49.000002 h 1 v 1 h -1"
+       id="path3763" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,49.000002 h 1 v 1 h -1"
+       id="path3761" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,49.000002 h 1 v 1 h -1"
+       id="path3759" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,49.000002 h 1 v 1 h -1"
+       id="path3757" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 77,49.000002 h 1 v 1 h -1"
+       id="path3755" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,49.000002 h 1 v 1 h -1"
+       id="path3753" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,49.000002 h 1 v 1 h -1"
+       id="path3751" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,49.000002 h 1 v 1 h -1"
+       id="path3749" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,49.000002 h 1 v 1 h -1"
+       id="path3747" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,49.000002 h 1 v 1 h -1"
+       id="path3745" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,49.000002 h 1 v 1 h -1"
+       id="path3743" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,49.000002 h 1 v 1 h -1"
+       id="path3741" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,49.000002 h 1 v 1 h -1"
+       id="path3739" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,49.000002 h 1 v 1 h -1"
+       id="path3737" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,49.000002 h 1 v 1 h -1"
+       id="path3735" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,49.000002 h 1 v 1 h -1"
+       id="path3733" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,49.000002 h 1 v 1 h -1"
+       id="path3731" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,49.000002 h 1 v 1 h -1"
+       id="path3729" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,49.000002 h 1 v 1 h -1"
+       id="path3727" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,49.000002 h 1 v 1 h -1"
+       id="path3725" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,49.000002 h 1 v 1 h -1"
+       id="path3723" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,49.000002 h 1 v 1 h -1"
+       id="path3721" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,49.000002 h 1 v 1 h -1"
+       id="path3719" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,49.000002 h 1 v 1 h -1"
+       id="path3717" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,49.000002 h 1 v 1 h -1"
+       id="path3715" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,49.000002 h 1 v 1 h -1"
+       id="path3713" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,49.000002 h 1 v 1 h -1"
+       id="path3711" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,49.000002 h 1 v 1 h -1"
+       id="path3709" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,49.000002 h 1 v 1 h -1"
+       id="path3707" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,49.000002 h 1 v 1 h -1"
+       id="path3705" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,49.000002 h 1 v 1 h -1"
+       id="path3703" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,49.000002 h 1 v 1 h -1"
+       id="path3701" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,49.000002 h 1 v 1 h -1"
+       id="path3699" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,49.000002 h 1 v 1 h -1"
+       id="path3697" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,49.000002 h 1 v 1 h -1"
+       id="path3695" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,49.000002 h 1 v 1 h -1"
+       id="path3693" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,49.000002 h 1 v 1 h -1"
+       id="path3691" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,49.000002 h 1 v 1 h -1"
+       id="path3689" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,49.000002 h 1 v 1 h -1"
+       id="path3687" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,49.000002 h 1 v 1 h -1"
+       id="path3685" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,49.000002 h 1 v 1 h -1"
+       id="path3683" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,49.000002 h 1 v 1 h -1"
+       id="path3681" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,49.000002 h 1 v 1 h -1"
+       id="path3679" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,49.000002 h 1 v 1 h -1"
+       id="path3677" />
+    <path
+       style="fill:#232020;fill-opacity:0.792157"
+       d="m 37,49.000002 h 1 v 1 h -1"
+       id="path3675" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,49.000002 h 1 v 1 h -1"
+       id="path3673" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,49.000002 h 1 v 1 h -1"
+       id="path3671" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,49.000002 h 1 v 1 h -1"
+       id="path3669" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,49.000002 h 1 v 1 h -1"
+       id="path3667" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,49.000002 h 1 v 1 h -1"
+       id="path3665" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,48.000002 h 1 v 1 h -1"
+       id="path3663" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,48.000002 h 1 v 1 h -1"
+       id="path3661" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,48.000002 h 1 v 1 h -1"
+       id="path3659" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,48.000002 h 1 v 1 h -1"
+       id="path3657" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,48.000002 h 1 v 1 h -1"
+       id="path3655" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 90,48.000002 h 1 v 1 h -1"
+       id="path3653" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 89,48.000002 h 1 v 1 h -1"
+       id="path3651" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.909804"
+       d="m 88,48.000002 h 1 v 1 h -1"
+       id="path3649" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,48.000002 h 1 v 1 h -1"
+       id="path3647" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,48.000002 h 1 v 1 h -1"
+       id="path3645" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,48.000002 h 1 v 1 h -1"
+       id="path3643" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,48.000002 h 1 v 1 h -1"
+       id="path3641" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,48.000002 h 1 v 1 h -1"
+       id="path3639" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 82,48.000002 h 1 v 1 h -1"
+       id="path3637" />
+    <path
+       style="fill:#231d1d;fill-opacity:0.172549"
+       d="m 81,48.000002 h 1 v 1 h -1"
+       id="path3635" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,48.000002 h 1 v 1 h -1"
+       id="path3633" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,48.000002 h 1 v 1 h -1"
+       id="path3631" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,48.000002 h 1 v 1 h -1"
+       id="path3629" />
+    <path
+       style="fill:#202020;fill-opacity:0.0627451"
+       d="m 77,48.000002 h 1 v 1 h -1"
+       id="path3627" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 76,48.000002 h 1 v 1 h -1"
+       id="path3625" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,48.000002 h 1 v 1 h -1"
+       id="path3623" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,48.000002 h 1 v 1 h -1"
+       id="path3621" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,48.000002 h 1 v 1 h -1"
+       id="path3619" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,48.000002 h 1 v 1 h -1"
+       id="path3617" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,48.000002 h 1 v 1 h -1"
+       id="path3615" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,48.000002 h 1 v 1 h -1"
+       id="path3613" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,48.000002 h 1 v 1 h -1"
+       id="path3611" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,48.000002 h 1 v 1 h -1"
+       id="path3609" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,48.000002 h 1 v 1 h -1"
+       id="path3607" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,48.000002 h 1 v 1 h -1"
+       id="path3605" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,48.000002 h 1 v 1 h -1"
+       id="path3603" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,48.000002 h 1 v 1 h -1"
+       id="path3601" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,48.000002 h 1 v 1 h -1"
+       id="path3599" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,48.000002 h 1 v 1 h -1"
+       id="path3597" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,48.000002 h 1 v 1 h -1"
+       id="path3595" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,48.000002 h 1 v 1 h -1"
+       id="path3593" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,48.000002 h 1 v 1 h -1"
+       id="path3591" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,48.000002 h 1 v 1 h -1"
+       id="path3589" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,48.000002 h 1 v 1 h -1"
+       id="path3587" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,48.000002 h 1 v 1 h -1"
+       id="path3585" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,48.000002 h 1 v 1 h -1"
+       id="path3583" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,48.000002 h 1 v 1 h -1"
+       id="path3581" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,48.000002 h 1 v 1 h -1"
+       id="path3579" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,48.000002 h 1 v 1 h -1"
+       id="path3577" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,48.000002 h 1 v 1 h -1"
+       id="path3575" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,48.000002 h 1 v 1 h -1"
+       id="path3573" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,48.000002 h 1 v 1 h -1"
+       id="path3571" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,48.000002 h 1 v 1 h -1"
+       id="path3569" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,48.000002 h 1 v 1 h -1"
+       id="path3567" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,48.000002 h 1 v 1 h -1"
+       id="path3565" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,48.000002 h 1 v 1 h -1"
+       id="path3563" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,48.000002 h 1 v 1 h -1"
+       id="path3561" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,48.000002 h 1 v 1 h -1"
+       id="path3559" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,48.000002 h 1 v 1 h -1"
+       id="path3557" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,48.000002 h 1 v 1 h -1"
+       id="path3555" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,48.000002 h 1 v 1 h -1"
+       id="path3553" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.909804"
+       d="m 39,48.000002 h 1 v 1 h -1"
+       id="path3551" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.74902"
+       d="m 38,48.000002 h 1 v 1 h -1"
+       id="path3549" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 37,48.000002 h 1 v 1 h -1"
+       id="path3547" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,48.000002 h 1 v 1 h -1"
+       id="path3545" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,48.000002 h 1 v 1 h -1"
+       id="path3543" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,48.000002 h 1 v 1 h -1"
+       id="path3541" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,48.000002 h 1 v 1 h -1"
+       id="path3539" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,48.000002 h 1 v 1 h -1"
+       id="path3537" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,47.000002 h 1 v 1 h -1"
+       id="path3535" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,47.000002 h 1 v 1 h -1"
+       id="path3533" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,47.000002 h 1 v 1 h -1"
+       id="path3531" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,47.000002 h 1 v 1 h -1"
+       id="path3529" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,47.000002 h 1 v 1 h -1"
+       id="path3527" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,47.000002 h 1 v 1 h -1"
+       id="path3525" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,47.000002 h 1 v 1 h -1"
+       id="path3523" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,47.000002 h 1 v 1 h -1"
+       id="path3521" />
+    <path
+       style="fill:#242020;fill-opacity:0.219608"
+       d="m 87,47.000002 h 1 v 1 h -1"
+       id="path3519" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,47.000002 h 1 v 1 h -1"
+       id="path3517" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,47.000002 h 1 v 1 h -1"
+       id="path3515" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,47.000002 h 1 v 1 h -1"
+       id="path3513" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,47.000002 h 1 v 1 h -1"
+       id="path3511" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,47.000002 h 1 v 1 h -1"
+       id="path3509" />
+    <path
+       style="fill:#232020;fill-opacity:0.792157"
+       d="m 81,47.000002 h 1 v 1 h -1"
+       id="path3507" />
+    <path
+       style="fill:#2b2b2b;fill-opacity:0.0235294"
+       d="m 80,47.000002 h 1 v 1 h -1"
+       id="path3505" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,47.000002 h 1 v 1 h -1"
+       id="path3503" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,47.000002 h 1 v 1 h -1"
+       id="path3501" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,47.000002 h 1 v 1 h -1"
+       id="path3499" />
+    <path
+       style="fill:#1e1e1e;fill-opacity:0.0666667"
+       d="m 76,47.000002 h 1 v 1 h -1"
+       id="path3497" />
+    <path
+       style="fill:#232020;fill-opacity:0.694118"
+       d="m 75,47.000002 h 1 v 1 h -1"
+       id="path3495" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,47.000002 h 1 v 1 h -1"
+       id="path3493" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,47.000002 h 1 v 1 h -1"
+       id="path3491" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,47.000002 h 1 v 1 h -1"
+       id="path3489" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,47.000002 h 1 v 1 h -1"
+       id="path3487" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,47.000002 h 1 v 1 h -1"
+       id="path3485" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,47.000002 h 1 v 1 h -1"
+       id="path3483" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,47.000002 h 1 v 1 h -1"
+       id="path3481" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,47.000002 h 1 v 1 h -1"
+       id="path3479" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,47.000002 h 1 v 1 h -1"
+       id="path3477" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,47.000002 h 1 v 1 h -1"
+       id="path3475" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,47.000002 h 1 v 1 h -1"
+       id="path3473" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,47.000002 h 1 v 1 h -1"
+       id="path3471" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,47.000002 h 1 v 1 h -1"
+       id="path3469" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,47.000002 h 1 v 1 h -1"
+       id="path3467" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,47.000002 h 1 v 1 h -1"
+       id="path3465" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,47.000002 h 1 v 1 h -1"
+       id="path3463" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,47.000002 h 1 v 1 h -1"
+       id="path3461" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,47.000002 h 1 v 1 h -1"
+       id="path3459" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,47.000002 h 1 v 1 h -1"
+       id="path3457" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,47.000002 h 1 v 1 h -1"
+       id="path3455" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,47.000002 h 1 v 1 h -1"
+       id="path3453" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,47.000002 h 1 v 1 h -1"
+       id="path3451" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,47.000002 h 1 v 1 h -1"
+       id="path3449" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,47.000002 h 1 v 1 h -1"
+       id="path3447" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,47.000002 h 1 v 1 h -1"
+       id="path3445" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,47.000002 h 1 v 1 h -1"
+       id="path3443" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,47.000002 h 1 v 1 h -1"
+       id="path3441" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,47.000002 h 1 v 1 h -1"
+       id="path3439" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,47.000002 h 1 v 1 h -1"
+       id="path3437" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,47.000002 h 1 v 1 h -1"
+       id="path3435" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,47.000002 h 1 v 1 h -1"
+       id="path3433" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,47.000002 h 1 v 1 h -1"
+       id="path3431" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,47.000002 h 1 v 1 h -1"
+       id="path3429" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,47.000002 h 1 v 1 h -1"
+       id="path3427" />
+    <path
+       style="fill:#242020;fill-opacity:0.219608"
+       d="m 40,47.000002 h 1 v 1 h -1"
+       id="path3425" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,47.000002 h 1 v 1 h -1"
+       id="path3423" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,47.000002 h 1 v 1 h -1"
+       id="path3421" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,47.000002 h 1 v 1 h -1"
+       id="path3419" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,47.000002 h 1 v 1 h -1"
+       id="path3417" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,47.000002 h 1 v 1 h -1"
+       id="path3415" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,47.000002 h 1 v 1 h -1"
+       id="path3413" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,47.000002 h 1 v 1 h -1"
+       id="path3411" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,47.000002 h 1 v 1 h -1"
+       id="path3409" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,46.000002 h 1 v 1 h -1"
+       id="path3407" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,46.000002 h 1 v 1 h -1"
+       id="path3405" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,46.000002 h 1 v 1 h -1"
+       id="path3403" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,46.000002 h 1 v 1 h -1"
+       id="path3401" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,46.000002 h 1 v 1 h -1"
+       id="path3399" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,46.000002 h 1 v 1 h -1"
+       id="path3397" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,46.000002 h 1 v 1 h -1"
+       id="path3395" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,46.000002 h 1 v 1 h -1"
+       id="path3393" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 87,46.000002 h 1 v 1 h -1"
+       id="path3391" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,46.000002 h 1 v 1 h -1"
+       id="path3389" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,46.000002 h 1 v 1 h -1"
+       id="path3387" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,46.000002 h 1 v 1 h -1"
+       id="path3385" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,46.000002 h 1 v 1 h -1"
+       id="path3383" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,46.000002 h 1 v 1 h -1"
+       id="path3381" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,46.000002 h 1 v 1 h -1"
+       id="path3379" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.592157"
+       d="m 80,46.000002 h 1 v 1 h -1"
+       id="path3377" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,46.000002 h 1 v 1 h -1"
+       id="path3375" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,46.000002 h 1 v 1 h -1"
+       id="path3373" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,46.000002 h 1 v 1 h -1"
+       id="path3371" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,46.000002 h 1 v 1 h -1"
+       id="path3369" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,46.000002 h 1 v 1 h -1"
+       id="path3367" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.286275"
+       d="m 74,46.000002 h 1 v 1 h -1"
+       id="path3365" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.745098"
+       d="m 73,46.000002 h 1 v 1 h -1"
+       id="path3363" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 72,46.000002 h 1 v 1 h -1"
+       id="path3361" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,46.000002 h 1 v 1 h -1"
+       id="path3359" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,46.000002 h 1 v 1 h -1"
+       id="path3357" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,46.000002 h 1 v 1 h -1"
+       id="path3355" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,46.000002 h 1 v 1 h -1"
+       id="path3353" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,46.000002 h 1 v 1 h -1"
+       id="path3351" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,46.000002 h 1 v 1 h -1"
+       id="path3349" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,46.000002 h 1 v 1 h -1"
+       id="path3347" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,46.000002 h 1 v 1 h -1"
+       id="path3345" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,46.000002 h 1 v 1 h -1"
+       id="path3343" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,46.000002 h 1 v 1 h -1"
+       id="path3341" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,46.000002 h 1 v 1 h -1"
+       id="path3339" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,46.000002 h 1 v 1 h -1"
+       id="path3337" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,46.000002 h 1 v 1 h -1"
+       id="path3335" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,46.000002 h 1 v 1 h -1"
+       id="path3333" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,46.000002 h 1 v 1 h -1"
+       id="path3331" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,46.000002 h 1 v 1 h -1"
+       id="path3329" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,46.000002 h 1 v 1 h -1"
+       id="path3327" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,46.000002 h 1 v 1 h -1"
+       id="path3325" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,46.000002 h 1 v 1 h -1"
+       id="path3323" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,46.000002 h 1 v 1 h -1"
+       id="path3321" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,46.000002 h 1 v 1 h -1"
+       id="path3319" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,46.000002 h 1 v 1 h -1"
+       id="path3317" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,46.000002 h 1 v 1 h -1"
+       id="path3315" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,46.000002 h 1 v 1 h -1"
+       id="path3313" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,46.000002 h 1 v 1 h -1"
+       id="path3311" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,46.000002 h 1 v 1 h -1"
+       id="path3309" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,46.000002 h 1 v 1 h -1"
+       id="path3307" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,46.000002 h 1 v 1 h -1"
+       id="path3305" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,46.000002 h 1 v 1 h -1"
+       id="path3303" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,46.000002 h 1 v 1 h -1"
+       id="path3301" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,46.000002 h 1 v 1 h -1"
+       id="path3299" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 40,46.000002 h 1 v 1 h -1"
+       id="path3297" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,46.000002 h 1 v 1 h -1"
+       id="path3295" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,46.000002 h 1 v 1 h -1"
+       id="path3293" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,46.000002 h 1 v 1 h -1"
+       id="path3291" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,46.000002 h 1 v 1 h -1"
+       id="path3289" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,46.000002 h 1 v 1 h -1"
+       id="path3287" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,46.000002 h 1 v 1 h -1"
+       id="path3285" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,46.000002 h 1 v 1 h -1"
+       id="path3283" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,46.000002 h 1 v 1 h -1"
+       id="path3281" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,45.000002 h 1 v 1 h -1"
+       id="path3279" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,45.000002 h 1 v 1 h -1"
+       id="path3277" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,45.000002 h 1 v 1 h -1"
+       id="path3275" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,45.000002 h 1 v 1 h -1"
+       id="path3273" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,45.000002 h 1 v 1 h -1"
+       id="path3271" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,45.000002 h 1 v 1 h -1"
+       id="path3269" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,45.000002 h 1 v 1 h -1"
+       id="path3267" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 88,45.000002 h 1 v 1 h -1"
+       id="path3265" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 87,45.000002 h 1 v 1 h -1"
+       id="path3263" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,45.000002 h 1 v 1 h -1"
+       id="path3261" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,45.000002 h 1 v 1 h -1"
+       id="path3259" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,45.000002 h 1 v 1 h -1"
+       id="path3257" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,45.000002 h 1 v 1 h -1"
+       id="path3255" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,45.000002 h 1 v 1 h -1"
+       id="path3253" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,45.000002 h 1 v 1 h -1"
+       id="path3251" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,45.000002 h 1 v 1 h -1"
+       id="path3249" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.427451"
+       d="m 79,45.000002 h 1 v 1 h -1"
+       id="path3247" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,45.000002 h 1 v 1 h -1"
+       id="path3245" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,45.000002 h 1 v 1 h -1"
+       id="path3243" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,45.000002 h 1 v 1 h -1"
+       id="path3241" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,45.000002 h 1 v 1 h -1"
+       id="path3239" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,45.000002 h 1 v 1 h -1"
+       id="path3237" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,45.000002 h 1 v 1 h -1"
+       id="path3235" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,45.000002 h 1 v 1 h -1"
+       id="path3233" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,45.000002 h 1 v 1 h -1"
+       id="path3231" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,45.000002 h 1 v 1 h -1"
+       id="path3229" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,45.000002 h 1 v 1 h -1"
+       id="path3227" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,45.000002 h 1 v 1 h -1"
+       id="path3225" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,45.000002 h 1 v 1 h -1"
+       id="path3223" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,45.000002 h 1 v 1 h -1"
+       id="path3221" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,45.000002 h 1 v 1 h -1"
+       id="path3219" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,45.000002 h 1 v 1 h -1"
+       id="path3217" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,45.000002 h 1 v 1 h -1"
+       id="path3215" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,45.000002 h 1 v 1 h -1"
+       id="path3213" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,45.000002 h 1 v 1 h -1"
+       id="path3211" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,45.000002 h 1 v 1 h -1"
+       id="path3209" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,45.000002 h 1 v 1 h -1"
+       id="path3207" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,45.000002 h 1 v 1 h -1"
+       id="path3205" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,45.000002 h 1 v 1 h -1"
+       id="path3203" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,45.000002 h 1 v 1 h -1"
+       id="path3201" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,45.000002 h 1 v 1 h -1"
+       id="path3199" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,45.000002 h 1 v 1 h -1"
+       id="path3197" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,45.000002 h 1 v 1 h -1"
+       id="path3195" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,45.000002 h 1 v 1 h -1"
+       id="path3193" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,45.000002 h 1 v 1 h -1"
+       id="path3191" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,45.000002 h 1 v 1 h -1"
+       id="path3189" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,45.000002 h 1 v 1 h -1"
+       id="path3187" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.74902"
+       d="m 48,45.000002 h 1 v 1 h -1"
+       id="path3185" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,45.000002 h 1 v 1 h -1"
+       id="path3183" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,45.000002 h 1 v 1 h -1"
+       id="path3181" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,45.000002 h 1 v 1 h -1"
+       id="path3179" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,45.000002 h 1 v 1 h -1"
+       id="path3177" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,45.000002 h 1 v 1 h -1"
+       id="path3175" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,45.000002 h 1 v 1 h -1"
+       id="path3173" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,45.000002 h 1 v 1 h -1"
+       id="path3171" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 40,45.000002 h 1 v 1 h -1"
+       id="path3169" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 39,45.000002 h 1 v 1 h -1"
+       id="path3167" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,45.000002 h 1 v 1 h -1"
+       id="path3165" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,45.000002 h 1 v 1 h -1"
+       id="path3163" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,45.000002 h 1 v 1 h -1"
+       id="path3161" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,45.000002 h 1 v 1 h -1"
+       id="path3159" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,45.000002 h 1 v 1 h -1"
+       id="path3157" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,45.000002 h 1 v 1 h -1"
+       id="path3155" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,45.000002 h 1 v 1 h -1"
+       id="path3153" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,44.000002 h 1 v 1 h -1"
+       id="path3151" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,44.000002 h 1 v 1 h -1"
+       id="path3149" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,44.000002 h 1 v 1 h -1"
+       id="path3147" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,44.000002 h 1 v 1 h -1"
+       id="path3145" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,44.000002 h 1 v 1 h -1"
+       id="path3143" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,44.000002 h 1 v 1 h -1"
+       id="path3141" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,44.000002 h 1 v 1 h -1"
+       id="path3139" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.223529"
+       d="m 88,44.000002 h 1 v 1 h -1"
+       id="path3137" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 87,44.000002 h 1 v 1 h -1"
+       id="path3135" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 86,44.000002 h 1 v 1 h -1"
+       id="path3133" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 85,44.000002 h 1 v 1 h -1"
+       id="path3131" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 84,44.000002 h 1 v 1 h -1"
+       id="path3129" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,44.000002 h 1 v 1 h -1"
+       id="path3127" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,44.000002 h 1 v 1 h -1"
+       id="path3125" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,44.000002 h 1 v 1 h -1"
+       id="path3123" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,44.000002 h 1 v 1 h -1"
+       id="path3121" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,44.000002 h 1 v 1 h -1"
+       id="path3119" />
+    <path
+       style="fill:#222020;fill-opacity:0.411765"
+       d="m 78,44.000002 h 1 v 1 h -1"
+       id="path3117" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,44.000002 h 1 v 1 h -1"
+       id="path3115" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,44.000002 h 1 v 1 h -1"
+       id="path3113" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,44.000002 h 1 v 1 h -1"
+       id="path3111" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,44.000002 h 1 v 1 h -1"
+       id="path3109" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,44.000002 h 1 v 1 h -1"
+       id="path3107" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,44.000002 h 1 v 1 h -1"
+       id="path3105" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,44.000002 h 1 v 1 h -1"
+       id="path3103" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,44.000002 h 1 v 1 h -1"
+       id="path3101" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,44.000002 h 1 v 1 h -1"
+       id="path3099" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,44.000002 h 1 v 1 h -1"
+       id="path3097" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,44.000002 h 1 v 1 h -1"
+       id="path3095" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,44.000002 h 1 v 1 h -1"
+       id="path3093" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,44.000002 h 1 v 1 h -1"
+       id="path3091" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,44.000002 h 1 v 1 h -1"
+       id="path3089" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,44.000002 h 1 v 1 h -1"
+       id="path3087" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,44.000002 h 1 v 1 h -1"
+       id="path3085" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,44.000002 h 1 v 1 h -1"
+       id="path3083" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,44.000002 h 1 v 1 h -1"
+       id="path3081" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,44.000002 h 1 v 1 h -1"
+       id="path3079" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,44.000002 h 1 v 1 h -1"
+       id="path3077" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,44.000002 h 1 v 1 h -1"
+       id="path3075" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,44.000002 h 1 v 1 h -1"
+       id="path3073" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,44.000002 h 1 v 1 h -1"
+       id="path3071" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,44.000002 h 1 v 1 h -1"
+       id="path3069" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,44.000002 h 1 v 1 h -1"
+       id="path3067" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,44.000002 h 1 v 1 h -1"
+       id="path3065" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,44.000002 h 1 v 1 h -1"
+       id="path3063" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,44.000002 h 1 v 1 h -1"
+       id="path3061" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.423529"
+       d="m 49,44.000002 h 1 v 1 h -1"
+       id="path3059" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,44.000002 h 1 v 1 h -1"
+       id="path3057" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,44.000002 h 1 v 1 h -1"
+       id="path3055" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,44.000002 h 1 v 1 h -1"
+       id="path3053" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,44.000002 h 1 v 1 h -1"
+       id="path3051" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,44.000002 h 1 v 1 h -1"
+       id="path3049" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,44.000002 h 1 v 1 h -1"
+       id="path3047" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,44.000002 h 1 v 1 h -1"
+       id="path3045" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,44.000002 h 1 v 1 h -1"
+       id="path3043" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,44.000002 h 1 v 1 h -1"
+       id="path3041" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.223529"
+       d="m 39,44.000002 h 1 v 1 h -1"
+       id="path3039" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,44.000002 h 1 v 1 h -1"
+       id="path3037" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,44.000002 h 1 v 1 h -1"
+       id="path3035" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,44.000002 h 1 v 1 h -1"
+       id="path3033" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,44.000002 h 1 v 1 h -1"
+       id="path3031" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,44.000002 h 1 v 1 h -1"
+       id="path3029" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,44.000002 h 1 v 1 h -1"
+       id="path3027" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,44.000002 h 1 v 1 h -1"
+       id="path3025" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,43.000002 h 1 v 1 h -1"
+       id="path3023" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,43.000002 h 1 v 1 h -1"
+       id="path3021" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,43.000002 h 1 v 1 h -1"
+       id="path3019" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,43.000002 h 1 v 1 h -1"
+       id="path3017" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,43.000002 h 1 v 1 h -1"
+       id="path3015" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,43.000002 h 1 v 1 h -1"
+       id="path3013" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,43.000002 h 1 v 1 h -1"
+       id="path3011" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0352941"
+       d="m 88,43.000002 h 1 v 1 h -1"
+       id="path3009" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 87,43.000002 h 1 v 1 h -1"
+       id="path3007" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.498039"
+       d="m 86,43.000002 h 1 v 1 h -1"
+       id="path3005" />
+    <path
+       style="fill:#222020;fill-opacity:0.439216"
+       d="m 85,43.000002 h 1 v 1 h -1"
+       id="path3003" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.611765"
+       d="m 84,43.000002 h 1 v 1 h -1"
+       id="path3001" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,43.000002 h 1 v 1 h -1"
+       id="path2999" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,43.000002 h 1 v 1 h -1"
+       id="path2997" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,43.000002 h 1 v 1 h -1"
+       id="path2995" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,43.000002 h 1 v 1 h -1"
+       id="path2993" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,43.000002 h 1 v 1 h -1"
+       id="path2991" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,43.000002 h 1 v 1 h -1"
+       id="path2989" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.552941"
+       d="m 77,43.000002 h 1 v 1 h -1"
+       id="path2987" />
+    <path
+       style="fill:#000000;fill-opacity:0.0117647"
+       d="m 76,43.000002 h 1 v 1 h -1"
+       id="path2985" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,43.000002 h 1 v 1 h -1"
+       id="path2983" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,43.000002 h 1 v 1 h -1"
+       id="path2981" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,43.000002 h 1 v 1 h -1"
+       id="path2979" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,43.000002 h 1 v 1 h -1"
+       id="path2977" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,43.000002 h 1 v 1 h -1"
+       id="path2975" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,43.000002 h 1 v 1 h -1"
+       id="path2973" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,43.000002 h 1 v 1 h -1"
+       id="path2971" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,43.000002 h 1 v 1 h -1"
+       id="path2969" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,43.000002 h 1 v 1 h -1"
+       id="path2967" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,43.000002 h 1 v 1 h -1"
+       id="path2965" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,43.000002 h 1 v 1 h -1"
+       id="path2963" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,43.000002 h 1 v 1 h -1"
+       id="path2961" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,43.000002 h 1 v 1 h -1"
+       id="path2959" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,43.000002 h 1 v 1 h -1"
+       id="path2957" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,43.000002 h 1 v 1 h -1"
+       id="path2955" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,43.000002 h 1 v 1 h -1"
+       id="path2953" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,43.000002 h 1 v 1 h -1"
+       id="path2951" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,43.000002 h 1 v 1 h -1"
+       id="path2949" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,43.000002 h 1 v 1 h -1"
+       id="path2947" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,43.000002 h 1 v 1 h -1"
+       id="path2945" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,43.000002 h 1 v 1 h -1"
+       id="path2943" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,43.000002 h 1 v 1 h -1"
+       id="path2941" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,43.000002 h 1 v 1 h -1"
+       id="path2939" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,43.000002 h 1 v 1 h -1"
+       id="path2937" />
+    <path
+       style="fill:#000000;fill-opacity:0.0117647"
+       d="m 51,43.000002 h 1 v 1 h -1"
+       id="path2935" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 50,43.000002 h 1 v 1 h -1"
+       id="path2933" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,43.000002 h 1 v 1 h -1"
+       id="path2931" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,43.000002 h 1 v 1 h -1"
+       id="path2929" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,43.000002 h 1 v 1 h -1"
+       id="path2927" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,43.000002 h 1 v 1 h -1"
+       id="path2925" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,43.000002 h 1 v 1 h -1"
+       id="path2923" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,43.000002 h 1 v 1 h -1"
+       id="path2921" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.611765"
+       d="m 43,43.000002 h 1 v 1 h -1"
+       id="path2919" />
+    <path
+       style="fill:#222020;fill-opacity:0.439216"
+       d="m 42,43.000002 h 1 v 1 h -1"
+       id="path2917" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.498039"
+       d="m 41,43.000002 h 1 v 1 h -1"
+       id="path2915" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 40,43.000002 h 1 v 1 h -1"
+       id="path2913" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0352941"
+       d="m 39,43.000002 h 1 v 1 h -1"
+       id="path2911" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,43.000002 h 1 v 1 h -1"
+       id="path2909" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,43.000002 h 1 v 1 h -1"
+       id="path2907" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,43.000002 h 1 v 1 h -1"
+       id="path2905" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,43.000002 h 1 v 1 h -1"
+       id="path2903" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,43.000002 h 1 v 1 h -1"
+       id="path2901" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,43.000002 h 1 v 1 h -1"
+       id="path2899" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,43.000002 h 1 v 1 h -1"
+       id="path2897" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,42.000002 h 1 v 1 h -1"
+       id="path2895" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,42.000002 h 1 v 1 h -1"
+       id="path2893" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,42.000002 h 1 v 1 h -1"
+       id="path2891" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,42.000002 h 1 v 1 h -1"
+       id="path2889" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,42.000002 h 1 v 1 h -1"
+       id="path2887" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,42.000002 h 1 v 1 h -1"
+       id="path2885" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,42.000002 h 1 v 1 h -1"
+       id="path2883" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,42.000002 h 1 v 1 h -1"
+       id="path2881" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,42.000002 h 1 v 1 h -1"
+       id="path2879" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,42.000002 h 1 v 1 h -1"
+       id="path2877" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,42.000002 h 1 v 1 h -1"
+       id="path2875" />
+    <path
+       style="fill:#242020;fill-opacity:0.247059"
+       d="m 84,42.000002 h 1 v 1 h -1"
+       id="path2873" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,42.000002 h 1 v 1 h -1"
+       id="path2871" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,42.000002 h 1 v 1 h -1"
+       id="path2869" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,42.000002 h 1 v 1 h -1"
+       id="path2867" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,42.000002 h 1 v 1 h -1"
+       id="path2865" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,42.000002 h 1 v 1 h -1"
+       id="path2863" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,42.000002 h 1 v 1 h -1"
+       id="path2861" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,42.000002 h 1 v 1 h -1"
+       id="path2859" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.74902"
+       d="m 76,42.000002 h 1 v 1 h -1"
+       id="path2857" />
+    <path
+       style="fill:#202020;fill-opacity:0.12549"
+       d="m 75,42.000002 h 1 v 1 h -1"
+       id="path2855" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,42.000002 h 1 v 1 h -1"
+       id="path2853" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,42.000002 h 1 v 1 h -1"
+       id="path2851" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,42.000002 h 1 v 1 h -1"
+       id="path2849" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,42.000002 h 1 v 1 h -1"
+       id="path2847" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,42.000002 h 1 v 1 h -1"
+       id="path2845" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,42.000002 h 1 v 1 h -1"
+       id="path2843" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,42.000002 h 1 v 1 h -1"
+       id="path2841" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,42.000002 h 1 v 1 h -1"
+       id="path2839" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,42.000002 h 1 v 1 h -1"
+       id="path2837" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,42.000002 h 1 v 1 h -1"
+       id="path2835" />
+    <path
+       style="fill:#222222;fill-opacity:0.117647"
+       d="m 64,42.000002 h 1 v 1 h -1"
+       id="path2833" />
+    <path
+       style="fill:#252020;fill-opacity:0.188235"
+       d="m 63,42.000002 h 1 v 1 h -1"
+       id="path2831" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,42.000002 h 1 v 1 h -1"
+       id="path2829" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,42.000002 h 1 v 1 h -1"
+       id="path2827" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,42.000002 h 1 v 1 h -1"
+       id="path2825" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,42.000002 h 1 v 1 h -1"
+       id="path2823" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,42.000002 h 1 v 1 h -1"
+       id="path2821" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,42.000002 h 1 v 1 h -1"
+       id="path2819" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,42.000002 h 1 v 1 h -1"
+       id="path2817" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,42.000002 h 1 v 1 h -1"
+       id="path2815" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,42.000002 h 1 v 1 h -1"
+       id="path2813" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,42.000002 h 1 v 1 h -1"
+       id="path2811" />
+    <path
+       style="fill:#232323;fill-opacity:0.113725"
+       d="m 52,42.000002 h 1 v 1 h -1"
+       id="path2809" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 51,42.000002 h 1 v 1 h -1"
+       id="path2807" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,42.000002 h 1 v 1 h -1"
+       id="path2805" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,42.000002 h 1 v 1 h -1"
+       id="path2803" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,42.000002 h 1 v 1 h -1"
+       id="path2801" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,42.000002 h 1 v 1 h -1"
+       id="path2799" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,42.000002 h 1 v 1 h -1"
+       id="path2797" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,42.000002 h 1 v 1 h -1"
+       id="path2795" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,42.000002 h 1 v 1 h -1"
+       id="path2793" />
+    <path
+       style="fill:#242020;fill-opacity:0.247059"
+       d="m 43,42.000002 h 1 v 1 h -1"
+       id="path2791" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,42.000002 h 1 v 1 h -1"
+       id="path2789" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,42.000002 h 1 v 1 h -1"
+       id="path2787" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,42.000002 h 1 v 1 h -1"
+       id="path2785" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,42.000002 h 1 v 1 h -1"
+       id="path2783" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,42.000002 h 1 v 1 h -1"
+       id="path2781" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,42.000002 h 1 v 1 h -1"
+       id="path2779" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,42.000002 h 1 v 1 h -1"
+       id="path2777" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,42.000002 h 1 v 1 h -1"
+       id="path2775" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,42.000002 h 1 v 1 h -1"
+       id="path2773" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,42.000002 h 1 v 1 h -1"
+       id="path2771" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,42.000002 h 1 v 1 h -1"
+       id="path2769" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,41.000002 h 1 v 1 h -1"
+       id="path2767" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,41.000002 h 1 v 1 h -1"
+       id="path2765" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,41.000002 h 1 v 1 h -1"
+       id="path2763" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,41.000002 h 1 v 1 h -1"
+       id="path2761" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,41.000002 h 1 v 1 h -1"
+       id="path2759" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,41.000002 h 1 v 1 h -1"
+       id="path2757" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,41.000002 h 1 v 1 h -1"
+       id="path2755" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,41.000002 h 1 v 1 h -1"
+       id="path2753" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,41.000002 h 1 v 1 h -1"
+       id="path2751" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,41.000002 h 1 v 1 h -1"
+       id="path2749" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,41.000002 h 1 v 1 h -1"
+       id="path2747" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.482353"
+       d="m 84,41.000002 h 1 v 1 h -1"
+       id="path2745" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,41.000002 h 1 v 1 h -1"
+       id="path2743" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,41.000002 h 1 v 1 h -1"
+       id="path2741" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,41.000002 h 1 v 1 h -1"
+       id="path2739" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,41.000002 h 1 v 1 h -1"
+       id="path2737" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,41.000002 h 1 v 1 h -1"
+       id="path2735" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,41.000002 h 1 v 1 h -1"
+       id="path2733" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,41.000002 h 1 v 1 h -1"
+       id="path2731" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,41.000002 h 1 v 1 h -1"
+       id="path2729" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.960784"
+       d="m 75,41.000002 h 1 v 1 h -1"
+       id="path2727" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.458824"
+       d="m 74,41.000002 h 1 v 1 h -1"
+       id="path2725" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0352941"
+       d="m 73,41.000002 h 1 v 1 h -1"
+       id="path2723" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,41.000002 h 1 v 1 h -1"
+       id="path2721" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,41.000002 h 1 v 1 h -1"
+       id="path2719" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,41.000002 h 1 v 1 h -1"
+       id="path2717" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,41.000002 h 1 v 1 h -1"
+       id="path2715" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,41.000002 h 1 v 1 h -1"
+       id="path2713" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,41.000002 h 1 v 1 h -1"
+       id="path2711" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,41.000002 h 1 v 1 h -1"
+       id="path2709" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.352941"
+       d="m 65,41.000002 h 1 v 1 h -1"
+       id="path2707" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.976471"
+       d="m 64,41.000002 h 1 v 1 h -1"
+       id="path2705" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,41.000002 h 1 v 1 h -1"
+       id="path2703" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.584314"
+       d="m 62,41.000002 h 1 v 1 h -1"
+       id="path2701" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 61,41.000002 h 1 v 1 h -1"
+       id="path2699" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,41.000002 h 1 v 1 h -1"
+       id="path2697" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,41.000002 h 1 v 1 h -1"
+       id="path2695" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,41.000002 h 1 v 1 h -1"
+       id="path2693" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,41.000002 h 1 v 1 h -1"
+       id="path2691" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,41.000002 h 1 v 1 h -1"
+       id="path2689" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,41.000002 h 1 v 1 h -1"
+       id="path2687" />
+    <path
+       style="fill:#202020;fill-opacity:0.0313725"
+       d="m 54,41.000002 h 1 v 1 h -1"
+       id="path2685" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.454902"
+       d="m 53,41.000002 h 1 v 1 h -1"
+       id="path2683" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.952941"
+       d="m 52,41.000002 h 1 v 1 h -1"
+       id="path2681" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,41.000002 h 1 v 1 h -1"
+       id="path2679" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,41.000002 h 1 v 1 h -1"
+       id="path2677" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,41.000002 h 1 v 1 h -1"
+       id="path2675" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,41.000002 h 1 v 1 h -1"
+       id="path2673" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,41.000002 h 1 v 1 h -1"
+       id="path2671" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,41.000002 h 1 v 1 h -1"
+       id="path2669" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,41.000002 h 1 v 1 h -1"
+       id="path2667" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,41.000002 h 1 v 1 h -1"
+       id="path2665" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.482353"
+       d="m 43,41.000002 h 1 v 1 h -1"
+       id="path2663" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,41.000002 h 1 v 1 h -1"
+       id="path2661" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,41.000002 h 1 v 1 h -1"
+       id="path2659" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,41.000002 h 1 v 1 h -1"
+       id="path2657" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,41.000002 h 1 v 1 h -1"
+       id="path2655" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,41.000002 h 1 v 1 h -1"
+       id="path2653" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,41.000002 h 1 v 1 h -1"
+       id="path2651" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,41.000002 h 1 v 1 h -1"
+       id="path2649" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,41.000002 h 1 v 1 h -1"
+       id="path2647" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,41.000002 h 1 v 1 h -1"
+       id="path2645" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,41.000002 h 1 v 1 h -1"
+       id="path2643" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,41.000002 h 1 v 1 h -1"
+       id="path2641" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,40.000002 h 1 v 1 h -1"
+       id="path2639" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,40.000002 h 1 v 1 h -1"
+       id="path2637" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,40.000002 h 1 v 1 h -1"
+       id="path2635" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,40.000002 h 1 v 1 h -1"
+       id="path2633" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,40.000002 h 1 v 1 h -1"
+       id="path2631" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,40.000002 h 1 v 1 h -1"
+       id="path2629" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,40.000002 h 1 v 1 h -1"
+       id="path2627" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,40.000002 h 1 v 1 h -1"
+       id="path2625" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,40.000002 h 1 v 1 h -1"
+       id="path2623" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,40.000002 h 1 v 1 h -1"
+       id="path2621" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,40.000002 h 1 v 1 h -1"
+       id="path2619" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.705882"
+       d="m 84,40.000002 h 1 v 1 h -1"
+       id="path2617" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 83,40.000002 h 1 v 1 h -1"
+       id="path2615" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 82,40.000002 h 1 v 1 h -1"
+       id="path2613" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 81,40.000002 h 1 v 1 h -1"
+       id="path2611" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 80,40.000002 h 1 v 1 h -1"
+       id="path2609" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,40.000002 h 1 v 1 h -1"
+       id="path2607" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,40.000002 h 1 v 1 h -1"
+       id="path2605" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,40.000002 h 1 v 1 h -1"
+       id="path2603" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,40.000002 h 1 v 1 h -1"
+       id="path2601" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,40.000002 h 1 v 1 h -1"
+       id="path2599" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,40.000002 h 1 v 1 h -1"
+       id="path2597" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.905882"
+       d="m 73,40.000002 h 1 v 1 h -1"
+       id="path2595" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.447059"
+       d="m 72,40.000002 h 1 v 1 h -1"
+       id="path2593" />
+    <path
+       style="fill:#281b1b;fill-opacity:0.0745098"
+       d="m 71,40.000002 h 1 v 1 h -1"
+       id="path2591" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,40.000002 h 1 v 1 h -1"
+       id="path2589" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,40.000002 h 1 v 1 h -1"
+       id="path2587" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,40.000002 h 1 v 1 h -1"
+       id="path2585" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,40.000002 h 1 v 1 h -1"
+       id="path2583" />
+    <path
+       style="fill:#222020;fill-opacity:0.380392"
+       d="m 66,40.000002 h 1 v 1 h -1"
+       id="path2581" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.992157"
+       d="m 65,40.000002 h 1 v 1 h -1"
+       id="path2579" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,40.000002 h 1 v 1 h -1"
+       id="path2577" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,40.000002 h 1 v 1 h -1"
+       id="path2575" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,40.000002 h 1 v 1 h -1"
+       id="path2573" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 61,40.000002 h 1 v 1 h -1"
+       id="path2571" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,40.000002 h 1 v 1 h -1"
+       id="path2569" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,40.000002 h 1 v 1 h -1"
+       id="path2567" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,40.000002 h 1 v 1 h -1"
+       id="path2565" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,40.000002 h 1 v 1 h -1"
+       id="path2563" />
+    <path
+       style="fill:#1e1e1e;fill-opacity:0.0666667"
+       d="m 56,40.000002 h 1 v 1 h -1"
+       id="path2561" />
+    <path
+       style="fill:#242020;fill-opacity:0.443137"
+       d="m 55,40.000002 h 1 v 1 h -1"
+       id="path2559" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.886275"
+       d="m 54,40.000002 h 1 v 1 h -1"
+       id="path2557" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,40.000002 h 1 v 1 h -1"
+       id="path2555" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,40.000002 h 1 v 1 h -1"
+       id="path2553" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,40.000002 h 1 v 1 h -1"
+       id="path2551" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,40.000002 h 1 v 1 h -1"
+       id="path2549" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,40.000002 h 1 v 1 h -1"
+       id="path2547" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,40.000002 h 1 v 1 h -1"
+       id="path2545" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 47,40.000002 h 1 v 1 h -1"
+       id="path2543" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 46,40.000002 h 1 v 1 h -1"
+       id="path2541" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,40.000002 h 1 v 1 h -1"
+       id="path2539" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,40.000002 h 1 v 1 h -1"
+       id="path2537" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.705882"
+       d="m 43,40.000002 h 1 v 1 h -1"
+       id="path2535" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,40.000002 h 1 v 1 h -1"
+       id="path2533" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,40.000002 h 1 v 1 h -1"
+       id="path2531" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,40.000002 h 1 v 1 h -1"
+       id="path2529" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,40.000002 h 1 v 1 h -1"
+       id="path2527" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,40.000002 h 1 v 1 h -1"
+       id="path2525" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,40.000002 h 1 v 1 h -1"
+       id="path2523" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,40.000002 h 1 v 1 h -1"
+       id="path2521" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,40.000002 h 1 v 1 h -1"
+       id="path2519" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,40.000002 h 1 v 1 h -1"
+       id="path2517" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,40.000002 h 1 v 1 h -1"
+       id="path2515" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,40.000002 h 1 v 1 h -1"
+       id="path2513" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,39.000002 h 1 v 1 h -1"
+       id="path2511" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,39.000002 h 1 v 1 h -1"
+       id="path2509" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,39.000002 h 1 v 1 h -1"
+       id="path2507" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,39.000002 h 1 v 1 h -1"
+       id="path2505" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,39.000002 h 1 v 1 h -1"
+       id="path2503" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,39.000002 h 1 v 1 h -1"
+       id="path2501" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,39.000002 h 1 v 1 h -1"
+       id="path2499" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,39.000002 h 1 v 1 h -1"
+       id="path2497" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,39.000002 h 1 v 1 h -1"
+       id="path2495" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,39.000002 h 1 v 1 h -1"
+       id="path2493" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,39.000002 h 1 v 1 h -1"
+       id="path2491" />
+    <path
+       style="fill:#242020;fill-opacity:0.443137"
+       d="m 84,39.000002 h 1 v 1 h -1"
+       id="path2489" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.705882"
+       d="m 83,39.000002 h 1 v 1 h -1"
+       id="path2487" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 82,39.000002 h 1 v 1 h -1"
+       id="path2485" />
+    <path
+       style="fill:#252121;fill-opacity:0.243137"
+       d="m 81,39.000002 h 1 v 1 h -1"
+       id="path2483" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.611765"
+       d="m 80,39.000002 h 1 v 1 h -1"
+       id="path2481" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,39.000002 h 1 v 1 h -1"
+       id="path2479" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,39.000002 h 1 v 1 h -1"
+       id="path2477" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,39.000002 h 1 v 1 h -1"
+       id="path2475" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,39.000002 h 1 v 1 h -1"
+       id="path2473" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,39.000002 h 1 v 1 h -1"
+       id="path2471" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,39.000002 h 1 v 1 h -1"
+       id="path2469" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,39.000002 h 1 v 1 h -1"
+       id="path2467" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,39.000002 h 1 v 1 h -1"
+       id="path2465" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.976471"
+       d="m 71,39.000002 h 1 v 1 h -1"
+       id="path2463" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.686275"
+       d="m 70,39.000002 h 1 v 1 h -1"
+       id="path2461" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.396078"
+       d="m 69,39.000002 h 1 v 1 h -1"
+       id="path2459" />
+    <path
+       style="fill:#202020;fill-opacity:0.156863"
+       d="m 68,39.000002 h 1 v 1 h -1"
+       id="path2457" />
+    <path
+       style="fill:#222020;fill-opacity:0.411765"
+       d="m 67,39.000002 h 1 v 1 h -1"
+       id="path2455" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,39.000002 h 1 v 1 h -1"
+       id="path2453" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 65,39.000002 h 1 v 1 h -1"
+       id="path2451" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 64,39.000002 h 1 v 1 h -1"
+       id="path2449" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.560784"
+       d="m 63,39.000002 h 1 v 1 h -1"
+       id="path2447" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.968627"
+       d="m 62,39.000002 h 1 v 1 h -1"
+       id="path2445" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,39.000002 h 1 v 1 h -1"
+       id="path2443" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.490196"
+       d="m 60,39.000002 h 1 v 1 h -1"
+       id="path2441" />
+    <path
+       style="fill:#221c1c;fill-opacity:0.145098"
+       d="m 59,39.000002 h 1 v 1 h -1"
+       id="path2439" />
+    <path
+       style="fill:#222020;fill-opacity:0.380392"
+       d="m 58,39.000002 h 1 v 1 h -1"
+       id="path2437" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.686275"
+       d="m 57,39.000002 h 1 v 1 h -1"
+       id="path2435" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.968627"
+       d="m 56,39.000002 h 1 v 1 h -1"
+       id="path2433" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,39.000002 h 1 v 1 h -1"
+       id="path2431" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,39.000002 h 1 v 1 h -1"
+       id="path2429" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,39.000002 h 1 v 1 h -1"
+       id="path2427" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,39.000002 h 1 v 1 h -1"
+       id="path2425" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,39.000002 h 1 v 1 h -1"
+       id="path2423" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,39.000002 h 1 v 1 h -1"
+       id="path2421" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,39.000002 h 1 v 1 h -1"
+       id="path2419" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,39.000002 h 1 v 1 h -1"
+       id="path2417" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.611765"
+       d="m 47,39.000002 h 1 v 1 h -1"
+       id="path2415" />
+    <path
+       style="fill:#252121;fill-opacity:0.243137"
+       d="m 46,39.000002 h 1 v 1 h -1"
+       id="path2413" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 45,39.000002 h 1 v 1 h -1"
+       id="path2411" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.705882"
+       d="m 44,39.000002 h 1 v 1 h -1"
+       id="path2409" />
+    <path
+       style="fill:#242020;fill-opacity:0.443137"
+       d="m 43,39.000002 h 1 v 1 h -1"
+       id="path2407" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,39.000002 h 1 v 1 h -1"
+       id="path2405" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,39.000002 h 1 v 1 h -1"
+       id="path2403" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,39.000002 h 1 v 1 h -1"
+       id="path2401" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,39.000002 h 1 v 1 h -1"
+       id="path2399" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,39.000002 h 1 v 1 h -1"
+       id="path2397" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,39.000002 h 1 v 1 h -1"
+       id="path2395" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,39.000002 h 1 v 1 h -1"
+       id="path2393" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,39.000002 h 1 v 1 h -1"
+       id="path2391" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,39.000002 h 1 v 1 h -1"
+       id="path2389" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,39.000002 h 1 v 1 h -1"
+       id="path2387" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,39.000002 h 1 v 1 h -1"
+       id="path2385" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,38.000002 h 1 v 1 h -1"
+       id="path2383" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,38.000002 h 1 v 1 h -1"
+       id="path2381" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,38.000002 h 1 v 1 h -1"
+       id="path2379" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,38.000002 h 1 v 1 h -1"
+       id="path2377" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,38.000002 h 1 v 1 h -1"
+       id="path2375" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,38.000002 h 1 v 1 h -1"
+       id="path2373" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,38.000002 h 1 v 1 h -1"
+       id="path2371" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,38.000002 h 1 v 1 h -1"
+       id="path2369" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,38.000002 h 1 v 1 h -1"
+       id="path2367" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,38.000002 h 1 v 1 h -1"
+       id="path2365" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,38.000002 h 1 v 1 h -1"
+       id="path2363" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,38.000002 h 1 v 1 h -1"
+       id="path2361" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,38.000002 h 1 v 1 h -1"
+       id="path2359" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,38.000002 h 1 v 1 h -1"
+       id="path2357" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,38.000002 h 1 v 1 h -1"
+       id="path2355" />
+    <path
+       style="fill:#222020;fill-opacity:0.439216"
+       d="m 80,38.000002 h 1 v 1 h -1"
+       id="path2353" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,38.000002 h 1 v 1 h -1"
+       id="path2351" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,38.000002 h 1 v 1 h -1"
+       id="path2349" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,38.000002 h 1 v 1 h -1"
+       id="path2347" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,38.000002 h 1 v 1 h -1"
+       id="path2345" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,38.000002 h 1 v 1 h -1"
+       id="path2343" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,38.000002 h 1 v 1 h -1"
+       id="path2341" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,38.000002 h 1 v 1 h -1"
+       id="path2339" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,38.000002 h 1 v 1 h -1"
+       id="path2337" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,38.000002 h 1 v 1 h -1"
+       id="path2335" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,38.000002 h 1 v 1 h -1"
+       id="path2333" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,38.000002 h 1 v 1 h -1"
+       id="path2331" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,38.000002 h 1 v 1 h -1"
+       id="path2329" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,38.000002 h 1 v 1 h -1"
+       id="path2327" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,38.000002 h 1 v 1 h -1"
+       id="path2325" />
+    <path
+       style="fill:#232020;fill-opacity:0.6"
+       d="m 65,38.000002 h 1 v 1 h -1"
+       id="path2323" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,38.000002 h 1 v 1 h -1"
+       id="path2321" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,38.000002 h 1 v 1 h -1"
+       id="path2319" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 62,38.000002 h 1 v 1 h -1"
+       id="path2317" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,38.000002 h 1 v 1 h -1"
+       id="path2315" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,38.000002 h 1 v 1 h -1"
+       id="path2313" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,38.000002 h 1 v 1 h -1"
+       id="path2311" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,38.000002 h 1 v 1 h -1"
+       id="path2309" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,38.000002 h 1 v 1 h -1"
+       id="path2307" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,38.000002 h 1 v 1 h -1"
+       id="path2305" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,38.000002 h 1 v 1 h -1"
+       id="path2303" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,38.000002 h 1 v 1 h -1"
+       id="path2301" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,38.000002 h 1 v 1 h -1"
+       id="path2299" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,38.000002 h 1 v 1 h -1"
+       id="path2297" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,38.000002 h 1 v 1 h -1"
+       id="path2295" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,38.000002 h 1 v 1 h -1"
+       id="path2293" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,38.000002 h 1 v 1 h -1"
+       id="path2291" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,38.000002 h 1 v 1 h -1"
+       id="path2289" />
+    <path
+       style="fill:#222020;fill-opacity:0.439216"
+       d="m 47,38.000002 h 1 v 1 h -1"
+       id="path2287" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,38.000002 h 1 v 1 h -1"
+       id="path2285" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,38.000002 h 1 v 1 h -1"
+       id="path2283" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,38.000002 h 1 v 1 h -1"
+       id="path2281" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,38.000002 h 1 v 1 h -1"
+       id="path2279" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,38.000002 h 1 v 1 h -1"
+       id="path2277" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,38.000002 h 1 v 1 h -1"
+       id="path2275" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,38.000002 h 1 v 1 h -1"
+       id="path2273" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,38.000002 h 1 v 1 h -1"
+       id="path2271" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,38.000002 h 1 v 1 h -1"
+       id="path2269" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,38.000002 h 1 v 1 h -1"
+       id="path2267" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,38.000002 h 1 v 1 h -1"
+       id="path2265" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,38.000002 h 1 v 1 h -1"
+       id="path2263" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,38.000002 h 1 v 1 h -1"
+       id="path2261" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,38.000002 h 1 v 1 h -1"
+       id="path2259" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,38.000002 h 1 v 1 h -1"
+       id="path2257" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,37.000002 h 1 v 1 h -1"
+       id="path2255" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,37.000002 h 1 v 1 h -1"
+       id="path2253" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,37.000002 h 1 v 1 h -1"
+       id="path2251" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,37.000002 h 1 v 1 h -1"
+       id="path2249" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,37.000002 h 1 v 1 h -1"
+       id="path2247" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,37.000002 h 1 v 1 h -1"
+       id="path2245" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,37.000002 h 1 v 1 h -1"
+       id="path2243" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,37.000002 h 1 v 1 h -1"
+       id="path2241" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,37.000002 h 1 v 1 h -1"
+       id="path2239" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,37.000002 h 1 v 1 h -1"
+       id="path2237" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,37.000002 h 1 v 1 h -1"
+       id="path2235" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,37.000002 h 1 v 1 h -1"
+       id="path2233" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,37.000002 h 1 v 1 h -1"
+       id="path2231" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,37.000002 h 1 v 1 h -1"
+       id="path2229" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,37.000002 h 1 v 1 h -1"
+       id="path2227" />
+    <path
+       style="fill:#242020;fill-opacity:0.501961"
+       d="m 80,37.000002 h 1 v 1 h -1"
+       id="path2225" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,37.000002 h 1 v 1 h -1"
+       id="path2223" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 78,37.000002 h 1 v 1 h -1"
+       id="path2221" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 77,37.000002 h 1 v 1 h -1"
+       id="path2219" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 76,37.000002 h 1 v 1 h -1"
+       id="path2217" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,37.000002 h 1 v 1 h -1"
+       id="path2215" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,37.000002 h 1 v 1 h -1"
+       id="path2213" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,37.000002 h 1 v 1 h -1"
+       id="path2211" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,37.000002 h 1 v 1 h -1"
+       id="path2209" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,37.000002 h 1 v 1 h -1"
+       id="path2207" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,37.000002 h 1 v 1 h -1"
+       id="path2205" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,37.000002 h 1 v 1 h -1"
+       id="path2203" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,37.000002 h 1 v 1 h -1"
+       id="path2201" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,37.000002 h 1 v 1 h -1"
+       id="path2199" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,37.000002 h 1 v 1 h -1"
+       id="path2197" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.498039"
+       d="m 65,37.000002 h 1 v 1 h -1"
+       id="path2195" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,37.000002 h 1 v 1 h -1"
+       id="path2193" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,37.000002 h 1 v 1 h -1"
+       id="path2191" />
+    <path
+       style="fill:#232020;fill-opacity:0.313725"
+       d="m 62,37.000002 h 1 v 1 h -1"
+       id="path2189" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,37.000002 h 1 v 1 h -1"
+       id="path2187" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,37.000002 h 1 v 1 h -1"
+       id="path2185" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,37.000002 h 1 v 1 h -1"
+       id="path2183" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,37.000002 h 1 v 1 h -1"
+       id="path2181" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,37.000002 h 1 v 1 h -1"
+       id="path2179" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,37.000002 h 1 v 1 h -1"
+       id="path2177" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,37.000002 h 1 v 1 h -1"
+       id="path2175" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,37.000002 h 1 v 1 h -1"
+       id="path2173" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,37.000002 h 1 v 1 h -1"
+       id="path2171" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,37.000002 h 1 v 1 h -1"
+       id="path2169" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 51,37.000002 h 1 v 1 h -1"
+       id="path2167" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 50,37.000002 h 1 v 1 h -1"
+       id="path2165" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 49,37.000002 h 1 v 1 h -1"
+       id="path2163" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,37.000002 h 1 v 1 h -1"
+       id="path2161" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.498039"
+       d="m 47,37.000002 h 1 v 1 h -1"
+       id="path2159" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,37.000002 h 1 v 1 h -1"
+       id="path2157" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,37.000002 h 1 v 1 h -1"
+       id="path2155" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,37.000002 h 1 v 1 h -1"
+       id="path2153" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,37.000002 h 1 v 1 h -1"
+       id="path2151" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,37.000002 h 1 v 1 h -1"
+       id="path2149" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,37.000002 h 1 v 1 h -1"
+       id="path2147" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,37.000002 h 1 v 1 h -1"
+       id="path2145" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,37.000002 h 1 v 1 h -1"
+       id="path2143" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,37.000002 h 1 v 1 h -1"
+       id="path2141" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,37.000002 h 1 v 1 h -1"
+       id="path2139" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,37.000002 h 1 v 1 h -1"
+       id="path2137" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,37.000002 h 1 v 1 h -1"
+       id="path2135" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,37.000002 h 1 v 1 h -1"
+       id="path2133" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,37.000002 h 1 v 1 h -1"
+       id="path2131" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,37.000002 h 1 v 1 h -1"
+       id="path2129" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,36.000002 h 1 v 1 h -1"
+       id="path2127" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,36.000002 h 1 v 1 h -1"
+       id="path2125" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,36.000002 h 1 v 1 h -1"
+       id="path2123" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,36.000002 h 1 v 1 h -1"
+       id="path2121" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,36.000002 h 1 v 1 h -1"
+       id="path2119" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,36.000002 h 1 v 1 h -1"
+       id="path2117" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,36.000002 h 1 v 1 h -1"
+       id="path2115" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,36.000002 h 1 v 1 h -1"
+       id="path2113" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,36.000002 h 1 v 1 h -1"
+       id="path2111" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,36.000002 h 1 v 1 h -1"
+       id="path2109" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,36.000002 h 1 v 1 h -1"
+       id="path2107" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,36.000002 h 1 v 1 h -1"
+       id="path2105" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,36.000002 h 1 v 1 h -1"
+       id="path2103" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,36.000002 h 1 v 1 h -1"
+       id="path2101" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,36.000002 h 1 v 1 h -1"
+       id="path2099" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 80,36.000002 h 1 v 1 h -1"
+       id="path2097" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 79,36.000002 h 1 v 1 h -1"
+       id="path2095" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 78,36.000002 h 1 v 1 h -1"
+       id="path2093" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.4"
+       d="m 77,36.000002 h 1 v 1 h -1"
+       id="path2091" />
+    <path
+       style="fill:#242020;fill-opacity:0.219608"
+       d="m 76,36.000002 h 1 v 1 h -1"
+       id="path2089" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 75,36.000002 h 1 v 1 h -1"
+       id="path2087" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,36.000002 h 1 v 1 h -1"
+       id="path2085" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,36.000002 h 1 v 1 h -1"
+       id="path2083" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,36.000002 h 1 v 1 h -1"
+       id="path2081" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,36.000002 h 1 v 1 h -1"
+       id="path2079" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,36.000002 h 1 v 1 h -1"
+       id="path2077" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,36.000002 h 1 v 1 h -1"
+       id="path2075" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,36.000002 h 1 v 1 h -1"
+       id="path2073" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,36.000002 h 1 v 1 h -1"
+       id="path2071" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,36.000002 h 1 v 1 h -1"
+       id="path2069" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.933333"
+       d="m 65,36.000002 h 1 v 1 h -1"
+       id="path2067" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.337255"
+       d="m 64,36.000002 h 1 v 1 h -1"
+       id="path2065" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.266667"
+       d="m 63,36.000002 h 1 v 1 h -1"
+       id="path2063" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.847059"
+       d="m 62,36.000002 h 1 v 1 h -1"
+       id="path2061" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,36.000002 h 1 v 1 h -1"
+       id="path2059" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,36.000002 h 1 v 1 h -1"
+       id="path2057" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,36.000002 h 1 v 1 h -1"
+       id="path2055" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,36.000002 h 1 v 1 h -1"
+       id="path2053" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,36.000002 h 1 v 1 h -1"
+       id="path2051" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,36.000002 h 1 v 1 h -1"
+       id="path2049" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,36.000002 h 1 v 1 h -1"
+       id="path2047" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,36.000002 h 1 v 1 h -1"
+       id="path2045" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,36.000002 h 1 v 1 h -1"
+       id="path2043" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 52,36.000002 h 1 v 1 h -1"
+       id="path2041" />
+    <path
+       style="fill:#242020;fill-opacity:0.219608"
+       d="m 51,36.000002 h 1 v 1 h -1"
+       id="path2039" />
+    <path
+       style="fill:#232020;fill-opacity:0.403922"
+       d="m 50,36.000002 h 1 v 1 h -1"
+       id="path2037" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 49,36.000002 h 1 v 1 h -1"
+       id="path2035" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 48,36.000002 h 1 v 1 h -1"
+       id="path2033" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 47,36.000002 h 1 v 1 h -1"
+       id="path2031" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,36.000002 h 1 v 1 h -1"
+       id="path2029" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,36.000002 h 1 v 1 h -1"
+       id="path2027" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,36.000002 h 1 v 1 h -1"
+       id="path2025" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,36.000002 h 1 v 1 h -1"
+       id="path2023" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,36.000002 h 1 v 1 h -1"
+       id="path2021" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,36.000002 h 1 v 1 h -1"
+       id="path2019" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,36.000002 h 1 v 1 h -1"
+       id="path2017" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,36.000002 h 1 v 1 h -1"
+       id="path2015" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,36.000002 h 1 v 1 h -1"
+       id="path2013" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,36.000002 h 1 v 1 h -1"
+       id="path2011" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,36.000002 h 1 v 1 h -1"
+       id="path2009" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,36.000002 h 1 v 1 h -1"
+       id="path2007" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,36.000002 h 1 v 1 h -1"
+       id="path2005" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,36.000002 h 1 v 1 h -1"
+       id="path2003" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,36.000002 h 1 v 1 h -1"
+       id="path2001" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,35.000002 h 1 v 1 h -1"
+       id="path1999" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,35.000002 h 1 v 1 h -1"
+       id="path1997" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,35.000002 h 1 v 1 h -1"
+       id="path1995" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,35.000002 h 1 v 1 h -1"
+       id="path1993" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,35.000002 h 1 v 1 h -1"
+       id="path1991" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,35.000002 h 1 v 1 h -1"
+       id="path1989" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,35.000002 h 1 v 1 h -1"
+       id="path1987" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,35.000002 h 1 v 1 h -1"
+       id="path1985" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,35.000002 h 1 v 1 h -1"
+       id="path1983" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,35.000002 h 1 v 1 h -1"
+       id="path1981" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,35.000002 h 1 v 1 h -1"
+       id="path1979" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,35.000002 h 1 v 1 h -1"
+       id="path1977" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,35.000002 h 1 v 1 h -1"
+       id="path1975" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,35.000002 h 1 v 1 h -1"
+       id="path1973" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,35.000002 h 1 v 1 h -1"
+       id="path1971" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0352941"
+       d="m 80,35.000002 h 1 v 1 h -1"
+       id="path1969" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.223529"
+       d="m 79,35.000002 h 1 v 1 h -1"
+       id="path1967" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 78,35.000002 h 1 v 1 h -1"
+       id="path1965" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,35.000002 h 1 v 1 h -1"
+       id="path1963" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,35.000002 h 1 v 1 h -1"
+       id="path1961" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.913725"
+       d="m 75,35.000002 h 1 v 1 h -1"
+       id="path1959" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,35.000002 h 1 v 1 h -1"
+       id="path1957" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 73,35.000002 h 1 v 1 h -1"
+       id="path1955" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 72,35.000002 h 1 v 1 h -1"
+       id="path1953" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 71,35.000002 h 1 v 1 h -1"
+       id="path1951" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,35.000002 h 1 v 1 h -1"
+       id="path1949" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,35.000002 h 1 v 1 h -1"
+       id="path1947" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,35.000002 h 1 v 1 h -1"
+       id="path1945" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,35.000002 h 1 v 1 h -1"
+       id="path1943" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,35.000002 h 1 v 1 h -1"
+       id="path1941" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,35.000002 h 1 v 1 h -1"
+       id="path1939" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,35.000002 h 1 v 1 h -1"
+       id="path1937" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,35.000002 h 1 v 1 h -1"
+       id="path1935" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,35.000002 h 1 v 1 h -1"
+       id="path1933" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,35.000002 h 1 v 1 h -1"
+       id="path1931" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,35.000002 h 1 v 1 h -1"
+       id="path1929" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,35.000002 h 1 v 1 h -1"
+       id="path1927" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,35.000002 h 1 v 1 h -1"
+       id="path1925" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,35.000002 h 1 v 1 h -1"
+       id="path1923" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 56,35.000002 h 1 v 1 h -1"
+       id="path1921" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 55,35.000002 h 1 v 1 h -1"
+       id="path1919" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 54,35.000002 h 1 v 1 h -1"
+       id="path1917" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,35.000002 h 1 v 1 h -1"
+       id="path1915" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.909804"
+       d="m 52,35.000002 h 1 v 1 h -1"
+       id="path1913" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,35.000002 h 1 v 1 h -1"
+       id="path1911" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,35.000002 h 1 v 1 h -1"
+       id="path1909" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 49,35.000002 h 1 v 1 h -1"
+       id="path1907" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.223529"
+       d="m 48,35.000002 h 1 v 1 h -1"
+       id="path1905" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0352941"
+       d="m 47,35.000002 h 1 v 1 h -1"
+       id="path1903" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,35.000002 h 1 v 1 h -1"
+       id="path1901" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,35.000002 h 1 v 1 h -1"
+       id="path1899" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,35.000002 h 1 v 1 h -1"
+       id="path1897" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,35.000002 h 1 v 1 h -1"
+       id="path1895" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,35.000002 h 1 v 1 h -1"
+       id="path1893" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,35.000002 h 1 v 1 h -1"
+       id="path1891" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,35.000002 h 1 v 1 h -1"
+       id="path1889" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,35.000002 h 1 v 1 h -1"
+       id="path1887" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,35.000002 h 1 v 1 h -1"
+       id="path1885" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,35.000002 h 1 v 1 h -1"
+       id="path1883" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,35.000002 h 1 v 1 h -1"
+       id="path1881" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,35.000002 h 1 v 1 h -1"
+       id="path1879" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,35.000002 h 1 v 1 h -1"
+       id="path1877" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,35.000002 h 1 v 1 h -1"
+       id="path1875" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,35.000002 h 1 v 1 h -1"
+       id="path1873" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,34.000002 h 1 v 1 h -1"
+       id="path1871" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,34.000002 h 1 v 1 h -1"
+       id="path1869" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,34.000002 h 1 v 1 h -1"
+       id="path1867" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,34.000002 h 1 v 1 h -1"
+       id="path1865" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,34.000002 h 1 v 1 h -1"
+       id="path1863" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,34.000002 h 1 v 1 h -1"
+       id="path1861" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,34.000002 h 1 v 1 h -1"
+       id="path1859" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,34.000002 h 1 v 1 h -1"
+       id="path1857" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,34.000002 h 1 v 1 h -1"
+       id="path1855" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,34.000002 h 1 v 1 h -1"
+       id="path1853" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,34.000002 h 1 v 1 h -1"
+       id="path1851" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,34.000002 h 1 v 1 h -1"
+       id="path1849" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,34.000002 h 1 v 1 h -1"
+       id="path1847" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,34.000002 h 1 v 1 h -1"
+       id="path1845" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,34.000002 h 1 v 1 h -1"
+       id="path1843" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,34.000002 h 1 v 1 h -1"
+       id="path1841" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,34.000002 h 1 v 1 h -1"
+       id="path1839" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,34.000002 h 1 v 1 h -1"
+       id="path1837" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,34.000002 h 1 v 1 h -1"
+       id="path1835" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,34.000002 h 1 v 1 h -1"
+       id="path1833" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 75,34.000002 h 1 v 1 h -1"
+       id="path1831" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 74,34.000002 h 1 v 1 h -1"
+       id="path1829" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 73,34.000002 h 1 v 1 h -1"
+       id="path1827" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 72,34.000002 h 1 v 1 h -1"
+       id="path1825" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.329412"
+       d="m 71,34.000002 h 1 v 1 h -1"
+       id="path1823" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 70,34.000002 h 1 v 1 h -1"
+       id="path1821" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,34.000002 h 1 v 1 h -1"
+       id="path1819" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,34.000002 h 1 v 1 h -1"
+       id="path1817" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 67,34.000002 h 1 v 1 h -1"
+       id="path1815" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 66,34.000002 h 1 v 1 h -1"
+       id="path1813" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 65,34.000002 h 1 v 1 h -1"
+       id="path1811" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,34.000002 h 1 v 1 h -1"
+       id="path1809" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,34.000002 h 1 v 1 h -1"
+       id="path1807" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 62,34.000002 h 1 v 1 h -1"
+       id="path1805" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 61,34.000002 h 1 v 1 h -1"
+       id="path1803" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 60,34.000002 h 1 v 1 h -1"
+       id="path1801" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,34.000002 h 1 v 1 h -1"
+       id="path1799" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,34.000002 h 1 v 1 h -1"
+       id="path1797" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 57,34.000002 h 1 v 1 h -1"
+       id="path1795" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.329412"
+       d="m 56,34.000002 h 1 v 1 h -1"
+       id="path1793" />
+    <path
+       style="fill:#222020;fill-opacity:0.470588"
+       d="m 55,34.000002 h 1 v 1 h -1"
+       id="path1791" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 54,34.000002 h 1 v 1 h -1"
+       id="path1789" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 53,34.000002 h 1 v 1 h -1"
+       id="path1787" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 52,34.000002 h 1 v 1 h -1"
+       id="path1785" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,34.000002 h 1 v 1 h -1"
+       id="path1783" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,34.000002 h 1 v 1 h -1"
+       id="path1781" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,34.000002 h 1 v 1 h -1"
+       id="path1779" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,34.000002 h 1 v 1 h -1"
+       id="path1777" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,34.000002 h 1 v 1 h -1"
+       id="path1775" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,34.000002 h 1 v 1 h -1"
+       id="path1773" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,34.000002 h 1 v 1 h -1"
+       id="path1771" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,34.000002 h 1 v 1 h -1"
+       id="path1769" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,34.000002 h 1 v 1 h -1"
+       id="path1767" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,34.000002 h 1 v 1 h -1"
+       id="path1765" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,34.000002 h 1 v 1 h -1"
+       id="path1763" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,34.000002 h 1 v 1 h -1"
+       id="path1761" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,34.000002 h 1 v 1 h -1"
+       id="path1759" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,34.000002 h 1 v 1 h -1"
+       id="path1757" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,34.000002 h 1 v 1 h -1"
+       id="path1755" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,34.000002 h 1 v 1 h -1"
+       id="path1753" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,34.000002 h 1 v 1 h -1"
+       id="path1751" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,34.000002 h 1 v 1 h -1"
+       id="path1749" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,34.000002 h 1 v 1 h -1"
+       id="path1747" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,34.000002 h 1 v 1 h -1"
+       id="path1745" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,33.000002 h 1 v 1 h -1"
+       id="path1743" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,33.000002 h 1 v 1 h -1"
+       id="path1741" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,33.000002 h 1 v 1 h -1"
+       id="path1739" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,33.000002 h 1 v 1 h -1"
+       id="path1737" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,33.000002 h 1 v 1 h -1"
+       id="path1735" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,33.000002 h 1 v 1 h -1"
+       id="path1733" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,33.000002 h 1 v 1 h -1"
+       id="path1731" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,33.000002 h 1 v 1 h -1"
+       id="path1729" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,33.000002 h 1 v 1 h -1"
+       id="path1727" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,33.000002 h 1 v 1 h -1"
+       id="path1725" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,33.000002 h 1 v 1 h -1"
+       id="path1723" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,33.000002 h 1 v 1 h -1"
+       id="path1721" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,33.000002 h 1 v 1 h -1"
+       id="path1719" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,33.000002 h 1 v 1 h -1"
+       id="path1717" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,33.000002 h 1 v 1 h -1"
+       id="path1715" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,33.000002 h 1 v 1 h -1"
+       id="path1713" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,33.000002 h 1 v 1 h -1"
+       id="path1711" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,33.000002 h 1 v 1 h -1"
+       id="path1709" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,33.000002 h 1 v 1 h -1"
+       id="path1707" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,33.000002 h 1 v 1 h -1"
+       id="path1705" />
+    <path
+       style="fill:#222020;fill-opacity:0.411765"
+       d="m 75,33.000002 h 1 v 1 h -1"
+       id="path1703" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 74,33.000002 h 1 v 1 h -1"
+       id="path1701" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.203922"
+       d="m 73,33.000002 h 1 v 1 h -1"
+       id="path1699" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,33.000002 h 1 v 1 h -1"
+       id="path1697" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,33.000002 h 1 v 1 h -1"
+       id="path1695" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 70,33.000002 h 1 v 1 h -1"
+       id="path1693" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,33.000002 h 1 v 1 h -1"
+       id="path1691" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 68,33.000002 h 1 v 1 h -1"
+       id="path1689" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.733333"
+       d="m 67,33.000002 h 1 v 1 h -1"
+       id="path1687" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.227451"
+       d="m 66,33.000002 h 1 v 1 h -1"
+       id="path1685" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.956863"
+       d="m 65,33.000002 h 1 v 1 h -1"
+       id="path1683" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 64,33.000002 h 1 v 1 h -1"
+       id="path1681" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,33.000002 h 1 v 1 h -1"
+       id="path1679" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.952941"
+       d="m 62,33.000002 h 1 v 1 h -1"
+       id="path1677" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.227451"
+       d="m 61,33.000002 h 1 v 1 h -1"
+       id="path1675" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.737255"
+       d="m 60,33.000002 h 1 v 1 h -1"
+       id="path1673" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 59,33.000002 h 1 v 1 h -1"
+       id="path1671" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,33.000002 h 1 v 1 h -1"
+       id="path1669" />
+    <path
+       style="fill:#232020;fill-opacity:0.854902"
+       d="m 57,33.000002 h 1 v 1 h -1"
+       id="path1667" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,33.000002 h 1 v 1 h -1"
+       id="path1665" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,33.000002 h 1 v 1 h -1"
+       id="path1663" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.203922"
+       d="m 54,33.000002 h 1 v 1 h -1"
+       id="path1661" />
+    <path
+       style="fill:#232020;fill-opacity:0.792157"
+       d="m 53,33.000002 h 1 v 1 h -1"
+       id="path1659" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 52,33.000002 h 1 v 1 h -1"
+       id="path1657" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,33.000002 h 1 v 1 h -1"
+       id="path1655" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,33.000002 h 1 v 1 h -1"
+       id="path1653" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,33.000002 h 1 v 1 h -1"
+       id="path1651" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,33.000002 h 1 v 1 h -1"
+       id="path1649" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,33.000002 h 1 v 1 h -1"
+       id="path1647" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,33.000002 h 1 v 1 h -1"
+       id="path1645" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,33.000002 h 1 v 1 h -1"
+       id="path1643" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,33.000002 h 1 v 1 h -1"
+       id="path1641" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,33.000002 h 1 v 1 h -1"
+       id="path1639" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,33.000002 h 1 v 1 h -1"
+       id="path1637" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,33.000002 h 1 v 1 h -1"
+       id="path1635" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,33.000002 h 1 v 1 h -1"
+       id="path1633" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,33.000002 h 1 v 1 h -1"
+       id="path1631" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,33.000002 h 1 v 1 h -1"
+       id="path1629" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,33.000002 h 1 v 1 h -1"
+       id="path1627" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,33.000002 h 1 v 1 h -1"
+       id="path1625" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,33.000002 h 1 v 1 h -1"
+       id="path1623" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,33.000002 h 1 v 1 h -1"
+       id="path1621" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,33.000002 h 1 v 1 h -1"
+       id="path1619" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,33.000002 h 1 v 1 h -1"
+       id="path1617" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,32.000002 h 1 v 1 h -1"
+       id="path1615" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,32.000002 h 1 v 1 h -1"
+       id="path1613" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,32.000002 h 1 v 1 h -1"
+       id="path1611" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,32.000002 h 1 v 1 h -1"
+       id="path1609" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,32.000002 h 1 v 1 h -1"
+       id="path1607" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,32.000002 h 1 v 1 h -1"
+       id="path1605" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,32.000002 h 1 v 1 h -1"
+       id="path1603" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,32.000002 h 1 v 1 h -1"
+       id="path1601" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,32.000002 h 1 v 1 h -1"
+       id="path1599" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,32.000002 h 1 v 1 h -1"
+       id="path1597" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,32.000002 h 1 v 1 h -1"
+       id="path1595" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,32.000002 h 1 v 1 h -1"
+       id="path1593" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,32.000002 h 1 v 1 h -1"
+       id="path1591" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,32.000002 h 1 v 1 h -1"
+       id="path1589" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,32.000002 h 1 v 1 h -1"
+       id="path1587" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,32.000002 h 1 v 1 h -1"
+       id="path1585" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,32.000002 h 1 v 1 h -1"
+       id="path1583" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,32.000002 h 1 v 1 h -1"
+       id="path1581" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,32.000002 h 1 v 1 h -1"
+       id="path1579" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,32.000002 h 1 v 1 h -1"
+       id="path1577" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,32.000002 h 1 v 1 h -1"
+       id="path1575" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,32.000002 h 1 v 1 h -1"
+       id="path1573" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,32.000002 h 1 v 1 h -1"
+       id="path1571" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,32.000002 h 1 v 1 h -1"
+       id="path1569" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,32.000002 h 1 v 1 h -1"
+       id="path1567" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 70,32.000002 h 1 v 1 h -1"
+       id="path1565" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 69,32.000002 h 1 v 1 h -1"
+       id="path1563" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.784314"
+       d="m 68,32.000002 h 1 v 1 h -1"
+       id="path1561" />
+    <path
+       style="fill:#1a1a1a;fill-opacity:0.0392157"
+       d="m 67,32.000002 h 1 v 1 h -1"
+       id="path1559" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66.25,32.250002 0.75,-0.25 v 1 h -1"
+       id="path1557" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.45098"
+       d="m 65,32 v 0 h 1 v 0 1.000002 h -1"
+       id="path1555"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="M 64,32.000002 65,32 v 1.000002 h -1"
+       id="path1553"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 63,32 1,2e-6 v 1 h -1"
+       id="path1551"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.447059"
+       d="M 62,32.000002 V 32 h 1 v 0 1.000002 h -1"
+       id="path1549"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,32.000002 0.75,0.25 0.25,0.75 h -1"
+       id="path1547" />
+    <path
+       style="fill:#1a1a1a;fill-opacity:0.0392157"
+       d="m 60,32.000002 h 1 v 1 h -1"
+       id="path1545" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 59,32.000002 h 1 v 1 h -1"
+       id="path1543" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 58,32.000002 h 1 v 1 h -1"
+       id="path1541" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.478431"
+       d="m 57,32.000002 h 1 v 1 h -1"
+       id="path1539" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,32.000002 h 1 v 1 h -1"
+       id="path1537" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,32.000002 h 1 v 1 h -1"
+       id="path1535" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,32.000002 h 1 v 1 h -1"
+       id="path1533" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,32.000002 h 1 v 1 h -1"
+       id="path1531" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,32.000002 h 1 v 1 h -1"
+       id="path1529" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,32.000002 h 1 v 1 h -1"
+       id="path1527" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,32.000002 h 1 v 1 h -1"
+       id="path1525" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,32.000002 h 1 v 1 h -1"
+       id="path1523" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,32.000002 h 1 v 1 h -1"
+       id="path1521" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,32.000002 h 1 v 1 h -1"
+       id="path1519" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,32.000002 h 1 v 1 h -1"
+       id="path1517" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,32.000002 h 1 v 1 h -1"
+       id="path1515" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,32.000002 h 1 v 1 h -1"
+       id="path1513" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,32.000002 h 1 v 1 h -1"
+       id="path1511" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,32.000002 h 1 v 1 h -1"
+       id="path1509" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,32.000002 h 1 v 1 h -1"
+       id="path1507" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,32.000002 h 1 v 1 h -1"
+       id="path1505" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,32.000002 h 1 v 1 h -1"
+       id="path1503" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,32.000002 h 1 v 1 h -1"
+       id="path1501" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,32.000002 h 1 v 1 h -1"
+       id="path1499" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,32.000002 h 1 v 1 h -1"
+       id="path1497" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,32.000002 h 1 v 1 h -1"
+       id="path1495" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,32.000002 h 1 v 1 h -1"
+       id="path1493" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,32.000002 h 1 v 1 h -1"
+       id="path1491" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,32.000002 h 1 v 1 h -1"
+       id="path1489" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,31.000002 h 1 v 1 h -1"
+       id="path1487" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,31.000002 h 1 v 1 h -1"
+       id="path1485" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,31.000002 h 1 v 1 h -1"
+       id="path1483" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,31.000002 h 1 v 1 h -1"
+       id="path1481" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,31.000002 h 1 v 1 h -1"
+       id="path1479" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,31.000002 h 1 v 1 h -1"
+       id="path1477" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,31.000002 h 1 v 1 h -1"
+       id="path1475" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,31.000002 h 1 v 1 h -1"
+       id="path1473" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,31.000002 h 1 v 1 h -1"
+       id="path1471" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,31.000002 h 1 v 1 h -1"
+       id="path1469" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,31.000002 h 1 v 1 h -1"
+       id="path1467" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,31.000002 h 1 v 1 h -1"
+       id="path1465" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,31.000002 h 1 v 1 h -1"
+       id="path1463" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,31.000002 h 1 v 1 h -1"
+       id="path1461" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,31.000002 h 1 v 1 h -1"
+       id="path1459" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,31.000002 h 1 v 1 h -1"
+       id="path1457" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,31.000002 h 1 v 1 h -1"
+       id="path1455" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,31.000002 h 1 v 1 h -1"
+       id="path1453" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,31.000002 h 1 v 1 h -1"
+       id="path1451" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,31.000002 h 1 v 1 h -1"
+       id="path1449" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,31.000002 h 1 v 1 h -1"
+       id="path1447" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,31.000002 h 1 v 1 h -1"
+       id="path1445" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,31.000002 h 1 v 1 h -1"
+       id="path1443" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,31.000002 h 1 v 1 h -1"
+       id="path1441" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,31.000002 h 1 v 1 h -1"
+       id="path1439" />
+    <path
+       style="fill:#272727;fill-opacity:0.0509804"
+       d="m 70,31.000002 h 1 v 1 h -1"
+       id="path1437" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 69,31.000002 h 1 v 1 h -1"
+       id="path1435" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 68,31.000002 h 1 v 1 h -1"
+       id="path1433" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,31.000002 h 1 v 1 h -1"
+       id="path1431" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65.75,31.250002 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path1429" />
+    <path
+       style="fill:#400000;fill-opacity:0.0156863"
+       d="m 65,31 h 1 v 1 h -1"
+       id="path1427"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.776471"
+       d="M 64,31.000002 65,31 v 0 1 0 l -1,2e-6"
+       id="path1425"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.768627"
+       d="m 63,31 v 0 l 1,2e-6 v 1 L 63,32 v 0"
+       id="path1423"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#400000;fill-opacity:0.0156863"
+       d="m 62,31 h 1 v 1 h -1"
+       id="path1421"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,31.000002 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path1419" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,31.000002 h 1 v 1 h -1"
+       id="path1417" />
+    <path
+       style="fill:#222222;fill-opacity:0.0588235"
+       d="m 59,31.000002 h 1 v 1 h -1"
+       id="path1415" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.419608"
+       d="m 58,31.000002 h 1 v 1 h -1"
+       id="path1413" />
+    <path
+       style="fill:#272727;fill-opacity:0.0509804"
+       d="m 57,31.000002 h 1 v 1 h -1"
+       id="path1411" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,31.000002 h 1 v 1 h -1"
+       id="path1409" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,31.000002 h 1 v 1 h -1"
+       id="path1407" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,31.000002 h 1 v 1 h -1"
+       id="path1405" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,31.000002 h 1 v 1 h -1"
+       id="path1403" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,31.000002 h 1 v 1 h -1"
+       id="path1401" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,31.000002 h 1 v 1 h -1"
+       id="path1399" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,31.000002 h 1 v 1 h -1"
+       id="path1397" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,31.000002 h 1 v 1 h -1"
+       id="path1395" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,31.000002 h 1 v 1 h -1"
+       id="path1393" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,31.000002 h 1 v 1 h -1"
+       id="path1391" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,31.000002 h 1 v 1 h -1"
+       id="path1389" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,31.000002 h 1 v 1 h -1"
+       id="path1387" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,31.000002 h 1 v 1 h -1"
+       id="path1385" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,31.000002 h 1 v 1 h -1"
+       id="path1383" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,31.000002 h 1 v 1 h -1"
+       id="path1381" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,31.000002 h 1 v 1 h -1"
+       id="path1379" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,31.000002 h 1 v 1 h -1"
+       id="path1377" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,31.000002 h 1 v 1 h -1"
+       id="path1375" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,31.000002 h 1 v 1 h -1"
+       id="path1373" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,31.000002 h 1 v 1 h -1"
+       id="path1371" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,31.000002 h 1 v 1 h -1"
+       id="path1369" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,31.000002 h 1 v 1 h -1"
+       id="path1367" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,31.000002 h 1 v 1 h -1"
+       id="path1365" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,31.000002 h 1 v 1 h -1"
+       id="path1363" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,31.000002 h 1 v 1 h -1"
+       id="path1361" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,30.000002 h 1 v 1 h -1"
+       id="path1359" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,30.000002 h 1 v 1 h -1"
+       id="path1357" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,30.000002 h 1 v 1 h -1"
+       id="path1355" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,30.000002 h 1 v 1 h -1"
+       id="path1353" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,30.000002 h 1 v 1 h -1"
+       id="path1351" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,30.000002 h 1 v 1 h -1"
+       id="path1349" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,30.000002 h 1 v 1 h -1"
+       id="path1347" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,30.000002 h 1 v 1 h -1"
+       id="path1345" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,30.000002 h 1 v 1 h -1"
+       id="path1343" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,30.000002 h 1 v 1 h -1"
+       id="path1341" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,30.000002 h 1 v 1 h -1"
+       id="path1339" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,30.000002 h 1 v 1 h -1"
+       id="path1337" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,30.000002 h 1 v 1 h -1"
+       id="path1335" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,30.000002 h 1 v 1 h -1"
+       id="path1333" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,30.000002 h 1 v 1 h -1"
+       id="path1331" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,30.000002 h 1 v 1 h -1"
+       id="path1329" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,30.000002 h 1 v 1 h -1"
+       id="path1327" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,30.000002 h 1 v 1 h -1"
+       id="path1325" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,30.000002 h 1 v 1 h -1"
+       id="path1323" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,30.000002 h 1 v 1 h -1"
+       id="path1321" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,30.000002 h 1 v 1 h -1"
+       id="path1319" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,30.000002 h 1 v 1 h -1"
+       id="path1317" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,30.000002 h 1 v 1 h -1"
+       id="path1315" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,30.000002 h 1 v 1 h -1"
+       id="path1313" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,30.000002 h 1 v 1 h -1"
+       id="path1311" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,30.000002 h 1 v 1 h -1"
+       id="path1309" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,30.000002 h 1 v 1 h -1"
+       id="path1307" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,30.000002 h 1 v 1 h -1"
+       id="path1305" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,30.000002 h 1 v 1 h -1"
+       id="path1303" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,30.000002 h 1 v 1 l -0.75,-0.25"
+       id="path1301" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,30.000002 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path1299" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,30.000002 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path1297" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,30.000002 h 1 v 1 l -0.75,-0.25"
+       id="path1295" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,30.000002 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path1293" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,30.000002 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path1291" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,30.000002 h 1 v 1 h -1"
+       id="path1289" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,30.000002 h 1 v 1 h -1"
+       id="path1287" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,30.000002 h 1 v 1 h -1"
+       id="path1285" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,30.000002 h 1 v 1 h -1"
+       id="path1283" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,30.000002 h 1 v 1 h -1"
+       id="path1281" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,30.000002 h 1 v 1 h -1"
+       id="path1279" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,30.000002 h 1 v 1 h -1"
+       id="path1277" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,30.000002 h 1 v 1 h -1"
+       id="path1275" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,30.000002 h 1 v 1 h -1"
+       id="path1273" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,30.000002 h 1 v 1 h -1"
+       id="path1271" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,30.000002 h 1 v 1 h -1"
+       id="path1269" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,30.000002 h 1 v 1 h -1"
+       id="path1267" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,30.000002 h 1 v 1 h -1"
+       id="path1265" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,30.000002 h 1 v 1 h -1"
+       id="path1263" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,30.000002 h 1 v 1 h -1"
+       id="path1261" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,30.000002 h 1 v 1 h -1"
+       id="path1259" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,30.000002 h 1 v 1 h -1"
+       id="path1257" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,30.000002 h 1 v 1 h -1"
+       id="path1255" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,30.000002 h 1 v 1 h -1"
+       id="path1253" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,30.000002 h 1 v 1 h -1"
+       id="path1251" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,30.000002 h 1 v 1 h -1"
+       id="path1249" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,30.000002 h 1 v 1 h -1"
+       id="path1247" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,30.000002 h 1 v 1 h -1"
+       id="path1245" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,30.000002 h 1 v 1 h -1"
+       id="path1243" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,30.000002 h 1 v 1 h -1"
+       id="path1241" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,30.000002 h 1 v 1 h -1"
+       id="path1239" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,30.000002 h 1 v 1 h -1"
+       id="path1237" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,30.000002 h 1 v 1 h -1"
+       id="path1235" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,30.000002 h 1 v 1 h -1"
+       id="path1233" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,29.000002 h 1 v 1 h -1"
+       id="path1231" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,29.000002 h 1 v 1 h -1"
+       id="path1229" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,29.000002 h 1 v 1 h -1"
+       id="path1227" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,29.000002 h 1 v 1 h -1"
+       id="path1225" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,29.000002 h 1 v 1 h -1"
+       id="path1223" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,29.000002 h 1 v 1 h -1"
+       id="path1221" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,29.000002 h 1 v 1 h -1"
+       id="path1219" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,29.000002 h 1 v 1 h -1"
+       id="path1217" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,29.000002 h 1 v 1 h -1"
+       id="path1215" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,29.000002 h 1 v 1 h -1"
+       id="path1213" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,29.000002 h 1 v 1 h -1"
+       id="path1211" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,29.000002 h 1 v 1 h -1"
+       id="path1209" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,29.000002 h 1 v 1 h -1"
+       id="path1207" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,29.000002 h 1 v 1 h -1"
+       id="path1205" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,29.000002 h 1 v 1 h -1"
+       id="path1203" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,29.000002 h 1 v 1 h -1"
+       id="path1201" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,29.000002 h 1 v 1 h -1"
+       id="path1199" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,29.000002 h 1 v 1 h -1"
+       id="path1197" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,29.000002 h 1 v 1 h -1"
+       id="path1195" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,29.000002 h 1 v 1 h -1"
+       id="path1193" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,29.000002 h 1 v 1 h -1"
+       id="path1191" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,29.000002 h 1 v 1 h -1"
+       id="path1189" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,29.000002 h 1 v 1 h -1"
+       id="path1187" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,29.000002 h 1 v 1 h -1"
+       id="path1185" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,29.000002 h 1 v 1 h -1"
+       id="path1183" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,29.000002 h 1 v 1 h -1"
+       id="path1181" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,29.000002 h 1 v 1 h -1"
+       id="path1179" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,29.000002 h 1 v 1 h -1"
+       id="path1177" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,29.000002 h 1 v 1 h -1"
+       id="path1175" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,29.000002 h 1 v 1 h -1"
+       id="path1173" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,29.000002 h 1 v 1 h -1"
+       id="path1171" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,29.000002 h 1 v 1 h -1"
+       id="path1169" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,29.000002 h 1 v 1 h -1"
+       id="path1167" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,29.000002 h 1 v 1 h -1"
+       id="path1165" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,29.000002 h 1 v 1 h -1"
+       id="path1163" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,29.000002 h 1 v 1 h -1"
+       id="path1161" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,29.000002 h 1 v 1 h -1"
+       id="path1159" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,29.000002 h 1 v 1 h -1"
+       id="path1157" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,29.000002 h 1 v 1 h -1"
+       id="path1155" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,29.000002 h 1 v 1 h -1"
+       id="path1153" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,29.000002 h 1 v 1 h -1"
+       id="path1151" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,29.000002 h 1 v 1 h -1"
+       id="path1149" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,29.000002 h 1 v 1 h -1"
+       id="path1147" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,29.000002 h 1 v 1 h -1"
+       id="path1145" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,29.000002 h 1 v 1 h -1"
+       id="path1143" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,29.000002 h 1 v 1 h -1"
+       id="path1141" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,29.000002 h 1 v 1 h -1"
+       id="path1139" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,29.000002 h 1 v 1 h -1"
+       id="path1137" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,29.000002 h 1 v 1 h -1"
+       id="path1135" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,29.000002 h 1 v 1 h -1"
+       id="path1133" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,29.000002 h 1 v 1 h -1"
+       id="path1131" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,29.000002 h 1 v 1 h -1"
+       id="path1129" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,29.000002 h 1 v 1 h -1"
+       id="path1127" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,29.000002 h 1 v 1 h -1"
+       id="path1125" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,29.000002 h 1 v 1 h -1"
+       id="path1123" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,29.000002 h 1 v 1 h -1"
+       id="path1121" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,29.000002 h 1 v 1 h -1"
+       id="path1119" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,29.000002 h 1 v 1 h -1"
+       id="path1117" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,29.000002 h 1 v 1 h -1"
+       id="path1115" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,29.000002 h 1 v 1 h -1"
+       id="path1113" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,29.000002 h 1 v 1 h -1"
+       id="path1111" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,29.000002 h 1 v 1 h -1"
+       id="path1109" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,29.000002 h 1 v 1 h -1"
+       id="path1107" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,29.000002 h 1 v 1 h -1"
+       id="path1105" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 95,28.000002 h 1 v 1 h -1"
+       id="path1103" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 94,28.000002 h 1 v 1 h -1"
+       id="path1101" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 93,28.000002 h 1 v 1 h -1"
+       id="path1099" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 92,28.000002 h 1 v 1 h -1"
+       id="path1097" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 91,28.000002 h 1 v 1 h -1"
+       id="path1095" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 90,28.000002 h 1 v 1 h -1"
+       id="path1093" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 89,28.000002 h 1 v 1 h -1"
+       id="path1091" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 88,28.000002 h 1 v 1 h -1"
+       id="path1089" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 87,28.000002 h 1 v 1 h -1"
+       id="path1087" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 86,28.000002 h 1 v 1 h -1"
+       id="path1085" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 85,28.000002 h 1 v 1 h -1"
+       id="path1083" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 84,28.000002 h 1 v 1 h -1"
+       id="path1081" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 83,28.000002 h 1 v 1 h -1"
+       id="path1079" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 82,28.000002 h 1 v 1 h -1"
+       id="path1077" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 81,28.000002 h 1 v 1 h -1"
+       id="path1075" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 80,28.000002 h 1 v 1 h -1"
+       id="path1073" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 79,28.000002 h 1 v 1 h -1"
+       id="path1071" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 78,28.000002 h 1 v 1 h -1"
+       id="path1069" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 77,28.000002 h 1 v 1 h -1"
+       id="path1067" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 76,28.000002 h 1 v 1 h -1"
+       id="path1065" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 75,28.000002 h 1 v 1 h -1"
+       id="path1063" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 74,28.000002 h 1 v 1 h -1"
+       id="path1061" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 73,28.000002 h 1 v 1 h -1"
+       id="path1059" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 72,28.000002 h 1 v 1 h -1"
+       id="path1057" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 71,28.000002 h 1 v 1 h -1"
+       id="path1055" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 70,28.000002 h 1 v 1 h -1"
+       id="path1053" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 69,28.000002 h 1 v 1 h -1"
+       id="path1051" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 68,28.000002 h 1 v 1 h -1"
+       id="path1049" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 67,28.000002 h 1 v 1 h -1"
+       id="path1047" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 66,28.000002 h 1 v 1 h -1"
+       id="path1045" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 65,28.000002 h 1 v 1 h -1"
+       id="path1043" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 64,28.000002 h 1 v 1 h -1"
+       id="path1041" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 63,28.000002 h 1 v 1 h -1"
+       id="path1039" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 62,28.000002 h 1 v 1 h -1"
+       id="path1037" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 61,28.000002 h 1 v 1 h -1"
+       id="path1035" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 60,28.000002 h 1 v 1 h -1"
+       id="path1033" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 59,28.000002 h 1 v 1 h -1"
+       id="path1031" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 58,28.000002 h 1 v 1 h -1"
+       id="path1029" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 57,28.000002 h 1 v 1 h -1"
+       id="path1027" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 56,28.000002 h 1 v 1 h -1"
+       id="path1025" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 55,28.000002 h 1 v 1 h -1"
+       id="path1023" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 54,28.000002 h 1 v 1 h -1"
+       id="path1021" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 53,28.000002 h 1 v 1 h -1"
+       id="path1019" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 52,28.000002 h 1 v 1 h -1"
+       id="path1017" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 51,28.000002 h 1 v 1 h -1"
+       id="path1015" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 50,28.000002 h 1 v 1 h -1"
+       id="path1013" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 49,28.000002 h 1 v 1 h -1"
+       id="path1011" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 48,28.000002 h 1 v 1 h -1"
+       id="path1009" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,28.000002 h 1 v 1 h -1"
+       id="path1007" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,28.000002 h 1 v 1 h -1"
+       id="path1005" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,28.000002 h 1 v 1 h -1"
+       id="path1003" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,28.000002 h 1 v 1 h -1"
+       id="path1001" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,28.000002 h 1 v 1 h -1"
+       id="path999" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,28.000002 h 1 v 1 h -1"
+       id="path997" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,28.000002 h 1 v 1 h -1"
+       id="path995" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,28.000002 h 1 v 1 h -1"
+       id="path993" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,28.000002 h 1 v 1 h -1"
+       id="path991" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,28.000002 h 1 v 1 h -1"
+       id="path989" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,28.000002 h 1 v 1 h -1"
+       id="path987" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,28.000002 h 1 v 1 h -1"
+       id="path985" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,28.000002 h 1 v 1 h -1"
+       id="path983" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,28.000002 h 1 v 1 h -1"
+       id="path981" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,28.000002 h 1 v 1 h -1"
+       id="path979" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,28.000002 h 1 v 1 h -1"
+       id="path977" />
+  </g>
+  <g
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)"
+     style="opacity:0.2;stroke-width:1.03923047"
+     id="g978">
+    <rect
+       width="14.210526"
+       height="4.9999995"
+       x="103.78947"
+       y="116.00149"
+       id="rect2801"
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288" />
+    <rect
+       width="14.210526"
+       height="4.9999995"
+       x="-24.210518"
+       y="-121.00149"
+       transform="scale(-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288" />
+    <rect
+       width="79.578949"
+       height="5"
+       x="24.210518"
+       y="116.00149"
+       id="rect3700"
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288" />
+  </g>
+  <path
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1"
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z" />
+  <path
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-6-1"
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z" />
+</svg>

--- a/mimes/32/text-rust.svg
+++ b/mimes/32/text-rust.svg
@@ -1,0 +1,1248 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg3182"
+   sodipodi:docname="text-rust.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview35"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:snap-page="true"
+     inkscape:zoom="2.8237469"
+     inkscape:cx="-5.3120908"
+     inkscape:cy="38.601193"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4072" />
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99999994" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.1851754"
+       x2="23.99999"
+       y2="41.814808"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z"
+     id="path4160-3"
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
+  <rect
+     width="22.100021"
+     height="2"
+     x="4.9499893"
+     y="29"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <g
+     id="g4072">
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 17,14 h 1 v 1 h -1"
+       id="path4316" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,22 h 1 v 1 h -1"
+       id="path4584" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,22 h 1 v 1 h -1"
+       id="path4582" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,22 h 1 v 1 h -1"
+       id="path4580" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,22 h 1 v 1 h -1"
+       id="path4578" />
+    <path
+       style="fill:#212121;fill-opacity:0.211765"
+       d="m 19,22 h 1 v 1 h -1"
+       id="path4576" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.603922"
+       d="m 18,22 h 1 v 1 h -1"
+       id="path4574" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 17,22 h 1 v 1 h -1"
+       id="path4572" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 16,22 h 1 v 1 h -1"
+       id="path4570" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 15,22 h 1 v 1 h -1"
+       id="path4568" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 14,22 h 1 v 1 h -1"
+       id="path4566" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.603922"
+       d="m 13,22 h 1 v 1 h -1"
+       id="path4564" />
+    <path
+       style="fill:#212121;fill-opacity:0.211765"
+       d="m 12,22 h 1 v 1 h -1"
+       id="path4562" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 11,22 h 1 v 1 h -1"
+       id="path4560" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 10,22 h 1 v 1 h -1"
+       id="path4558" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 9,22 h 1 v 1 H 9"
+       id="path4556" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 8,22 h 1 v 1 H 8"
+       id="path4554" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,21 h 1 v 1 h -1"
+       id="path4552" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,21 h 1 v 1 h -1"
+       id="path4550" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 21,21 h 1 v 1 h -1"
+       id="path4548" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.647059"
+       d="m 20,21 h 1 v 1 h -1"
+       id="path4546" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,21 h 1 v 1 h -1"
+       id="path4544" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,21 h 1 v 1 h -1"
+       id="path4542" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 17,21 h 1 v 1 h -1"
+       id="path4540" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 16,21 h 1 v 1 h -1"
+       id="path4538" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 15,21 h 1 v 1 h -1"
+       id="path4536" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 14,21 h 1 v 1 h -1"
+       id="path4534" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 13,21 h 1 v 1 h -1"
+       id="path4532" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 12,21 h 1 v 1 h -1"
+       id="path4530" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.647059"
+       d="m 11,21 h 1 v 1 h -1"
+       id="path4528" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 10,21 h 1 v 1 h -1"
+       id="path4526" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 9,21 h 1 v 1 H 9"
+       id="path4524" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 8,21 h 1 v 1 H 8"
+       id="path4522" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,20 h 1 v 1 h -1"
+       id="path4520" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 22,20 h 1 v 1 h -1"
+       id="path4518" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 21,20 h 1 v 1 h -1"
+       id="path4516" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,20 h 1 v 1 h -1"
+       id="path4514" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.94902"
+       d="m 19,20 h 1 v 1 h -1"
+       id="path4512" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.513725"
+       d="m 18,20 h 1 v 1 h -1"
+       id="path4510" />
+    <path
+       style="fill:#222222;fill-opacity:0.14902"
+       d="m 17,20 h 1 v 1 h -1"
+       id="path4508" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 16,20 h 1 v 1 h -1"
+       id="path4506" />
+    <path
+       style="fill:#000000;fill-opacity:0.00784314"
+       d="m 15,20 h 1 v 1 h -1"
+       id="path4504" />
+    <path
+       style="fill:#222222;fill-opacity:0.14902"
+       d="m 14,20 h 1 v 1 h -1"
+       id="path4502" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.513725"
+       d="m 13,20 h 1 v 1 h -1"
+       id="path4500" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.94902"
+       d="m 12,20 h 1 v 1 h -1"
+       id="path4498" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 11,20 h 1 v 1 h -1"
+       id="path4496" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 10,20 h 1 v 1 h -1"
+       id="path4494" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 9,20 h 1 v 1 H 9"
+       id="path4492" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 8,20 h 1 v 1 H 8"
+       id="path4490" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,19 h 1 v 1 h -1"
+       id="path4488" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.647059"
+       d="m 22,19 h 1 v 1 h -1"
+       id="path4486" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,19 h 1 v 1 h -1"
+       id="path4484" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.858824"
+       d="m 20,19 h 1 v 1 h -1"
+       id="path4482" />
+    <path
+       style="fill:#271f1f;fill-opacity:0.129412"
+       d="m 19,19 h 1 v 1 h -1"
+       id="path4480" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,19 h 1 v 1 h -1"
+       id="path4478" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,19 h 1 v 1 h -1"
+       id="path4476" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,19 h 1 v 1 h -1"
+       id="path4474" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 15,19 h 1 v 1 h -1"
+       id="path4472" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 14,19 h 1 v 1 h -1"
+       id="path4470" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 13,19 h 1 v 1 h -1"
+       id="path4468" />
+    <path
+       style="fill:#271f1f;fill-opacity:0.129412"
+       d="m 12,19 h 1 v 1 h -1"
+       id="path4466" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.858824"
+       d="m 11,19 h 1 v 1 h -1"
+       id="path4464" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 10,19 h 1 v 1 h -1"
+       id="path4462" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.647059"
+       d="m 9,19 h 1 v 1 H 9"
+       id="path4460" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 8,19 h 1 v 1 H 8"
+       id="path4458" />
+    <path
+       style="fill:#212121;fill-opacity:0.211765"
+       d="m 23,18 h 1 v 1 h -1"
+       id="path4456" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,18 h 1 v 1 h -1"
+       id="path4454" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,18 h 1 v 1 h -1"
+       id="path4452" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.741176"
+       d="m 20,18 h 1 v 1 h -1"
+       id="path4450" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 19,18 h 1 v 1 h -1"
+       id="path4448" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 18,18 h 1 v 1 h -1"
+       id="path4446" />
+    <path
+       style="fill:#1f1f1f;fill-opacity:0.0980392"
+       d="m 17,18 h 1 v 1 h -1"
+       id="path4444" />
+    <path
+       style="fill:#212121;fill-opacity:0.152941"
+       d="m 16,18 h 1 v 1 h -1"
+       id="path4442" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 15,18 h 1 v 1 h -1"
+       id="path4440" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 14,18 h 1 v 1 h -1"
+       id="path4438" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 13,18 h 1 v 1 h -1"
+       id="path4436" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 12,18 h 1 v 1 h -1"
+       id="path4434" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.741176"
+       d="m 11,18 h 1 v 1 h -1"
+       id="path4432" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 10,18 h 1 v 1 h -1"
+       id="path4430" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 9,18 h 1 v 1 H 9"
+       id="path4428" />
+    <path
+       style="fill:#212121;fill-opacity:0.211765"
+       d="m 8,18 h 1 v 1 H 8"
+       id="path4426" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.603922"
+       d="m 23,17 h 1 v 1 h -1"
+       id="path4424" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,17 h 1 v 1 h -1"
+       id="path4422" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,17 h 1 v 1 h -1"
+       id="path4420" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,17 h 1 v 1 h -1"
+       id="path4418" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,17 h 1 v 1 h -1"
+       id="path4416" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,17 h 1 v 1 h -1"
+       id="path4414" />
+    <path
+       style="fill:#232020;fill-opacity:0.568627"
+       d="m 17,17 h 1 v 1 h -1"
+       id="path4412" />
+    <path
+       style="fill:#242020;fill-opacity:0.25098"
+       d="m 16,17 h 1 v 1 h -1"
+       id="path4410" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 15,17 h 1 v 1 h -1"
+       id="path4408" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 14,17 h 1 v 1 h -1"
+       id="path4406" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 13,17 h 1 v 1 h -1"
+       id="path4404" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 12,17 h 1 v 1 h -1"
+       id="path4402" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 11,17 h 1 v 1 h -1"
+       id="path4400" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 10,17 h 1 v 1 h -1"
+       id="path4398" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 9,17 h 1 v 1 H 9"
+       id="path4396" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.603922"
+       d="m 8,17 h 1 v 1 H 8"
+       id="path4394" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 23,16 h 1 v 1 h -1"
+       id="path4392" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,16 h 1 v 1 h -1"
+       id="path4390" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.427451"
+       d="m 21,16 h 1 v 1 h -1"
+       id="path4388" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.462745"
+       d="m 20,16 h 1 v 1 h -1"
+       id="path4386" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 19,16 h 1 v 1 h -1"
+       id="path4384" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,16 h 1 v 1 h -1"
+       id="path4382" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.831373"
+       d="m 17,16 h 1 v 1 h -1"
+       id="path4380" />
+    <path
+       style="fill:#212121;fill-opacity:0.0901961"
+       d="m 16,16 h 1 v 1 h -1"
+       id="path4378" />
+    <path
+       style="fill:#232020;fill-opacity:0.376471"
+       d="m 15,16 h 1 v 1 h -1"
+       id="path4376" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.807843"
+       d="m 14,16 h 1 v 1 h -1"
+       id="path4374" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 13,16 h 1 v 1 h -1"
+       id="path4372" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 12,16 h 1 v 1 h -1"
+       id="path4370" />
+    <path
+       style="fill:#242020;fill-opacity:0.47451"
+       d="m 11,16 h 1 v 1 h -1"
+       id="path4368" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.482353"
+       d="m 10,16 h 1 v 1 h -1"
+       id="path4366" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 9,16 h 1 v 1 H 9"
+       id="path4364" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 8,16 h 1 v 1 H 8"
+       id="path4362" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 23,15 h 1 v 1 h -1"
+       id="path4360" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.964706"
+       d="m 22,15 h 1 v 1 h -1"
+       id="path4358" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,15 h 1 v 1 h -1"
+       id="path4356" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,15 h 1 v 1 h -1"
+       id="path4354" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 19,15 h 1 v 1 h -1"
+       id="path4352" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,15 h 1 v 1 h -1"
+       id="path4350" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 17,15 h 1 v 1 h -1"
+       id="path4348" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.721569"
+       d="m 16,15 h 1 v 1 h -1"
+       id="path4346" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 15,15 h 1 v 1 h -1"
+       id="path4344" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.886275"
+       d="m 14,15 h 1 v 1 h -1"
+       id="path4342" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 13,15 h 1 v 1 h -1"
+       id="path4340" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 12,15 h 1 v 1 h -1"
+       id="path4338" />
+    <path
+       style="fill:#202020;fill-opacity:0.0627451"
+       d="m 11,15 h 1 v 1 h -1"
+       id="path4336" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 10,15 h 1 v 1 h -1"
+       id="path4334" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.964706"
+       d="m 9,15 h 1 v 1 H 9"
+       id="path4332" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 8,15 h 1 v 1 H 8"
+       id="path4330" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 23,14 h 1 v 1 h -1"
+       id="path4328" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.976471"
+       d="m 22,14 h 1 v 1 h -1"
+       id="path4326" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,14 h 1 v 1 h -1"
+       id="path4324" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,14 h 1 v 1 h -1"
+       id="path4322" />
+    <path
+       style="fill:#222020;fill-opacity:0.407843"
+       d="m 19,14 h 1 v 1 h -1"
+       id="path4320" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,14 h 1 v 1 h -1"
+       id="path4318" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 16,14 h 1 v 1 h -1"
+       id="path4314" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 15,14 h 1 v 1 h -1"
+       id="path4312" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 14,14 h 1 v 1 h -1"
+       id="path4310" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 13,14 h 1 v 1 h -1"
+       id="path4308" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 12,14 h 1 v 1 h -1"
+       id="path4306" />
+    <path
+       style="fill:#202020;fill-opacity:0.0627451"
+       d="m 11,14 h 1 v 1 h -1"
+       id="path4304" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 10,14 h 1 v 1 h -1"
+       id="path4302" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.976471"
+       d="m 9,14 h 1 v 1 H 9"
+       id="path4300" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 8,14 h 1 v 1 H 8"
+       id="path4298" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 23,13 h 1 v 1 h -1"
+       id="path4296" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,13 h 1 v 1 h -1"
+       id="path4294" />
+    <path
+       style="fill:#221c1c;fill-opacity:0.145098"
+       d="m 21,13 h 1 v 1 h -1"
+       id="path4292" />
+    <path
+       style="fill:#202020;fill-opacity:0.12549"
+       d="m 20,13 h 1 v 1 h -1"
+       id="path4290" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.988235"
+       d="m 19,13 h 1 v 1 h -1"
+       id="path4288" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,13 h 1 v 1 h -1"
+       id="path4286" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.733333"
+       d="m 17,13 h 1 v 1 h -1"
+       id="path4284" />
+    <path
+       style="fill:#241d1d;fill-opacity:0.137255"
+       d="m 16,13 h 1 v 1 h -1"
+       id="path4282" />
+    <path
+       style="fill:#202020;fill-opacity:0.12549"
+       d="m 15,13 h 1 v 1 h -1"
+       id="path4280" />
+    <path
+       style="fill:#242020;fill-opacity:0.729412"
+       d="m 14,13 h 1 v 1 h -1"
+       id="path4278" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 13,13 h 1 v 1 h -1"
+       id="path4276" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 12,13 h 1 v 1 h -1"
+       id="path4274" />
+    <path
+       style="fill:#202020;fill-opacity:0.0627451"
+       d="m 11,13 h 1 v 1 h -1"
+       id="path4272" />
+    <path
+       style="fill:#221c1c;fill-opacity:0.145098"
+       d="m 10,13 h 1 v 1 h -1"
+       id="path4270" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 9,13 h 1 v 1 H 9"
+       id="path4268" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 8,13 h 1 v 1 H 8"
+       id="path4266" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.603922"
+       d="m 23,12 h 1 v 1 h -1"
+       id="path4264" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,12 h 1 v 1 h -1"
+       id="path4262" />
+    <path
+       style="fill:#242020;fill-opacity:0.505882"
+       d="m 21,12 h 1 v 1 h -1"
+       id="path4260" />
+    <path
+       style="fill:#221c1c;fill-opacity:0.176471"
+       d="m 20,12 h 1 v 1 h -1"
+       id="path4258" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,12 h 1 v 1 h -1"
+       id="path4256" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,12 h 1 v 1 h -1"
+       id="path4254" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 17,12 h 1 v 1 h -1"
+       id="path4252" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 16,12 h 1 v 1 h -1"
+       id="path4250" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.815686"
+       d="m 15,12 h 1 v 1 h -1"
+       id="path4248" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.945098"
+       d="m 14,12 h 1 v 1 h -1"
+       id="path4246" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 13,12 h 1 v 1 h -1"
+       id="path4244" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 12,12 h 1 v 1 h -1"
+       id="path4242" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.768627"
+       d="m 11,12 h 1 v 1 h -1"
+       id="path4240" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.835294"
+       d="m 10,12 h 1 v 1 h -1"
+       id="path4238" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 9,12 h 1 v 1 H 9"
+       id="path4236" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.603922"
+       d="m 8,12 h 1 v 1 H 8"
+       id="path4234" />
+    <path
+       style="fill:#212121;fill-opacity:0.211765"
+       d="m 23,11 h 1 v 1 h -1"
+       id="path4232" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,11 h 1 v 1 h -1"
+       id="path4230" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.94902"
+       d="m 21,11 h 1 v 1 h -1"
+       id="path4228" />
+    <path
+       style="fill:#241d1d;fill-opacity:0.137255"
+       d="m 20,11 h 1 v 1 h -1"
+       id="path4226" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.509804"
+       d="m 19,11 h 1 v 1 h -1"
+       id="path4224"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.972549"
+       d="m 18,11 v 0 h 1 v 0 1 h -1"
+       id="path4222"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 17,11 h 1 v 1 h -1"
+       id="path4220"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 16,11 h 1 v 1 h -1"
+       id="path4218" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 15,11 h 1 v 1 h -1"
+       id="path4216" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 14,11 h 1 v 1 h -1"
+       id="path4214" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 13,11 h 1 v 1 h -1"
+       id="path4212" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 12,11 h 1 v 1 h -1"
+       id="path4210" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 11,11 h 1 v 1 h -1"
+       id="path4208" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 10,11 h 1 v 1 h -1"
+       id="path4206" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 9,11 h 1 v 1 H 9"
+       id="path4204" />
+    <path
+       style="fill:#212121;fill-opacity:0.211765"
+       d="m 8,11 h 1 v 1 H 8"
+       id="path4202" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,10 h 1 v 1 h -1"
+       id="path4200" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.647059"
+       d="m 22,10 h 1 v 1 h -1"
+       id="path4198" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,10 h 1 v 1 h -1"
+       id="path4196" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.85098"
+       d="m 20,10 h 1 v 1 h -1"
+       id="path4194" />
+    <path
+       style="fill:#241d1d;fill-opacity:0.137255"
+       d="m 19,10 v 0 h 1 v 1 h -1 v 0"
+       id="path4192"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 18,10 h 1 v 1 h -1"
+       id="path4190"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#202020;fill-opacity:0.12549"
+       d="m 17,10 h 1 v 0 1 0 h -1"
+       id="path4188"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#202020;fill-opacity:0.12549"
+       d="m 16,10 h 1 v 1 h -1"
+       id="path4186" />
+    <path
+       style="fill:#202020;fill-opacity:0.12549"
+       d="m 15,10 h 1 v 1 h -1"
+       id="path4184" />
+    <path
+       style="fill:#202020;fill-opacity:0.12549"
+       d="m 14,10 h 1 v 1 h -1"
+       id="path4182" />
+    <path
+       style="fill:#202020;fill-opacity:0.12549"
+       d="m 13,10 h 1 v 1 h -1"
+       id="path4180" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.262745"
+       d="m 12,10 h 1 v 1 h -1"
+       id="path4178" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.921569"
+       d="m 11,10 h 1 v 1 h -1"
+       id="path4176" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 10,10 h 1 v 1 h -1"
+       id="path4174" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.647059"
+       d="m 9,10 h 1 v 1 H 9"
+       id="path4172" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 8,10 h 1 v 1 H 8"
+       id="path4170" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,9 h 1 v 1 h -1"
+       id="path4168" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 22,9 h 1 v 1 h -1"
+       id="path4166" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 21,9 h 1 v 1 h -1"
+       id="path4164" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,9 h 1 v 1 h -1"
+       id="path4162" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.94902"
+       d="m 19,9 h 1 v 1 h -1"
+       id="path4160"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#242020;fill-opacity:0.505882"
+       d="m 18,9 h 1 v 1 0 h -1 v 0"
+       id="path4158"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#221c1c;fill-opacity:0.145098"
+       d="m 17,9 h 1 v 1 h -1"
+       id="path4156"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,9 h 1 v 1 h -1"
+       id="path4154" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 15,9 h 1 v 1 h -1"
+       id="path4152" />
+    <path
+       style="fill:#222222;fill-opacity:0.14902"
+       d="m 14,9 h 1 v 1 h -1"
+       id="path4150" />
+    <path
+       style="fill:#242020;fill-opacity:0.501961"
+       d="m 13,9 h 1 v 1 h -1"
+       id="path4148" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.956863"
+       d="m 12,9 h 1 v 1 h -1"
+       id="path4146" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 11,9 h 1 v 1 h -1"
+       id="path4144" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.788235"
+       d="m 10,9 h 1 v 1 h -1"
+       id="path4142" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 9,9 h 1 v 1 H 9"
+       id="path4140" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 8,9 h 1 v 1 H 8"
+       id="path4138" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,8 h 1 v 1 h -1"
+       id="path4136" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,8 h 1 v 1 h -1"
+       id="path4134" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 21,8 h 1 v 1 h -1"
+       id="path4132" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.647059"
+       d="m 20,8 h 1 v 1 h -1"
+       id="path4130" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,8 h 1 v 1 h -1"
+       id="path4128" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,8 h 1 v 1 h -1"
+       id="path4126" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 17,8 h 1 v 1 h -1"
+       id="path4124" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.976471"
+       d="m 16,8 h 1 v 1 h -1"
+       id="path4122" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 15,8 h 1 v 1 h -1"
+       id="path4120" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 14,8 h 1 v 1 h -1"
+       id="path4118" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 13,8 h 1 v 1 h -1"
+       id="path4116" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 12,8 h 1 v 1 h -1"
+       id="path4114" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.647059"
+       d="m 11,8 h 1 v 1 h -1"
+       id="path4112" />
+    <path
+       style="fill:#242424;fill-opacity:0.054902"
+       d="m 10,8 h 1 v 1 h -1"
+       id="path4110" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 9,8 h 1 V 9 H 9"
+       id="path4108" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="M 8,8 H 9 V 9 H 8"
+       id="path4106" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,7 h 1 v 1 h -1"
+       id="path4104" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,7 h 1 v 1 h -1"
+       id="path4102" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,7 h 1 v 1 h -1"
+       id="path4100" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,7 h 1 v 1 h -1"
+       id="path4098" />
+    <path
+       style="fill:#212121;fill-opacity:0.211765"
+       d="m 19,7 h 1 v 1 h -1"
+       id="path4096" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.603922"
+       d="m 18,7 h 1 v 1 h -1"
+       id="path4094" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 17,7 h 1 v 1 h -1"
+       id="path4092" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 16,7 h 1 v 1 h -1"
+       id="path4090" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 15,7 h 1 v 1 h -1"
+       id="path4088" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 14,7 h 1 v 1 h -1"
+       id="path4086" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.603922"
+       d="m 13,7 h 1 v 1 h -1"
+       id="path4084" />
+    <path
+       style="fill:#212121;fill-opacity:0.211765"
+       d="m 12,7 h 1 v 1 h -1"
+       id="path4082" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 11,7 h 1 v 1 h -1"
+       id="path4080" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 10,7 h 1 v 1 h -1"
+       id="path4078" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 9,7 h 1 V 8 H 9"
+       id="path4076" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="M 8,7 H 9 V 8 H 8"
+       id="path4074" />
+  </g>
+  <path
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
+</svg>

--- a/mimes/64/text-rust.svg
+++ b/mimes/64/text-rust.svg
@@ -1,0 +1,4369 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3844"
+   height="64"
+   width="64"
+   version="1.1"
+   sodipodi:docname="text-rust.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview35"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:snap-page="true"
+     inkscape:zoom="4"
+     inkscape:cx="48.25"
+     inkscape:cy="39.75"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3844">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3385" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3846">
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3033"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4"
+       id="linearGradient3093"
+       y2="42.175503"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9"
+       id="linearGradient3096"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+  </defs>
+  <metadata
+     id="metadata3849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
+     id="path4160-6"
+     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none" />
+  <g
+     id="g990">
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,44.99995 h 1 v 1 h -1"
+       id="path3038" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,44.99995 h 1 v 1 h -1"
+       id="path3036" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,44.99995 h 1 v 1 h -1"
+       id="path3034" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,44.99995 h 1 v 1 h -1"
+       id="path3032" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,44.99995 h 1 v 1 h -1"
+       id="path3030" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,44.99995 h 1 v 1 h -1"
+       id="path3028" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,44.99995 h 1 v 1 h -1"
+       id="path3026" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,44.99995 h 1 v 1 h -1"
+       id="path3024" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,44.99995 h 1 v 1 h -1"
+       id="path3022" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,44.99995 h 1 v 1 h -1"
+       id="path3020" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,44.99995 h 1 v 1 h -1"
+       id="path3018" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,44.99995 h 1 v 1 h -1"
+       id="path3016" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,44.99995 h 1 v 1 h -1"
+       id="path3014" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,44.99995 h 1 v 1 h -1"
+       id="path3012" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,44.99995 h 1 v 1 h -1"
+       id="path3010" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,44.99995 h 1 v 1 h -1"
+       id="path3008" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,44.99995 h 1 v 1 h -1"
+       id="path3006" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,44.99995 h 1 v 1 h -1"
+       id="path3004" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,44.99995 h 1 v 1 h -1"
+       id="path3002" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 28,44.99995 h 1 v 1 h -1"
+       id="path3000" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 27,44.99995 h 1 v 1 h -1"
+       id="path2998" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 26,44.99995 h 1 v 1 h -1"
+       id="path2996" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 25,44.99995 h 1 v 1 h -1"
+       id="path2994" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,44.99995 h 1 v 1 h -1"
+       id="path2992" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,44.99995 h 1 v 1 h -1"
+       id="path2990" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,44.99995 h 1 v 1 h -1"
+       id="path2988" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,44.99995 h 1 v 1 h -1"
+       id="path2986" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,44.99995 h 1 v 1 h -1"
+       id="path2984" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,44.99995 h 1 v 1 h -1"
+       id="path2982" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,44.99995 h 1 v 1 h -1"
+       id="path2980" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,44.99995 h 1 v 1 h -1"
+       id="path2978" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,44.99995 h 1 v 1 h -1"
+       id="path2976" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,43.99995 h 1 v 1 h -1"
+       id="path2974" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,43.99995 h 1 v 1 h -1"
+       id="path2972" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,43.99995 h 1 v 1 h -1"
+       id="path2970" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,43.99995 h 1 v 1 h -1"
+       id="path2968" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,43.99995 h 1 v 1 h -1"
+       id="path2966" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,43.99995 h 1 v 1 h -1"
+       id="path2964" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,43.99995 h 1 v 1 h -1"
+       id="path2962" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,43.99995 h 1 v 1 h -1"
+       id="path2960" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39.25,44.24995 0.75,-0.25 v 1 h -1"
+       id="path2958" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37.75,44.24995 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path2956" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,43.99995 0.75,0.25 0.25,0.75 h -1"
+       id="path2954" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,43.99995 h 1 v 1 h -1"
+       id="path2952" />
+    <path
+       style="fill:#252020;fill-opacity:0.215686"
+       d="m 35,43.99995 h 1 v 1 h -1"
+       id="path2950" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 34,43.99995 h 1 v 1 h -1"
+       id="path2948" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 33,43.99995 h 1 v 1 h -1"
+       id="path2946" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 32,43.99995 h 1 v 1 h -1"
+       id="path2944" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 31,43.99995 h 1 v 1 h -1"
+       id="path2942" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 30,43.99995 h 1 v 1 h -1"
+       id="path2940" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 29,43.99995 h 1 v 1 h -1"
+       id="path2938" />
+    <path
+       style="fill:#252020;fill-opacity:0.215686"
+       d="m 28,43.99995 h 1 v 1 h -1"
+       id="path2936" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 27,43.99995 h 1 v 1 h -1"
+       id="path2934" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 26.25,44.24995 0.75,-0.25 v 1 h -1"
+       id="path2932" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24.75,44.24995 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path2930" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,43.99995 0.75,0.25 0.25,0.75 h -1"
+       id="path2928" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,43.99995 h 1 v 1 h -1"
+       id="path2926" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,43.99995 h 1 v 1 h -1"
+       id="path2924" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,43.99995 h 1 v 1 h -1"
+       id="path2922" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,43.99995 h 1 v 1 h -1"
+       id="path2920" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,43.99995 h 1 v 1 h -1"
+       id="path2918" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,43.99995 h 1 v 1 h -1"
+       id="path2916" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,43.99995 h 1 v 1 h -1"
+       id="path2914" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,43.99995 h 1 v 1 h -1"
+       id="path2912" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,42.99995 h 1 v 1 h -1"
+       id="path2910" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,42.99995 h 1 v 1 h -1"
+       id="path2908" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,42.99995 h 1 v 1 h -1"
+       id="path2906" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,42.99995 h 1 v 1 h -1"
+       id="path2904" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,42.99995 h 1 v 1 h -1"
+       id="path2902" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,42.99995 h 1 v 1 h -1"
+       id="path2900" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,42.99995 h 1 v 1 h -1"
+       id="path2898" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,42.99995 h 1 v 1 h -1"
+       id="path2896" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38.75,43.24995 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path2894" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 38,43 h 1 v 1 h -1"
+       id="path2892"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="M 37,42.99995 38,43 v 0 1 0 l -1,-5e-5"
+       id="path2890"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#242020;fill-opacity:0.278431"
+       d="m 36,42.99995 h 1 v 1 h -1"
+       id="path2888" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 35,42.99995 h 1 v 1 h -1"
+       id="path2886" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,42.99995 h 1 v 1 h -1"
+       id="path2884" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.713725"
+       d="m 33,42.99995 h 1 v 1 h -1"
+       id="path2882" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,42.99995 h 1 v 1 h -1"
+       id="path2880" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 31,42.99995 h 1 v 1 h -1"
+       id="path2878" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.717647"
+       d="m 30,42.99995 h 1 v 1 h -1"
+       id="path2876" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,42.99995 h 1 v 1 h -1"
+       id="path2874" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 28,42.99995 h 1 v 1 h -1"
+       id="path2872" />
+    <path
+       style="fill:#242020;fill-opacity:0.278431"
+       d="m 27,42.99995 h 1 v 1 h -1"
+       id="path2870" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 26,43 v 0 l 1,-5e-5 v 1 L 26,44 c 0.77017,0.77021 -1.607115,-1.606992 0,0"
+       id="path2868"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 25,43 h 1 v 1 h -1"
+       id="path2866"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,42.99995 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path2864" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,42.99995 h 1 v 1 h -1"
+       id="path2862" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,42.99995 h 1 v 1 h -1"
+       id="path2860" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,42.99995 h 1 v 1 h -1"
+       id="path2858" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,42.99995 h 1 v 1 h -1"
+       id="path2856" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,42.99995 h 1 v 1 h -1"
+       id="path2854" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,42.99995 h 1 v 1 h -1"
+       id="path2852" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,42.99995 h 1 v 1 h -1"
+       id="path2850" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,42.99995 h 1 v 1 h -1"
+       id="path2848" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,41.99995 h 1 v 1 h -1"
+       id="path2846" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,41.99995 h 1 v 1 h -1"
+       id="path2844" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,41.99995 h 1 v 1 h -1"
+       id="path2842" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,41.99995 h 1 v 1 h -1"
+       id="path2840" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,41.99995 h 1 v 1 h -1"
+       id="path2838" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,41.99995 h 1 v 1 h -1"
+       id="path2836" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,41.99995 h 1 v 1 h -1"
+       id="path2834" />
+    <path
+       style="fill:#242121;fill-opacity:0.27451"
+       d="m 40,41.99995 h 1 v 1 h -1"
+       id="path2832" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.360784"
+       d="m 39,41.99995 h 1 v 1 L 39,43"
+       id="path2830"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.235294"
+       d="m 38,41.99995 h 1 V 43 43 h -1 v 0"
+       id="path2828"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,41.99995 h 1 V 43 l -1,-5e-5"
+       id="path2826"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,41.99995 h 1 v 1 h -1"
+       id="path2824" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,41.99995 h 1 v 1 h -1"
+       id="path2822" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,41.99995 h 1 v 1 h -1"
+       id="path2820" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,41.99995 h 1 v 1 h -1"
+       id="path2818" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,41.99995 h 1 v 1 h -1"
+       id="path2816" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,41.99995 h 1 v 1 h -1"
+       id="path2814" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,41.99995 h 1 v 1 h -1"
+       id="path2812" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,41.99995 h 1 v 1 h -1"
+       id="path2810" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,41.99995 h 1 v 1 h -1"
+       id="path2808" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,41.99995 h 1 v 1 h -1"
+       id="path2806" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,41.99995 h 1 v 1 L 26,43"
+       id="path2804"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.235294"
+       d="m 25,41.99995 h 1 V 43 43 h -1 v 0"
+       id="path2802"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.360784"
+       d="m 24,41.99995 h 1 V 43 l -1,-5e-5"
+       id="path2800"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#242121;fill-opacity:0.27451"
+       d="m 23,41.99995 h 1 v 1 h -1"
+       id="path2798" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,41.99995 h 1 v 1 h -1"
+       id="path2796" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,41.99995 h 1 v 1 h -1"
+       id="path2794" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,41.99995 h 1 v 1 h -1"
+       id="path2792" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,41.99995 h 1 v 1 h -1"
+       id="path2790" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,41.99995 h 1 v 1 h -1"
+       id="path2788" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,41.99995 h 1 v 1 h -1"
+       id="path2786" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,41.99995 h 1 v 1 h -1"
+       id="path2784" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,40.99995 h 1 v 1 h -1"
+       id="path2782" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,40.99995 h 1 v 1 h -1"
+       id="path2780" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,40.99995 h 1 v 1 h -1"
+       id="path2778" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,40.99995 h 1 v 1 h -1"
+       id="path2776" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,40.99995 h 1 v 1 h -1"
+       id="path2774" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,40.99995 h 1 v 1 h -1"
+       id="path2772" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,40.99995 h 1 v 1 h -1"
+       id="path2770" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 40,40.99995 h 1 v 1 h -1"
+       id="path2768" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,40.99995 h 1 v 1 h -1"
+       id="path2766" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 38,40.99995 h 1 v 1 h -1"
+       id="path2764" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,40.99995 h 1 v 1 h -1"
+       id="path2762" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,40.99995 h 1 v 1 h -1"
+       id="path2760" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,40.99995 h 1 v 1 h -1"
+       id="path2758" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,40.99995 h 1 v 1 h -1"
+       id="path2756" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,40.99995 h 1 v 1 h -1"
+       id="path2754" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,40.99995 h 1 v 1 h -1"
+       id="path2752" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,40.99995 h 1 v 1 h -1"
+       id="path2750" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,40.99995 h 1 v 1 h -1"
+       id="path2748" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,40.99995 h 1 v 1 h -1"
+       id="path2746" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,40.99995 h 1 v 1 h -1"
+       id="path2744" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,40.99995 h 1 v 1 h -1"
+       id="path2742" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,40.99995 h 1 v 1 h -1"
+       id="path2740" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 25,40.99995 h 1 v 1 h -1"
+       id="path2738" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,40.99995 h 1 v 1 h -1"
+       id="path2736" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 23,40.99995 h 1 v 1 h -1"
+       id="path2734" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,40.99995 h 1 v 1 h -1"
+       id="path2732" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,40.99995 h 1 v 1 h -1"
+       id="path2730" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,40.99995 h 1 v 1 h -1"
+       id="path2728" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,40.99995 h 1 v 1 h -1"
+       id="path2726" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,40.99995 h 1 v 1 h -1"
+       id="path2724" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,40.99995 h 1 v 1 h -1"
+       id="path2722" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,40.99995 h 1 v 1 h -1"
+       id="path2720" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,39.99995 h 1 v 1 h -1"
+       id="path2718" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,39.99995 h 1 v 1 h -1"
+       id="path2716" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,39.99995 h 1 v 1 h -1"
+       id="path2714" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,39.99995 h 1 v 1 h -1"
+       id="path2712" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,39.99995 h 1 v 1 h -1"
+       id="path2710" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 42,39.99995 h 1 v 1 h -1"
+       id="path2708" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 41,39.99995 h 1 v 1 h -1"
+       id="path2706" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 40,39.99995 h 1 v 1 h -1"
+       id="path2704" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,39.99995 h 1 v 1 h -1"
+       id="path2702" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 38,39.99995 h 1 v 1 h -1"
+       id="path2700" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,39.99995 h 1 v 1 h -1"
+       id="path2698" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,39.99995 h 1 v 1 h -1"
+       id="path2696" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.756863"
+       d="m 35,39.99995 h 1 v 1 h -1"
+       id="path2694" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 34,39.99995 h 1 v 1 h -1"
+       id="path2692" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.286275"
+       d="m 33,39.99995 h 1 v 1 h -1"
+       id="path2690" />
+    <path
+       style="fill:#252020;fill-opacity:0.188235"
+       d="m 32,39.99995 h 1 v 1 h -1"
+       id="path2688" />
+    <path
+       style="fill:#252020;fill-opacity:0.188235"
+       d="m 31,39.99995 h 1 v 1 h -1"
+       id="path2686" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.286275"
+       d="m 30,39.99995 h 1 v 1 h -1"
+       id="path2684" />
+    <path
+       style="fill:#222020;fill-opacity:0.470588"
+       d="m 29,39.99995 h 1 v 1 h -1"
+       id="path2682" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.756863"
+       d="m 28,39.99995 h 1 v 1 h -1"
+       id="path2680" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,39.99995 h 1 v 1 h -1"
+       id="path2678" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,39.99995 h 1 v 1 h -1"
+       id="path2676" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,39.99995 h 1 v 1 h -1"
+       id="path2674" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,39.99995 h 1 v 1 h -1"
+       id="path2672" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 23,39.99995 h 1 v 1 h -1"
+       id="path2670" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 22,39.99995 h 1 v 1 h -1"
+       id="path2668" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 21,39.99995 h 1 v 1 h -1"
+       id="path2666" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,39.99995 h 1 v 1 h -1"
+       id="path2664" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,39.99995 h 1 v 1 h -1"
+       id="path2662" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,39.99995 h 1 v 1 h -1"
+       id="path2660" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,39.99995 h 1 v 1 h -1"
+       id="path2658" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,39.99995 h 1 v 1 h -1"
+       id="path2656" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,38.99995 h 1 v 1 h -1"
+       id="path2654" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,38.99995 h 1 v 1 h -1"
+       id="path2652" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,38.99995 h 1 v 1 h -1"
+       id="path2650" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,38.99995 h 1 v 1 h -1"
+       id="path2648" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,38.99995 h 1 v 1 h -1"
+       id="path2646" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 42,38.99995 h 1 v 1 h -1"
+       id="path2644" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,38.99995 h 1 v 1 h -1"
+       id="path2642" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,38.99995 h 1 v 1 h -1"
+       id="path2640" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.733333"
+       d="m 39,38.99995 h 1 v 1 h -1"
+       id="path2638" />
+    <path
+       style="fill:#2b2b2b;fill-opacity:0.0235294"
+       d="m 38,38.99995 h 1 v 1 h -1"
+       id="path2636" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.811765"
+       d="m 37,38.99995 h 1 v 1 h -1"
+       id="path2634" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.45098"
+       d="m 36,38.99995 h 1 v 1 h -1"
+       id="path2632" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,38.99995 h 1 v 1 h -1"
+       id="path2630" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,38.99995 h 1 v 1 h -1"
+       id="path2628" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,38.99995 h 1 v 1 h -1"
+       id="path2626" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,38.99995 h 1 v 1 h -1"
+       id="path2624" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,38.99995 h 1 v 1 h -1"
+       id="path2622" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,38.99995 h 1 v 1 h -1"
+       id="path2620" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,38.99995 h 1 v 1 h -1"
+       id="path2618" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 28,38.99995 h 1 v 1 h -1"
+       id="path2616" />
+    <path
+       style="fill:#232020;fill-opacity:0.376471"
+       d="m 27,38.99995 h 1 v 1 h -1"
+       id="path2614" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.901961"
+       d="m 26,38.99995 h 1 v 1 h -1"
+       id="path2612" />
+    <path
+       style="fill:#202020;fill-opacity:0.0627451"
+       d="m 25,38.99995 h 1 v 1 h -1"
+       id="path2610" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 24,38.99995 h 1 v 1 h -1"
+       id="path2608" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,38.99995 h 1 v 1 h -1"
+       id="path2606" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,38.99995 h 1 v 1 h -1"
+       id="path2604" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 21,38.99995 h 1 v 1 h -1"
+       id="path2602" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,38.99995 h 1 v 1 h -1"
+       id="path2600" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,38.99995 h 1 v 1 h -1"
+       id="path2598" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,38.99995 h 1 v 1 h -1"
+       id="path2596" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,38.99995 h 1 v 1 h -1"
+       id="path2594" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,38.99995 h 1 v 1 h -1"
+       id="path2592" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,37.99995 h 1 v 1 h -1"
+       id="path2590" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,37.99995 h 1 v 1 h -1"
+       id="path2588" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,37.99995 h 1 v 1 h -1"
+       id="path2586" />
+    <path
+       style="fill:#242121;fill-opacity:0.27451"
+       d="m 44,37.99995 h 1 v 1 h -1"
+       id="path2584" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 43,37.99995 h 1 v 1 h -1"
+       id="path2582" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 42,37.99995 h 1 v 1 h -1"
+       id="path2580" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,37.99995 h 1 v 1 h -1"
+       id="path2578" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,37.99995 h 1 v 1 h -1"
+       id="path2576" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.886275"
+       d="m 39,37.99995 h 1 v 1 h -1"
+       id="path2574" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.423529"
+       d="m 38,37.99995 h 1 v 1 h -1"
+       id="path2572" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.937255"
+       d="m 37,37.99995 h 1 v 1 h -1"
+       id="path2570" />
+    <path
+       style="fill:#252020;fill-opacity:0.215686"
+       d="m 36,37.99995 h 1 v 1 h -1"
+       id="path2568" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,37.99995 h 1 v 1 h -1"
+       id="path2566" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,37.99995 h 1 v 1 h -1"
+       id="path2564" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,37.99995 h 1 v 1 h -1"
+       id="path2562" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,37.99995 h 1 v 1 h -1"
+       id="path2560" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,37.99995 h 1 v 1 h -1"
+       id="path2558" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,37.99995 h 1 v 1 h -1"
+       id="path2556" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,37.99995 h 1 v 1 h -1"
+       id="path2554" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 28,37.99995 h 1 v 1 h -1"
+       id="path2552" />
+    <path
+       style="fill:#271f1f;fill-opacity:0.129412"
+       d="m 27,37.99995 h 1 v 1 h -1"
+       id="path2550" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.964706"
+       d="m 26,37.99995 h 1 v 1 h -1"
+       id="path2548" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.392157"
+       d="m 25,37.99995 h 1 v 1 h -1"
+       id="path2546" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.819608"
+       d="m 24,37.99995 h 1 v 1 h -1"
+       id="path2544" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,37.99995 h 1 v 1 h -1"
+       id="path2542" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,37.99995 h 1 v 1 h -1"
+       id="path2540" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 21,37.99995 h 1 v 1 h -1"
+       id="path2538" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 20,37.99995 h 1 v 1 h -1"
+       id="path2536" />
+    <path
+       style="fill:#242121;fill-opacity:0.27451"
+       d="m 19,37.99995 h 1 v 1 h -1"
+       id="path2534" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,37.99995 h 1 v 1 h -1"
+       id="path2532" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,37.99995 h 1 v 1 h -1"
+       id="path2530" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,37.99995 h 1 v 1 h -1"
+       id="path2528" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,36.99995 h 1 v 1 h -1"
+       id="path2526" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46.25,37.24995 0.75,-0.25 v 1 h -1"
+       id="path2524" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44.75,37.24995 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path2522" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.360784"
+       d="M 44,36.99995 45,37 v 0.99995 h -1"
+       id="path2520"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,36.99995 h 1 v 1 h -1"
+       id="path2518" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,36.99995 h 1 v 1 h -1"
+       id="path2516" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,36.99995 h 1 v 1 h -1"
+       id="path2514" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.964706"
+       d="m 40,36.99995 h 1 v 1 h -1"
+       id="path2512" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 39,36.99995 h 1 v 1 h -1"
+       id="path2510" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.733333"
+       d="m 38,36.99995 h 1 v 1 h -1"
+       id="path2508" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.772549"
+       d="m 37,36.99995 h 1 v 1 h -1"
+       id="path2506" />
+    <path
+       style="fill:#2b2b2b;fill-opacity:0.0235294"
+       d="m 36,36.99995 h 1 v 1 h -1"
+       id="path2504" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,36.99995 h 1 v 1 h -1"
+       id="path2502" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,36.99995 h 1 v 1 h -1"
+       id="path2500" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,36.99995 h 1 v 1 h -1"
+       id="path2498" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,36.99995 h 1 v 1 h -1"
+       id="path2496" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,36.99995 h 1 v 1 h -1"
+       id="path2494" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,36.99995 h 1 v 1 h -1"
+       id="path2492" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,36.99995 h 1 v 1 h -1"
+       id="path2490" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 28,36.99995 h 1 v 1 h -1"
+       id="path2488" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 27,36.99995 h 1 v 1 h -1"
+       id="path2486" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.741176"
+       d="m 26,36.99995 h 1 v 1 h -1"
+       id="path2484" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.796078"
+       d="m 25,36.99995 h 1 v 1 h -1"
+       id="path2482" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 24,36.99995 h 1 v 1 h -1"
+       id="path2480" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.960784"
+       d="m 23,36.99995 h 1 v 1 h -1"
+       id="path2478" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,36.99995 h 1 v 1 h -1"
+       id="path2476" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,36.99995 h 1 v 1 h -1"
+       id="path2474" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,36.99995 h 1 v 1 h -1"
+       id="path2472" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.360784"
+       d="m 19,37 1,-5e-5 v 1 h -1"
+       id="path2470"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17.75,37.24995 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path2468" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,36.99995 0.75,0.25 0.25,0.75 h -1"
+       id="path2466" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,36.99995 h 1 v 1 h -1"
+       id="path2464" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,35.99995 h 1 v 1 h -1"
+       id="path2462" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45.75,36.24995 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path2460" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 45,36 h 1 v 1 h -1"
+       id="path2458"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.235294"
+       d="M 44,35.99995 45,36 v 0 1 0 l -1,-5e-5"
+       id="path2456"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 43,35.99995 h 1 v 1 h -1"
+       id="path2454" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,35.99995 h 1 v 1 h -1"
+       id="path2452" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,35.99995 h 1 v 1 h -1"
+       id="path2450" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.713725"
+       d="m 40,35.99995 h 1 v 1 h -1"
+       id="path2448" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,35.99995 h 1 v 1 h -1"
+       id="path2446" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,35.99995 h 1 v 1 h -1"
+       id="path2444" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,35.99995 h 1 v 1 h -1"
+       id="path2442" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,35.99995 h 1 v 1 h -1"
+       id="path2440" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,35.99995 h 1 v 1 h -1"
+       id="path2438" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,35.99995 h 1 v 1 h -1"
+       id="path2436" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,35.99995 h 1 v 1 h -1"
+       id="path2434" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,35.99995 h 1 v 1 h -1"
+       id="path2432" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,35.99995 h 1 v 1 h -1"
+       id="path2430" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,35.99995 h 1 v 1 h -1"
+       id="path2428" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,35.99995 h 1 v 1 h -1"
+       id="path2426" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 28,35.99995 h 1 v 1 h -1"
+       id="path2424" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 27,35.99995 h 1 v 1 h -1"
+       id="path2422" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 26,35.99995 h 1 v 1 h -1"
+       id="path2420" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 25,35.99995 h 1 v 1 h -1"
+       id="path2418" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,35.99995 h 1 v 1 h -1"
+       id="path2416" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.713725"
+       d="m 23,35.99995 h 1 v 1 h -1"
+       id="path2414" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,35.99995 h 1 v 1 h -1"
+       id="path2412" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,35.99995 h 1 v 1 h -1"
+       id="path2410" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 20,35.99995 h 1 v 1 h -1"
+       id="path2408" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.235294"
+       d="m 19,36 v 0 l 1,-5e-5 v 1 L 19,37 v 0"
+       id="path2406"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 18,36 h 1 v 1 h -1"
+       id="path2404"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,35.99995 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path2402" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,35.99995 h 1 v 1 h -1"
+       id="path2400" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,34.99995 h 1 v 1 h -1"
+       id="path2398" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,34.99995 h 1 v 1 l -0.75,-0.25"
+       id="path2396" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 45,34.99995 h 1 v 1 5e-5 h -1 v 0"
+       id="path2394"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,34.99995 h 1 V 36 l -1,-5e-5"
+       id="path2392"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,34.99995 h 1 v 1 h -1"
+       id="path2390" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,34.99995 h 1 v 1 h -1"
+       id="path2388" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,34.99995 h 1 v 1 h -1"
+       id="path2386" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,34.99995 h 1 v 1 h -1"
+       id="path2384" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,34.99995 h 1 v 1 h -1"
+       id="path2382" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,34.99995 h 1 v 1 h -1"
+       id="path2380" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,34.99995 h 1 v 1 h -1"
+       id="path2378" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,34.99995 h 1 v 1 h -1"
+       id="path2376" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.945098"
+       d="m 35,34.99995 h 1 v 1 h -1"
+       id="path2374" />
+    <path
+       style="fill:#271f1f;fill-opacity:0.129412"
+       d="m 34,34.99995 h 1 v 1 h -1"
+       id="path2372" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,34.99995 h 1 v 1 h -1"
+       id="path2370" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,34.99995 h 1 v 1 h -1"
+       id="path2368" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,34.99995 h 1 v 1 h -1"
+       id="path2366" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,34.99995 h 1 v 1 h -1"
+       id="path2364" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,34.99995 h 1 v 1 h -1"
+       id="path2362" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,34.99995 h 1 v 1 h -1"
+       id="path2360" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,34.99995 h 1 v 1 h -1"
+       id="path2358" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,34.99995 h 1 v 1 h -1"
+       id="path2356" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,34.99995 h 1 v 1 h -1"
+       id="path2354" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,34.99995 h 1 v 1 h -1"
+       id="path2352" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,34.99995 h 1 v 1 h -1"
+       id="path2350" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,34.99995 h 1 v 1 h -1"
+       id="path2348" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,34.99995 h 1 v 1 h -1"
+       id="path2346" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,34.99995 h 1 v 1 h -1"
+       id="path2344" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,34.99995 h 1 v 1 L 19,36"
+       id="path2342"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 18,34.99995 h 1 V 36 36 h -1 v 0"
+       id="path2340"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,34.99995 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path2338" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,34.99995 h 1 v 1 h -1"
+       id="path2336" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,33.99995 h 1 v 1 h -1"
+       id="path2334" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,33.99995 h 1 v 1 h -1"
+       id="path2332" />
+    <path
+       style="fill:#242020;fill-opacity:0.278431"
+       d="m 45,33.99995 h 1 v 1 h -1"
+       id="path2330" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,33.99995 h 1 v 1 h -1"
+       id="path2328" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,33.99995 h 1 v 1 h -1"
+       id="path2326" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,33.99995 h 1 v 1 h -1"
+       id="path2324" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,33.99995 h 1 v 1 h -1"
+       id="path2322" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,33.99995 h 1 v 1 h -1"
+       id="path2320" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,33.99995 h 1 v 1 h -1"
+       id="path2318" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,33.99995 h 1 v 1 h -1"
+       id="path2316" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,33.99995 h 1 v 1 h -1"
+       id="path2314" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,33.99995 h 1 v 1 h -1"
+       id="path2312" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,33.99995 h 1 v 1 h -1"
+       id="path2310" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,33.99995 h 1 v 1 h -1"
+       id="path2308" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,33.99995 h 1 v 1 h -1"
+       id="path2306" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,33.99995 h 1 v 1 h -1"
+       id="path2304" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,33.99995 h 1 v 1 h -1"
+       id="path2302" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,33.99995 h 1 v 1 h -1"
+       id="path2300" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,33.99995 h 1 v 1 h -1"
+       id="path2298" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,33.99995 h 1 v 1 h -1"
+       id="path2296" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,33.99995 h 1 v 1 h -1"
+       id="path2294" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,33.99995 h 1 v 1 h -1"
+       id="path2292" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,33.99995 h 1 v 1 h -1"
+       id="path2290" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,33.99995 h 1 v 1 h -1"
+       id="path2288" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,33.99995 h 1 v 1 h -1"
+       id="path2286" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,33.99995 h 1 v 1 h -1"
+       id="path2284" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,33.99995 h 1 v 1 h -1"
+       id="path2282" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,33.99995 h 1 v 1 h -1"
+       id="path2280" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,33.99995 h 1 v 1 h -1"
+       id="path2278" />
+    <path
+       style="fill:#242020;fill-opacity:0.278431"
+       d="m 18,33.99995 h 1 v 1 h -1"
+       id="path2276" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,33.99995 h 1 v 1 h -1"
+       id="path2274" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,33.99995 h 1 v 1 h -1"
+       id="path2272" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,32.99995 h 1 v 1 h -1"
+       id="path2270" />
+    <path
+       style="fill:#252020;fill-opacity:0.215686"
+       d="m 46,32.99995 h 1 v 1 h -1"
+       id="path2268" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 45,32.99995 h 1 v 1 h -1"
+       id="path2266" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,32.99995 h 1 v 1 h -1"
+       id="path2264" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,32.99995 h 1 v 1 h -1"
+       id="path2262" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,32.99995 h 1 v 1 h -1"
+       id="path2260" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,32.99995 h 1 v 1 h -1"
+       id="path2258" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,32.99995 h 1 v 1 h -1"
+       id="path2256" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,32.99995 h 1 v 1 h -1"
+       id="path2254" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,32.99995 h 1 v 1 h -1"
+       id="path2252" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,32.99995 h 1 v 1 h -1"
+       id="path2250" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,32.99995 h 1 v 1 h -1"
+       id="path2248" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,32.99995 h 1 v 1 h -1"
+       id="path2246" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.741176"
+       d="m 34,32.99995 h 1 v 1 h -1"
+       id="path2244" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,32.99995 h 1 v 1 h -1"
+       id="path2242" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,32.99995 h 1 v 1 h -1"
+       id="path2240" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,32.99995 h 1 v 1 h -1"
+       id="path2238" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,32.99995 h 1 v 1 h -1"
+       id="path2236" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,32.99995 h 1 v 1 h -1"
+       id="path2234" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,32.99995 h 1 v 1 h -1"
+       id="path2232" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,32.99995 h 1 v 1 h -1"
+       id="path2230" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,32.99995 h 1 v 1 h -1"
+       id="path2228" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,32.99995 h 1 v 1 h -1"
+       id="path2226" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,32.99995 h 1 v 1 h -1"
+       id="path2224" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,32.99995 h 1 v 1 h -1"
+       id="path2222" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,32.99995 h 1 v 1 h -1"
+       id="path2220" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,32.99995 h 1 v 1 h -1"
+       id="path2218" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,32.99995 h 1 v 1 h -1"
+       id="path2216" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,32.99995 h 1 v 1 h -1"
+       id="path2214" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 18,32.99995 h 1 v 1 h -1"
+       id="path2212" />
+    <path
+       style="fill:#252020;fill-opacity:0.215686"
+       d="m 17,32.99995 h 1 v 1 h -1"
+       id="path2210" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,32.99995 h 1 v 1 h -1"
+       id="path2208" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,31.99995 h 1 v 1 h -1"
+       id="path2206" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 46,31.99995 h 1 v 1 h -1"
+       id="path2204" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,31.99995 h 1 v 1 h -1"
+       id="path2202" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,31.99995 h 1 v 1 h -1"
+       id="path2200" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,31.99995 h 1 v 1 h -1"
+       id="path2198" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,31.99995 h 1 v 1 h -1"
+       id="path2196" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.756863"
+       d="m 41,31.99995 h 1 v 1 h -1"
+       id="path2194" />
+    <path
+       style="fill:#222222;fill-opacity:0.117647"
+       d="m 40,31.99995 h 1 v 1 h -1"
+       id="path2192" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.337255"
+       d="m 39,31.99995 h 1 v 1 h -1"
+       id="path2190" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,31.99995 h 1 v 1 h -1"
+       id="path2188" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,31.99995 h 1 v 1 h -1"
+       id="path2186" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,31.99995 h 1 v 1 h -1"
+       id="path2184" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,31.99995 h 1 v 1 h -1"
+       id="path2182" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.94902"
+       d="m 34,31.99995 h 1 v 1 h -1"
+       id="path2180" />
+    <path
+       style="fill:#242424;fill-opacity:0.027451"
+       d="m 33,31.99995 h 1 v 1 h -1"
+       id="path2178" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,31.99995 h 1 v 1 h -1"
+       id="path2176" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,31.99995 h 1 v 1 h -1"
+       id="path2174" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,31.99995 h 1 v 1 h -1"
+       id="path2172" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,31.99995 h 1 v 1 h -1"
+       id="path2170" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,31.99995 h 1 v 1 h -1"
+       id="path2168" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,31.99995 h 1 v 1 h -1"
+       id="path2166" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,31.99995 h 1 v 1 h -1"
+       id="path2164" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,31.99995 h 1 v 1 h -1"
+       id="path2162" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,31.99995 h 1 v 1 h -1"
+       id="path2160" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,31.99995 h 1 v 1 h -1"
+       id="path2158" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,31.99995 h 1 v 1 h -1"
+       id="path2156" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,31.99995 h 1 v 1 h -1"
+       id="path2154" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,31.99995 h 1 v 1 h -1"
+       id="path2152" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,31.99995 h 1 v 1 h -1"
+       id="path2150" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,31.99995 h 1 v 1 h -1"
+       id="path2148" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 17,31.99995 h 1 v 1 h -1"
+       id="path2146" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,31.99995 h 1 v 1 h -1"
+       id="path2144" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,30.99995 h 1 v 1 h -1"
+       id="path2142" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 46,30.99995 h 1 v 1 h -1"
+       id="path2140" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.717647"
+       d="m 45,30.99995 h 1 v 1 h -1"
+       id="path2138" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,30.99995 h 1 v 1 h -1"
+       id="path2136" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,30.99995 h 1 v 1 h -1"
+       id="path2134" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,30.99995 h 1 v 1 h -1"
+       id="path2132" />
+    <path
+       style="fill:#232020;fill-opacity:0.403922"
+       d="m 41,30.99995 h 1 v 1 h -1"
+       id="path2130" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,30.99995 h 1 v 1 h -1"
+       id="path2128" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,30.99995 h 1 v 1 h -1"
+       id="path2126" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.901961"
+       d="m 38,30.99995 h 1 v 1 h -1"
+       id="path2124" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,30.99995 h 1 v 1 h -1"
+       id="path2122" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,30.99995 h 1 v 1 h -1"
+       id="path2120" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,30.99995 h 1 v 1 h -1"
+       id="path2118" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,30.99995 h 1 v 1 h -1"
+       id="path2116" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.580392"
+       d="m 33,30.99995 h 1 v 1 h -1"
+       id="path2114" />
+    <path
+       style="fill:#212121;fill-opacity:0.0901961"
+       d="m 32,30.99995 h 1 v 1 h -1"
+       id="path2112" />
+    <path
+       style="fill:#202020;fill-opacity:0.0627451"
+       d="m 31,30.99995 h 1 v 1 h -1"
+       id="path2110" />
+    <path
+       style="fill:#202020;fill-opacity:0.0627451"
+       d="m 30,30.99995 h 1 v 1 h -1"
+       id="path2108" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,30.99995 h 1 v 1 h -1"
+       id="path2106" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,30.99995 h 1 v 1 h -1"
+       id="path2104" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,30.99995 h 1 v 1 h -1"
+       id="path2102" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,30.99995 h 1 v 1 h -1"
+       id="path2100" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,30.99995 h 1 v 1 h -1"
+       id="path2098" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,30.99995 h 1 v 1 h -1"
+       id="path2096" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,30.99995 h 1 v 1 h -1"
+       id="path2094" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,30.99995 h 1 v 1 h -1"
+       id="path2092" />
+    <path
+       style="fill:#221d1d;fill-opacity:0.203922"
+       d="m 21,30.99995 h 1 v 1 h -1"
+       id="path2090" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,30.99995 h 1 v 1 h -1"
+       id="path2088" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,30.99995 h 1 v 1 h -1"
+       id="path2086" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.717647"
+       d="m 18,30.99995 h 1 v 1 h -1"
+       id="path2084" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 17,30.99995 h 1 v 1 h -1"
+       id="path2082" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,30.99995 h 1 v 1 h -1"
+       id="path2080" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,29.99995 h 1 v 1 h -1"
+       id="path2078" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 46,29.99995 h 1 v 1 h -1"
+       id="path2076" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,29.99995 h 1 v 1 h -1"
+       id="path2074" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,29.99995 h 1 v 1 h -1"
+       id="path2072" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,29.99995 h 1 v 1 h -1"
+       id="path2070" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.356863"
+       d="m 42,29.99995 h 1 v 1 h -1"
+       id="path2068" />
+    <path
+       style="fill:#232323;fill-opacity:0.113725"
+       d="m 41,29.99995 h 1 v 1 h -1"
+       id="path2066" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,29.99995 h 1 v 1 h -1"
+       id="path2064" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,29.99995 h 1 v 1 h -1"
+       id="path2062" />
+    <path
+       style="fill:#242020;fill-opacity:0.443137"
+       d="m 38,29.99995 h 1 v 1 h -1"
+       id="path2060" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,29.99995 h 1 v 1 h -1"
+       id="path2058" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,29.99995 h 1 v 1 h -1"
+       id="path2056" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,29.99995 h 1 v 1 h -1"
+       id="path2054" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,29.99995 h 1 v 1 h -1"
+       id="path2052" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,29.99995 h 1 v 1 h -1"
+       id="path2050" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,29.99995 h 1 v 1 h -1"
+       id="path2048" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,29.99995 h 1 v 1 h -1"
+       id="path2046" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,29.99995 h 1 v 1 h -1"
+       id="path2044" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,29.99995 h 1 v 1 h -1"
+       id="path2042" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,29.99995 h 1 v 1 h -1"
+       id="path2040" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,29.99995 h 1 v 1 h -1"
+       id="path2038" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,29.99995 h 1 v 1 h -1"
+       id="path2036" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,29.99995 h 1 v 1 h -1"
+       id="path2034" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,29.99995 h 1 v 1 h -1"
+       id="path2032" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,29.99995 h 1 v 1 h -1"
+       id="path2030" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,29.99995 h 1 v 1 h -1"
+       id="path2028" />
+    <path
+       style="fill:#261c1c;fill-opacity:0.105882"
+       d="m 21,29.99995 h 1 v 1 h -1"
+       id="path2026" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,29.99995 h 1 v 1 h -1"
+       id="path2024" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,29.99995 h 1 v 1 h -1"
+       id="path2022" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,29.99995 h 1 v 1 h -1"
+       id="path2020" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 17,29.99995 h 1 v 1 h -1"
+       id="path2018" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,29.99995 h 1 v 1 h -1"
+       id="path2016" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,28.99995 h 1 v 1 h -1"
+       id="path2014" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 46,28.99995 h 1 v 1 h -1"
+       id="path2012" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,28.99995 h 1 v 1 h -1"
+       id="path2010" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,28.99995 h 1 v 1 h -1"
+       id="path2008" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,28.99995 h 1 v 1 h -1"
+       id="path2006" />
+    <path
+       style="fill:#242424;fill-opacity:0.0823529"
+       d="m 42,28.99995 h 1 v 1 h -1"
+       id="path2004" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,28.99995 h 1 v 1 h -1"
+       id="path2002" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,28.99995 h 1 v 1 h -1"
+       id="path2000" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,28.99995 h 1 v 1 h -1"
+       id="path1998" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 38,28.99995 h 1 v 1 h -1"
+       id="path1996" />
+    <path
+       style="fill:#222020;fill-opacity:0.698039"
+       d="m 37,28.99995 h 1 v 1 h -1"
+       id="path1994" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,28.99995 h 1 v 1 h -1"
+       id="path1992" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,28.99995 h 1 v 1 h -1"
+       id="path1990" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,28.99995 h 1 v 1 h -1"
+       id="path1988" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,28.99995 h 1 v 1 h -1"
+       id="path1986" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,28.99995 h 1 v 1 h -1"
+       id="path1984" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,28.99995 h 1 v 1 h -1"
+       id="path1982" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,28.99995 h 1 v 1 h -1"
+       id="path1980" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,28.99995 h 1 v 1 h -1"
+       id="path1978" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,28.99995 h 1 v 1 h -1"
+       id="path1976" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,28.99995 h 1 v 1 h -1"
+       id="path1974" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,28.99995 h 1 v 1 h -1"
+       id="path1972" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,28.99995 h 1 v 1 h -1"
+       id="path1970" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,28.99995 h 1 v 1 h -1"
+       id="path1968" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,28.99995 h 1 v 1 h -1"
+       id="path1966" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,28.99995 h 1 v 1 h -1"
+       id="path1964" />
+    <path
+       style="fill:#232323;fill-opacity:0.0862745"
+       d="m 21,28.99995 h 1 v 1 h -1"
+       id="path1962" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,28.99995 h 1 v 1 h -1"
+       id="path1960" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,28.99995 h 1 v 1 h -1"
+       id="path1958" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 18,28.99995 h 1 v 1 h -1"
+       id="path1956" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 17,28.99995 h 1 v 1 h -1"
+       id="path1954" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,28.99995 h 1 v 1 h -1"
+       id="path1952" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,27.99995 h 1 v 1 h -1"
+       id="path1950" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 46,27.99995 h 1 v 1 h -1"
+       id="path1948" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.717647"
+       d="m 45,27.99995 h 1 v 1 h -1"
+       id="path1946" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,27.99995 h 1 v 1 h -1"
+       id="path1944" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,27.99995 h 1 v 1 h -1"
+       id="path1942" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.690196"
+       d="m 42,27.99995 h 1 v 1 h -1"
+       id="path1940" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.231373"
+       d="m 41,27.99995 h 1 v 1 h -1"
+       id="path1938" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,27.99995 h 1 v 1 h -1"
+       id="path1936" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,27.99995 h 1 v 1 h -1"
+       id="path1934" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.466667"
+       d="m 38,27.99995 h 1 v 1 h -1"
+       id="path1932" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,27.99995 h 1 v 1 h -1"
+       id="path1930" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,27.99995 h 1 v 1 h -1"
+       id="path1928" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,27.99995 h 1 v 1 h -1"
+       id="path1926" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,27.99995 h 1 v 1 h -1"
+       id="path1924" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,27.99995 h 1 v 1 h -1"
+       id="path1922" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,27.99995 h 1 v 1 h -1"
+       id="path1920" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,27.99995 h 1 v 1 h -1"
+       id="path1918" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,27.99995 h 1 v 1 h -1"
+       id="path1916" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,27.99995 h 1 v 1 h -1"
+       id="path1914" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,27.99995 h 1 v 1 h -1"
+       id="path1912" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,27.99995 h 1 v 1 h -1"
+       id="path1910" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,27.99995 h 1 v 1 h -1"
+       id="path1908" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,27.99995 h 1 v 1 h -1"
+       id="path1906" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,27.99995 h 1 v 1 h -1"
+       id="path1904" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,27.99995 h 1 v 1 h -1"
+       id="path1902" />
+    <path
+       style="fill:#212121;fill-opacity:0.152941"
+       d="m 22,27.99995 h 1 v 1 h -1"
+       id="path1900" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.619608"
+       d="m 21,27.99995 h 1 v 1 h -1"
+       id="path1898" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,27.99995 h 1 v 1 h -1"
+       id="path1896" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,27.99995 h 1 v 1 h -1"
+       id="path1894" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.717647"
+       d="m 18,27.99995 h 1 v 1 h -1"
+       id="path1892" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 17,27.99995 h 1 v 1 h -1"
+       id="path1890" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,27.99995 h 1 v 1 h -1"
+       id="path1888" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,26.99995 h 1 v 1 h -1"
+       id="path1886" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 46,26.99995 h 1 v 1 h -1"
+       id="path1884" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 45,26.99995 h 1 v 1 h -1"
+       id="path1882" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,26.99995 h 1 v 1 h -1"
+       id="path1880" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.92549"
+       d="m 43,26.99995 h 1 v 1 h -1"
+       id="path1878" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.560784"
+       d="m 42,26.99995 h 1 v 1 h -1"
+       id="path1876" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.976471"
+       d="m 41,26.99995 h 1 v 1 h -1"
+       id="path1874" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,26.99995 h 1 v 1 h -1"
+       id="path1872" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,26.99995 h 1 v 1 h -1"
+       id="path1870" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,26.99995 h 1 v 1 h -1"
+       id="path1868" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,26.99995 h 1 v 1 h -1"
+       id="path1866" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,26.99995 h 1 v 1 h -1"
+       id="path1864" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,26.99995 h 1 v 1 h -1"
+       id="path1862" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,26.99995 h 1 v 1 h -1"
+       id="path1860" />
+    <path
+       style="fill:#1c1c1c;fill-opacity:0.0705882"
+       d="m 33,26.99995 h 1 v 1 h -1"
+       id="path1858" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,26.99995 h 1 v 1 h -1"
+       id="path1856" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,26.99995 h 1 v 1 h -1"
+       id="path1854" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,26.99995 h 1 v 1 h -1"
+       id="path1852" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,26.99995 h 1 v 1 h -1"
+       id="path1850" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,26.99995 h 1 v 1 h -1"
+       id="path1848" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,26.99995 h 1 v 1 h -1"
+       id="path1846" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,26.99995 h 1 v 1 h -1"
+       id="path1844" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,26.99995 h 1 v 1 h -1"
+       id="path1842" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,26.99995 h 1 v 1 h -1"
+       id="path1840" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,26.99995 h 1 v 1 h -1"
+       id="path1838" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.992157"
+       d="m 22,26.99995 h 1 v 1 h -1"
+       id="path1836" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.627451"
+       d="m 21,26.99995 h 1 v 1 h -1"
+       id="path1834" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.905882"
+       d="m 20,26.99995 h 1 v 1 h -1"
+       id="path1832" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,26.99995 h 1 v 1 h -1"
+       id="path1830" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 18,26.99995 h 1 v 1 h -1"
+       id="path1828" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 17,26.99995 h 1 v 1 h -1"
+       id="path1826" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,26.99995 h 1 v 1 h -1"
+       id="path1824" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,25.99995 h 1 v 1 h -1"
+       id="path1822" />
+    <path
+       style="fill:#252020;fill-opacity:0.215686"
+       d="m 46,25.99995 h 1 v 1 h -1"
+       id="path1820" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 45,25.99995 h 1 v 1 h -1"
+       id="path1818" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,25.99995 h 1 v 1 h -1"
+       id="path1816" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.65098"
+       d="m 43,25.99995 h 1 v 1 h -1"
+       id="path1814" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,25.99995 h 1 v 1 h -1"
+       id="path1812" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.811765"
+       d="m 41,26 1,-5e-5 v 1 h -1"
+       id="path1810"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39.75,26.24995 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path1808" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,25.99995 0.75,0.25 0.25,0.75 h -1"
+       id="path1806" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,25.99995 h 1 v 1 h -1"
+       id="path1804" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,25.99995 h 1 v 1 h -1"
+       id="path1802" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,25.99995 h 1 v 1 h -1"
+       id="path1800" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,25.99995 h 1 v 1 h -1"
+       id="path1798" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,25.99995 h 1 v 1 h -1"
+       id="path1796" />
+    <path
+       style="fill:#202020;fill-opacity:0.0941176"
+       d="m 33,25.99995 h 1 v 1 h -1"
+       id="path1794" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,25.99995 h 1 v 1 h -1"
+       id="path1792" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,25.99995 h 1 v 1 h -1"
+       id="path1790" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,25.99995 h 1 v 1 h -1"
+       id="path1788" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,25.99995 h 1 v 1 h -1"
+       id="path1786" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,25.99995 h 1 v 1 h -1"
+       id="path1784" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,25.99995 h 1 v 1 h -1"
+       id="path1782" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,25.99995 h 1 v 1 h -1"
+       id="path1780" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,25.99995 h 1 v 1 h -1"
+       id="path1778" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,25.99995 h 1 v 1 h -1"
+       id="path1776" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,25.99995 h 1 v 1 h -1"
+       id="path1774" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.894118"
+       d="m 22,25.99995 h 1 v 1 h -1"
+       id="path1772" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 21,25.99995 h 1 v 1 h -1"
+       id="path1770" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.54902"
+       d="m 20,25.99995 h 1 v 1 h -1"
+       id="path1768" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,25.99995 h 1 v 1 h -1"
+       id="path1766" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 18,25.99995 h 1 v 1 h -1"
+       id="path1764" />
+    <path
+       style="fill:#252020;fill-opacity:0.215686"
+       d="m 17,25.99995 h 1 v 1 h -1"
+       id="path1762" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,25.99995 h 1 v 1 h -1"
+       id="path1760" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,24.99995 h 1 v 1 h -1"
+       id="path1758" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,24.99995 h 1 v 1 h -1"
+       id="path1756" />
+    <path
+       style="fill:#242020;fill-opacity:0.278431"
+       d="m 45,24.99995 h 1 v 1 h -1"
+       id="path1754" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 44,24.99995 h 1 v 1 h -1"
+       id="path1752" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,24.99995 h 1 v 1 h -1"
+       id="path1750" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.870588"
+       d="m 42,24.99995 h 1 v 1 h -1"
+       id="path1748" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.933333"
+       d="m 41,25 v 0 l 1,-5e-5 v 1 L 41,26 v 0"
+       id="path1746"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#2e1717;fill-opacity:0.0431373"
+       d="m 40,25 h 1 v 1 h -1"
+       id="path1744"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,24.99995 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path1742" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,24.99995 h 1 v 1 h -1"
+       id="path1740" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,24.99995 h 1 v 1 h -1"
+       id="path1738" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,24.99995 h 1 v 1 h -1"
+       id="path1736" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,24.99995 h 1 v 1 h -1"
+       id="path1734" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,24.99995 h 1 v 1 h -1"
+       id="path1732" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,24.99995 h 1 v 1 h -1"
+       id="path1730" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,24.99995 h 1 v 1 h -1"
+       id="path1728" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,24.99995 h 1 v 1 h -1"
+       id="path1726" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,24.99995 h 1 v 1 h -1"
+       id="path1724" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,24.99995 h 1 v 1 h -1"
+       id="path1722" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,24.99995 h 1 v 1 h -1"
+       id="path1720" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,24.99995 h 1 v 1 h -1"
+       id="path1718" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,24.99995 h 1 v 1 h -1"
+       id="path1716" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,24.99995 h 1 v 1 h -1"
+       id="path1714" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.968627"
+       d="m 24,24.99995 h 1 v 1 h -1"
+       id="path1712" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.94902"
+       d="m 23,24.99995 h 1 v 1 h -1"
+       id="path1710" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,24.99995 h 1 v 1 h -1"
+       id="path1708" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.843137"
+       d="m 21,24.99995 h 1 v 1 h -1"
+       id="path1706" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.984314"
+       d="m 20,24.99995 h 1 v 1 h -1"
+       id="path1704" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,24.99995 h 1 v 1 h -1"
+       id="path1702" />
+    <path
+       style="fill:#242020;fill-opacity:0.278431"
+       d="m 18,24.99995 h 1 v 1 h -1"
+       id="path1700" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,24.99995 h 1 v 1 h -1"
+       id="path1698" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,24.99995 h 1 v 1 h -1"
+       id="path1696" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,23.99995 h 1 v 1 h -1"
+       id="path1694" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46.25,24.24995 0.75,-0.25 v 1 h -1"
+       id="path1692" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 45,24 v 0 h 1 v 0 0.99995 h -1"
+       id="path1690"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="M 44,23.99995 45,24 v 0.99995 h -1"
+       id="path1688"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,23.99995 h 1 v 1 h -1"
+       id="path1686" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,23.99995 h 1 v 1 h -1"
+       id="path1684" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 41,23.99995 h 1 v 1 L 41,25"
+       id="path1682"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,23.99995 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path1680" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,23.99995 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path1678" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.921569"
+       d="m 38,23.99995 h 1 v 1 h -1"
+       id="path1676" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,23.99995 h 1 v 1 h -1"
+       id="path1674" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,23.99995 h 1 v 1 h -1"
+       id="path1672" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,23.99995 h 1 v 1 h -1"
+       id="path1670" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,23.99995 h 1 v 1 h -1"
+       id="path1668" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,23.99995 h 1 v 1 h -1"
+       id="path1666" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,23.99995 h 1 v 1 h -1"
+       id="path1664" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,23.99995 h 1 v 1 h -1"
+       id="path1662" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,23.99995 h 1 v 1 h -1"
+       id="path1660" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,23.99995 h 1 v 1 h -1"
+       id="path1658" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,23.99995 h 1 v 1 h -1"
+       id="path1656" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,23.99995 h 1 v 1 h -1"
+       id="path1654" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,23.99995 h 1 v 1 h -1"
+       id="path1652" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,23.99995 h 1 v 1 h -1"
+       id="path1650" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,23.99995 h 1 v 1 h -1"
+       id="path1648" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,23.99995 h 1 v 1 h -1"
+       id="path1646" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,23.99995 h 1 v 1 h -1"
+       id="path1644" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,23.99995 h 1 v 1 h -1"
+       id="path1642" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,23.99995 h 1 v 1 h -1"
+       id="path1640" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 19,24 1,-5e-5 v 1 h -1"
+       id="path1638"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 18,24 v 0 h 1 v 0 0.99995 h -1"
+       id="path1636"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,23.99995 0.75,0.25 0.25,0.75 h -1"
+       id="path1634" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,23.99995 h 1 v 1 h -1"
+       id="path1632" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,22.99995 h 1 v 1 h -1"
+       id="path1630" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45.75,23.24995 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path1628" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 45,23 h 1 v 1 h -1"
+       id="path1626"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.235294"
+       d="M 44,22.99995 45,23 v 0 1 0 l -1,-5e-5"
+       id="path1624"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 43,22.99995 h 1 v 1 h -1"
+       id="path1622" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,22.99995 h 1 v 1 h -1"
+       id="path1620" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.980392"
+       d="m 41,22.99995 h 1 v 1 h -1"
+       id="path1618" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.192157"
+       d="m 40,22.99995 h 1 v 1 h -1"
+       id="path1616" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,22.99995 h 1 v 1 h -1"
+       id="path1614" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.196078"
+       d="m 38,22.99995 h 1 v 1 h -1"
+       id="path1612" />
+    <path
+       style="fill:#241f1f;fill-opacity:0.843137"
+       d="m 37,22.99995 h 1 v 1 h -1"
+       id="path1610" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,22.99995 h 1 v 1 h -1"
+       id="path1608" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,22.99995 h 1 v 1 h -1"
+       id="path1606" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,22.99995 h 1 v 1 h -1"
+       id="path1604" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,22.99995 h 1 v 1 h -1"
+       id="path1602" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,22.99995 h 1 v 1 h -1"
+       id="path1600" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 31,22.99995 h 1 v 1 h -1"
+       id="path1598" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,22.99995 h 1 v 1 h -1"
+       id="path1596" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,22.99995 h 1 v 1 h -1"
+       id="path1594" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,22.99995 h 1 v 1 h -1"
+       id="path1592" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,22.99995 h 1 v 1 h -1"
+       id="path1590" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,22.99995 h 1 v 1 h -1"
+       id="path1588" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,22.99995 h 1 v 1 h -1"
+       id="path1586" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,22.99995 h 1 v 1 h -1"
+       id="path1584" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,22.99995 h 1 v 1 h -1"
+       id="path1582" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,22.99995 h 1 v 1 h -1"
+       id="path1580" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,22.99995 h 1 v 1 h -1"
+       id="path1578" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 20,22.99995 h 1 v 1 h -1"
+       id="path1576" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.231373"
+       d="m 19,23 v 0 l 1,-5e-5 v 1 L 19,24 v 0"
+       id="path1574"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 18,23 h 1 v 1 h -1"
+       id="path1572"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,22.99995 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path1570" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,22.99995 h 1 v 1 h -1"
+       id="path1568" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,21.99995 h 1 v 1 h -1"
+       id="path1566" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,21.99995 h 1 v 1 l -0.75,-0.25"
+       id="path1564" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,21.99995 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path1562" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.364706"
+       d="m 44,21.99995 h 1 V 23 l -1,-5e-5"
+       id="path1560"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 43,21.99995 h 1 v 1 h -1"
+       id="path1558" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 42,21.99995 h 1 v 1 h -1"
+       id="path1556" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,21.99995 h 1 v 1 h -1"
+       id="path1554" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.878431"
+       d="m 40,21.99995 h 1 v 1 h -1"
+       id="path1552" />
+    <path
+       style="fill:#241b1b;fill-opacity:0.109804"
+       d="m 39,21.99995 h 1 v 1 h -1"
+       id="path1550" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,21.99995 h 1 v 1 h -1"
+       id="path1548" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,21.99995 h 1 v 1 h -1"
+       id="path1546" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,21.99995 h 1 v 1 h -1"
+       id="path1544" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,21.99995 h 1 v 1 h -1"
+       id="path1542" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,21.99995 h 1 v 1 h -1"
+       id="path1540" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,21.99995 h 1 v 1 h -1"
+       id="path1538" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,21.99995 h 1 v 1 h -1"
+       id="path1536" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,21.99995 h 1 v 1 h -1"
+       id="path1534" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,21.99995 h 1 v 1 h -1"
+       id="path1532" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,21.99995 h 1 v 1 h -1"
+       id="path1530" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 28,21.99995 h 1 v 1 h -1"
+       id="path1528" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 27,21.99995 h 1 v 1 h -1"
+       id="path1526" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 26,21.99995 h 1 v 1 h -1"
+       id="path1524" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 25,21.99995 h 1 v 1 h -1"
+       id="path1522" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,21.99995 h 1 v 1 h -1"
+       id="path1520" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,21.99995 h 1 v 1 h -1"
+       id="path1518" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,21.99995 h 1 v 1 h -1"
+       id="path1516" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 21,21.99995 h 1 v 1 h -1"
+       id="path1514" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 20,21.99995 h 1 v 1 h -1"
+       id="path1512" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.364706"
+       d="m 19,21.99995 h 1 v 1 L 19,23"
+       id="path1510"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,21.99995 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path1508" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,21.99995 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path1506" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,21.99995 h 1 v 1 h -1"
+       id="path1504" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,20.99995 h 1 v 1 h -1"
+       id="path1502" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,20.99995 h 1 v 1 h -1"
+       id="path1500" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,20.99995 h 1 v 1 h -1"
+       id="path1498" />
+    <path
+       style="fill:#242121;fill-opacity:0.27451"
+       d="m 44,20.99995 h 1 v 1 h -1"
+       id="path1496" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 43,20.99995 h 1 v 1 h -1"
+       id="path1494" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 42,20.99995 h 1 v 1 h -1"
+       id="path1492" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,20.99995 h 1 v 1 h -1"
+       id="path1490" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,20.99995 h 1 v 1 h -1"
+       id="path1488" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 39,20.99995 h 1 v 1 h -1"
+       id="path1486" />
+    <path
+       style="fill:#212121;fill-opacity:0.180392"
+       d="m 38,20.99995 h 1 v 1 h -1"
+       id="path1484" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37.25,21.24995 0.75,-0.25 v 1 h -1"
+       id="path1482" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35.75,21.24995 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path1480" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,20.99995 0.75,0.25 0.25,0.75 h -1"
+       id="path1478" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,20.99995 h 1 v 1 h -1"
+       id="path1476" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,20.99995 h 1 v 1 h -1"
+       id="path1474" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,20.99995 h 1 v 1 h -1"
+       id="path1472" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,20.99995 h 1 v 1 h -1"
+       id="path1470" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,20.99995 h 1 v 1 h -1"
+       id="path1468" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,20.99995 h 1 v 1 h -1"
+       id="path1466" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 28.25,21.24995 0.75,-0.25 v 1 h -1"
+       id="path1464" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 26.75,21.24995 0.5,-0.5 h 0.5 l 0.5,0.5 -0.25,0.75 h -1"
+       id="path1462" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 26,20.99995 0.75,0.25 0.25,0.75 h -1"
+       id="path1460" />
+    <path
+       style="fill:#212121;fill-opacity:0.184314"
+       d="m 25,20.99995 h 1 v 1 h -1"
+       id="path1458" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.87451"
+       d="m 24,20.99995 h 1 v 1 h -1"
+       id="path1456" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,20.99995 h 1 v 1 h -1"
+       id="path1454" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,20.99995 h 1 v 1 h -1"
+       id="path1452" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 21,20.99995 h 1 v 1 h -1"
+       id="path1450" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 20,20.99995 h 1 v 1 h -1"
+       id="path1448" />
+    <path
+       style="fill:#242121;fill-opacity:0.27451"
+       d="m 19,20.99995 h 1 v 1 h -1"
+       id="path1446" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,20.99995 h 1 v 1 h -1"
+       id="path1444" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,20.99995 h 1 v 1 h -1"
+       id="path1442" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,20.99995 h 1 v 1 h -1"
+       id="path1440" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,19.99995 h 1 v 1 h -1"
+       id="path1438" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,19.99995 h 1 v 1 h -1"
+       id="path1436" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,19.99995 h 1 v 1 h -1"
+       id="path1434" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,19.99995 h 1 v 1 h -1"
+       id="path1432" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,19.99995 h 1 v 1 h -1"
+       id="path1430" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 42,19.99995 h 1 v 1 h -1"
+       id="path1428" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 41,19.99995 h 1 v 1 h -1"
+       id="path1426" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 40,19.99995 h 1 v 1 h -1"
+       id="path1424" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,19.99995 h 1 v 1 h -1"
+       id="path1422" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.972549"
+       d="m 38,19.99995 h 1 v 1 h -1"
+       id="path1420" />
+    <path
+       style="fill:#242020;fill-opacity:0.47451"
+       d="m 37,20 v 0 l 1,-5e-5 v 1 L 37,21 v 0"
+       id="path1418"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#2e1717;fill-opacity:0.0431373"
+       d="m 36,20 h 1 v 1 h -1"
+       id="path1416"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,19.99995 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path1414" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,19.99995 h 1 v 1 h -1"
+       id="path1412" />
+    <path
+       style="fill:#000000;fill-opacity:0.0117647"
+       d="m 33,19.99995 h 1 v 1 h -1"
+       id="path1410" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.584314"
+       d="m 32,19.99995 h 1 v 1 h -1"
+       id="path1408" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.670588"
+       d="m 31,19.99995 h 1 v 1 h -1"
+       id="path1406" />
+    <path
+       style="fill:#1a1a1a;fill-opacity:0.0392157"
+       d="m 30,19.99995 h 1 v 1 h -1"
+       id="path1404" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,19.99995 h 1 v 1 h -1"
+       id="path1402" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 27.75,20.24995 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path1400" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 27,20 h 1 v 1 h -1"
+       id="path1398"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.498039"
+       d="M 26,19.99995 27,20 v 0 1 0 l -1,-5e-5"
+       id="path1396"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.976471"
+       d="m 25,19.99995 h 1 v 1 h -1"
+       id="path1394" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,19.99995 h 1 v 1 h -1"
+       id="path1392" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 23,19.99995 h 1 v 1 h -1"
+       id="path1390" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 22,19.99995 h 1 v 1 h -1"
+       id="path1388" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 21,19.99995 h 1 v 1 h -1"
+       id="path1386" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,19.99995 h 1 v 1 h -1"
+       id="path1384" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,19.99995 h 1 v 1 h -1"
+       id="path1382" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,19.99995 h 1 v 1 h -1"
+       id="path1380" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,19.99995 h 1 v 1 h -1"
+       id="path1378" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,19.99995 h 1 v 1 h -1"
+       id="path1376" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,18.99995 h 1 v 1 h -1"
+       id="path1374" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,18.99995 h 1 v 1 h -1"
+       id="path1372" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,18.99995 h 1 v 1 h -1"
+       id="path1370" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,18.99995 h 1 v 1 h -1"
+       id="path1368" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,18.99995 h 1 v 1 h -1"
+       id="path1366" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 42,18.99995 h 1 v 1 h -1"
+       id="path1364" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 41,18.99995 h 1 v 1 h -1"
+       id="path1362" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 40,18.99995 h 1 v 1 h -1"
+       id="path1360" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,18.99995 h 1 v 1 h -1"
+       id="path1358" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 38,18.99995 h 1 v 1 h -1"
+       id="path1356" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,18.99995 h 1 v 1 L 37,20"
+       id="path1354"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.92549"
+       d="m 36,18.99995 h 1 V 20 20 h -1 v -5e-5"
+       id="path1352"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#232020;fill-opacity:0.568627"
+       d="m 35,18.99995 h 1 v 1 h -1"
+       id="path1350"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#232020;fill-opacity:0.282353"
+       d="m 34,18.99995 h 1 v 1 h -1"
+       id="path1348" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.670588"
+       d="m 33,18.99995 h 1 v 1 h -1"
+       id="path1346" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 32,18.99995 h 1 v 1 h -1"
+       id="path1344" />
+    <path
+       style="fill:#232020;fill-opacity:0.792157"
+       d="m 31,18.99995 h 1 v 1 h -1"
+       id="path1342" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.713725"
+       d="m 30,18.99995 h 1 v 1 h -1"
+       id="path1340" />
+    <path
+       style="fill:#221f1f;fill-opacity:0.294118"
+       d="m 29,18.99995 h 1 v 1 h -1"
+       id="path1338" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.576471"
+       d="m 28,18.99995 h 1 v 1 L 28,20"
+       id="path1336"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.941176"
+       d="m 27,18.99995 h 1 V 20 20 h -1 v 0"
+       id="path1334"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,18.99995 h 1 V 20 l -1,-5e-5"
+       id="path1332"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 25,18.99995 h 1 v 1 h -1"
+       id="path1330" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,18.99995 h 1 v 1 h -1"
+       id="path1328" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.752941"
+       d="m 23,18.99995 h 1 v 1 h -1"
+       id="path1326" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 22,18.99995 h 1 v 1 h -1"
+       id="path1324" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 21,18.99995 h 1 v 1 h -1"
+       id="path1322" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,18.99995 h 1 v 1 h -1"
+       id="path1320" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,18.99995 h 1 v 1 h -1"
+       id="path1318" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,18.99995 h 1 v 1 h -1"
+       id="path1316" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,18.99995 h 1 v 1 h -1"
+       id="path1314" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,18.99995 h 1 v 1 h -1"
+       id="path1312" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,17.99995 h 1 v 1 h -1"
+       id="path1310" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,17.99995 h 1 v 1 h -1"
+       id="path1308" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,17.99995 h 1 v 1 h -1"
+       id="path1306" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,17.99995 h 1 v 1 h -1"
+       id="path1304" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,17.99995 h 1 v 1 h -1"
+       id="path1302" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,17.99995 h 1 v 1 h -1"
+       id="path1300" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,17.99995 h 1 v 1 h -1"
+       id="path1298" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 40,17.99995 h 1 v 1 h -1"
+       id="path1296" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 39,17.99995 h 1 v 1 h -1"
+       id="path1294" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 38,17.99995 h 1 v 1 h -1"
+       id="path1292" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 37,17.99995 h 1 v 1 h -1"
+       id="path1290" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,17.99995 h 1 v 1 h -1"
+       id="path1288" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,17.99995 h 1 v 1 h -1"
+       id="path1286" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,17.99995 h 1 v 1 h -1"
+       id="path1284" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,17.99995 h 1 v 1 h -1"
+       id="path1282" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.262745"
+       d="m 32,17.99995 h 1 v 1 h -1"
+       id="path1280" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.168627"
+       d="m 31,17.99995 h 1 v 1 h -1"
+       id="path1278" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,17.99995 h 1 v 1 h -1"
+       id="path1276" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,17.99995 h 1 v 1 h -1"
+       id="path1274" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,17.99995 h 1 v 1 h -1"
+       id="path1272" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,17.99995 h 1 v 1 h -1"
+       id="path1270" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,17.99995 h 1 v 1 h -1"
+       id="path1268" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 25,17.99995 h 1 v 1 h -1"
+       id="path1266" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 24,17.99995 h 1 v 1 h -1"
+       id="path1264" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.545098"
+       d="m 23,17.99995 h 1 v 1 h -1"
+       id="path1262" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,17.99995 h 1 v 1 h -1"
+       id="path1260" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,17.99995 h 1 v 1 h -1"
+       id="path1258" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,17.99995 h 1 v 1 h -1"
+       id="path1256" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,17.99995 h 1 v 1 h -1"
+       id="path1254" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,17.99995 h 1 v 1 h -1"
+       id="path1252" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,17.99995 h 1 v 1 h -1"
+       id="path1250" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,17.99995 h 1 v 1 h -1"
+       id="path1248" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,16.99995 h 1 v 1 h -1"
+       id="path1246" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,16.99995 h 1 v 1 h -1"
+       id="path1244" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,16.99995 h 1 v 1 h -1"
+       id="path1242" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,16.99995 h 1 v 1 h -1"
+       id="path1240" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,16.99995 h 1 v 1 h -1"
+       id="path1238" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,16.99995 h 1 v 1 h -1"
+       id="path1236" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,16.99995 h 1 v 1 h -1"
+       id="path1234" />
+    <path
+       style="fill:#242121;fill-opacity:0.27451"
+       d="m 40,16.99995 h 1 v 1 h -1"
+       id="path1232" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.360784"
+       d="m 39,17 1,-5e-5 v 1 h -1"
+       id="path1230"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.235294"
+       d="m 38,17 v 0 h 1 v 0 0.99995 h -1"
+       id="path1228"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="M 37,16.99995 38,17 v 0.99995 h -1"
+       id="path1226"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 36,16.99995 h 1 v 1 h -1"
+       id="path1224" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 35,16.99995 h 1 v 1 h -1"
+       id="path1222" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,16.99995 h 1 v 1 h -1"
+       id="path1220" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 33,16.99995 h 1 v 1 h -1"
+       id="path1218" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.886275"
+       d="m 32,16.99995 h 1 v 1 h -1"
+       id="path1216" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.858824"
+       d="m 31,16.99995 h 1 v 1 h -1"
+       id="path1214" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 30,16.99995 h 1 v 1 h -1"
+       id="path1212" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,16.99995 h 1 v 1 h -1"
+       id="path1210" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 28,16.99995 h 1 v 1 h -1"
+       id="path1208" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 27,16.99995 h 1 v 1 h -1"
+       id="path1206" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 26,17 1,-5e-5 v 1 h -1"
+       id="path1204"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#221e1e;fill-opacity:0.235294"
+       d="m 25,17 v 0 h 1 v 0 0.99995 h -1"
+       id="path1202"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#241e1e;fill-opacity:0.360784"
+       d="M 24,16.99995 25,17 v 0.99995 h -1"
+       id="path1200"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#242121;fill-opacity:0.27451"
+       d="m 23,16.99995 h 1 v 1 h -1"
+       id="path1198" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,16.99995 h 1 v 1 h -1"
+       id="path1196" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,16.99995 h 1 v 1 h -1"
+       id="path1194" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,16.99995 h 1 v 1 h -1"
+       id="path1192" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,16.99995 h 1 v 1 h -1"
+       id="path1190" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,16.99995 h 1 v 1 h -1"
+       id="path1188" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,16.99995 h 1 v 1 h -1"
+       id="path1186" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,16.99995 h 1 v 1 h -1"
+       id="path1184" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,15.99995 h 1 v 1 h -1"
+       id="path1182" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,15.99995 h 1 v 1 h -1"
+       id="path1180" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,15.99995 h 1 v 1 h -1"
+       id="path1178" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,15.99995 h 1 v 1 h -1"
+       id="path1176" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,15.99995 h 1 v 1 h -1"
+       id="path1174" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,15.99995 h 1 v 1 h -1"
+       id="path1172" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,15.99995 h 1 v 1 h -1"
+       id="path1170" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,15.99995 h 1 v 1 h -1"
+       id="path1168" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38.75,16.24995 0.5,-0.5 0.75,0.25 v 1 l -0.75,0.25 -0.5,-0.5"
+       id="path1166" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 38,16 h 1 v 1 h -1"
+       id="path1164"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="M 37,15.99995 38,16 v 0 1 0 l -1,-5e-5"
+       id="path1162"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#242020;fill-opacity:0.278431"
+       d="m 36,15.99995 h 1 v 1 h -1"
+       id="path1160" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 35,15.99995 h 1 v 1 h -1"
+       id="path1158" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 34,15.99995 h 1 v 1 h -1"
+       id="path1156" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.717647"
+       d="m 33,15.99995 h 1 v 1 h -1"
+       id="path1154" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 32,15.99995 h 1 v 1 h -1"
+       id="path1152" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.996078"
+       d="m 31,15.99995 h 1 v 1 h -1"
+       id="path1150" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.717647"
+       d="m 30,15.99995 h 1 v 1 h -1"
+       id="path1148" />
+    <path
+       style="fill:#231f1f;fill-opacity:1"
+       d="m 29,15.99995 h 1 v 1 h -1"
+       id="path1146" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.654902"
+       d="m 28,15.99995 h 1 v 1 h -1"
+       id="path1144" />
+    <path
+       style="fill:#242020;fill-opacity:0.278431"
+       d="m 27,15.99995 h 1 v 1 h -1"
+       id="path1142" />
+    <path
+       style="fill:#231f1f;fill-opacity:0.827451"
+       d="m 26,16 v 0 l 1,-5e-5 v 1 L 26,17 c 0.09894,0.09894 0.16765,0.16765 0,0"
+       id="path1140"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#2b1515;fill-opacity:0.0470588"
+       d="m 25,16 h 1 v 1 h -1"
+       id="path1138"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,15.99995 0.75,-0.25 0.5,0.5 v 0.5 l -0.5,0.5 -0.75,-0.25"
+       id="path1136" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,15.99995 h 1 v 1 h -1"
+       id="path1134" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,15.99995 h 1 v 1 h -1"
+       id="path1132" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,15.99995 h 1 v 1 h -1"
+       id="path1130" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,15.99995 h 1 v 1 h -1"
+       id="path1128" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,15.99995 h 1 v 1 h -1"
+       id="path1126" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,15.99995 h 1 v 1 h -1"
+       id="path1124" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,15.99995 h 1 v 1 h -1"
+       id="path1122" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,15.99995 h 1 v 1 h -1"
+       id="path1120" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,14.99995 h 1 v 1 h -1"
+       id="path1118" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,14.99995 h 1 v 1 h -1"
+       id="path1116" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,14.99995 h 1 v 1 h -1"
+       id="path1114" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,14.99995 h 1 v 1 h -1"
+       id="path1112" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,14.99995 h 1 v 1 h -1"
+       id="path1110" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,14.99995 h 1 v 1 h -1"
+       id="path1108" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,14.99995 h 1 v 1 h -1"
+       id="path1106" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,14.99995 h 1 v 1 h -1"
+       id="path1104" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,14.99995 h 1 v 1 l -0.75,-0.25"
+       id="path1102" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,14.99995 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path1100" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,14.99995 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path1098" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,14.99995 h 1 v 1 h -1"
+       id="path1096" />
+    <path
+       style="fill:#252020;fill-opacity:0.215686"
+       d="m 35,14.99995 h 1 v 1 h -1"
+       id="path1094" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 34,14.99995 h 1 v 1 h -1"
+       id="path1092" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 33,14.99995 h 1 v 1 h -1"
+       id="path1090" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 32,14.99995 h 1 v 1 h -1"
+       id="path1088" />
+    <path
+       style="fill:#231e1e;fill-opacity:0.596078"
+       d="m 31,14.99995 h 1 v 1 h -1"
+       id="path1086" />
+    <path
+       style="fill:#000000;fill-opacity:0.00392157"
+       d="m 30,14.99995 h 1 v 1 h -1"
+       id="path1084" />
+    <path
+       style="fill:#242020;fill-opacity:0.533333"
+       d="m 29,14.99995 h 1 v 1 h -1"
+       id="path1082" />
+    <path
+       style="fill:#252020;fill-opacity:0.215686"
+       d="m 28,14.99995 h 1 v 1 h -1"
+       id="path1080" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 27,14.99995 h 1 v 1 h -1"
+       id="path1078" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 26,14.99995 h 1 v 1 l -0.75,-0.25"
+       id="path1076" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 25,14.99995 h 1 l 0.25,0.75 -0.5,0.5 h -0.5 l -0.5,-0.5"
+       id="path1074" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,14.99995 h 1 l -0.25,0.75 -0.75,0.25"
+       id="path1072" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,14.99995 h 1 v 1 h -1"
+       id="path1070" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,14.99995 h 1 v 1 h -1"
+       id="path1068" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,14.99995 h 1 v 1 h -1"
+       id="path1066" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,14.99995 h 1 v 1 h -1"
+       id="path1064" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,14.99995 h 1 v 1 h -1"
+       id="path1062" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,14.99995 h 1 v 1 h -1"
+       id="path1060" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,14.99995 h 1 v 1 h -1"
+       id="path1058" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,14.99995 h 1 v 1 h -1"
+       id="path1056" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 47,13.99995 h 1 v 1 h -1"
+       id="path1054" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 46,13.99995 h 1 v 1 h -1"
+       id="path1052" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 45,13.99995 h 1 v 1 h -1"
+       id="path1050" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 44,13.99995 h 1 v 1 h -1"
+       id="path1048" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 43,13.99995 h 1 v 1 h -1"
+       id="path1046" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 42,13.99995 h 1 v 1 h -1"
+       id="path1044" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 41,13.99995 h 1 v 1 h -1"
+       id="path1042" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 40,13.99995 h 1 v 1 h -1"
+       id="path1040" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 39,13.99995 h 1 v 1 h -1"
+       id="path1038" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 38,13.99995 h 1 v 1 h -1"
+       id="path1036" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 37,13.99995 h 1 v 1 h -1"
+       id="path1034" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 36,13.99995 h 1 v 1 h -1"
+       id="path1032" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 35,13.99995 h 1 v 1 h -1"
+       id="path1030" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 34,13.99995 h 1 v 1 h -1"
+       id="path1028" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 33,13.99995 h 1 v 1 h -1"
+       id="path1026" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 32,13.99995 h 1 v 1 h -1"
+       id="path1024" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 31,13.99995 h 1 v 1 h -1"
+       id="path1022" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 30,13.99995 h 1 v 1 h -1"
+       id="path1020" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 29,13.99995 h 1 v 1 h -1"
+       id="path1018" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 28,13.99995 h 1 v 1 h -1"
+       id="path1016" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 27,13.99995 h 1 v 1 h -1"
+       id="path1014" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 26,13.99995 h 1 v 1 h -1"
+       id="path1012" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 25,13.99995 h 1 v 1 h -1"
+       id="path1010" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 24,13.99995 h 1 v 1 h -1"
+       id="path1008" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 23,13.99995 h 1 v 1 h -1"
+       id="path1006" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 22,13.99995 h 1 v 1 h -1"
+       id="path1004" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 21,13.99995 h 1 v 1 h -1"
+       id="path1002" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 20,13.99995 h 1 v 1 h -1"
+       id="path1000" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 19,13.99995 h 1 v 1 h -1"
+       id="path998" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 18,13.99995 h 1 v 1 h -1"
+       id="path996" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 17,13.99995 h 1 v 1 h -1"
+       id="path994" />
+    <path
+       style="fill:#000000;fill-opacity:0"
+       d="m 16,13.99995 h 1 v 1 h -1"
+       id="path992" />
+  </g>
+  <rect
+     width="44.199997"
+     height="5"
+     x="9.8999996"
+     y="57.000004"
+     id="rect2879"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z"
+     id="path2881"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z"
+     id="path2883"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z"
+     id="rect6741-1-8"
+     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+</svg>


### PR DESCRIPTION
Instead of using the SVG artwork as in #983, here I attempt a different method, namely tracing over the PNG images and exporting the result as SVG.