### PR TITLE
Usb reciever

### DIFF
--- a/devices/128/usb-receiver.svg
+++ b/devices/128/usb-receiver.svg
@@ -25,9 +25,9 @@
      inkscape:pagecheckerboard="false"
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="25.015638"
-     inkscape:cx="59.782605"
-     inkscape:cy="74.873166"
+     inkscape:zoom="1.0243477"
+     inkscape:cx="-6.3455017"
+     inkscape:cy="27.334469"
      inkscape:window-width="2418"
      inkscape:window-height="1209"
      inkscape:window-x="54"
@@ -65,6 +65,28 @@
   </metadata>
   <defs
      id="defs3">
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect14"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect13"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
     <linearGradient
        id="linearGradient39">
       <stop
@@ -117,26 +139,6 @@
        miter_limit="4"
        attempt_force_join="false"
        update_on_knot_move="true" />
-    <linearGradient
-       id="linearGradient28"
-       inkscape:collect="always">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.04849076;"
-         offset="0"
-         id="stop25" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.01;"
-         offset="0.23"
-         id="stop26" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.02;"
-         offset="0.83999997"
-         id="stop27" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.14808641;"
-         offset="1"
-         id="stop28" />
-    </linearGradient>
     <inkscape:path-effect
        effect="offset"
        id="path-effect20"
@@ -349,33 +351,6 @@
        y2="-44.395805"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient13"
-       id="linearGradient14"
-       x1="65"
-       y1="55"
-       x2="65"
-       y2="95"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient28"
-       id="linearGradient20"
-       gradientUnits="userSpaceOnUse"
-       x1="65"
-       y1="65"
-       x2="65"
-       y2="55" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient28"
-       id="linearGradient25"
-       x1="64.077774"
-       y1="64.5"
-       x2="64.077774"
-       y2="55.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
        xlink:href="#linearGradient4891"
        id="linearGradient4889"
        gradientUnits="userSpaceOnUse"
@@ -466,26 +441,124 @@
          style="stop-color:#3689e6;stop-opacity:1" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient39"
-       id="radialGradient41"
-       cx="76.218811"
-       cy="-9.3095264"
-       fx="76.218811"
-       fy="-9.3095264"
-       r="33.465588"
-       gradientTransform="matrix(0,-0.73160642,1.0213754,0,73.510475,77.646937)"
+       id="radialGradient7374-3"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.61871386,0,0,0.14061988,17.56277,53.961714)"
+       r="22.627001">
+      <stop
+         id="stop23421-6"
+         offset="0" />
+      <stop
+         id="stop23423-7"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2666667,0,0,1.2666667,0.6,-4.1333342)"
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763-5"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
        gradientUnits="userSpaceOnUse" />
-    <radialGradient
+    <linearGradient
+       xlink:href="#linearGradient4614-2"
+       id="linearGradient4604-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81288992,0,0,1.4490643,-54.78462,-4.0592618)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient4614-2">
+      <stop
+         id="stop4606-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608-1"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4610-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612-7"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9">
+      <stop
+         id="stop6"
+         style="stop-color:#ffffff;stop-opacity:0.15421827;"
+         offset="0" />
+      <stop
+         id="stop7"
+         style="stop-color:#ffffff;stop-opacity:0.0492001;"
+         offset="0.19412513" />
+      <stop
+         id="stop8"
+         style="stop-color:#ffffff;stop-opacity:0.05365422;"
+         offset="0.84586936" />
+      <stop
+         id="stop9"
+         style="stop-color:#ffffff;stop-opacity:0.08116093;"
+         offset="1" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect4"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect5"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient39"
-       id="radialGradient42"
-       cx="59.542591"
-       cy="37.915802"
-       fx="59.542591"
-       fy="37.915802"
-       r="21.428688"
-       gradientTransform="matrix(0,-0.41507593,1.5950796,0,3.5232309,64.333837)"
+       xlink:href="#linearGradient9"
+       id="linearGradient12"
+       x1="65"
+       y1="51"
+       x2="65"
+       y2="60"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9"
+       id="linearGradient17"
+       x1="65"
+       y1="85"
+       x2="65"
+       y2="94"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13"
+       id="linearGradient20"
+       x1="65"
+       y1="61"
+       x2="65"
+       y2="85"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <path
@@ -518,6 +591,15 @@
      width="37"
      y="-117.5"
      x="45.5" />
+  <rect
+     style="fill:url(#linearGradient20);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.29775199;paint-order:normal"
+     id="rect8"
+     width="50"
+     height="25"
+     x="39"
+     y="61"
+     rx="0"
+     ry="0" />
   <path
      id="path4655"
      d="m 68.5,103.5 v 7 h 9 v -7 z"
@@ -566,72 +648,56 @@
      id="rect4671"
      style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      rx="0.5" />
-  <path
-     id="path12"
-     style="fill:#373737;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.29674199;stroke-linejoin:miter;fill-opacity:1"
-     d="m 39,54.5 c -1.384735,0 -2.5,1.115265 -2.5,2.5 v 6 c 0,1.213628 0.856057,2.218976 2,2.449219 v 19.101562 c -1.143943,0.230243 -2,1.235591 -2,2.449219 v 6 c 0,1.384735 1.115265,2.5 2.5,2.5 h 50 c 1.384735,0 2.5,-1.115265 2.5,-2.5 v -6 c 0,-1.213628 -0.856057,-2.218976 -2,-2.449219 V 65.449219 c 1.143943,-0.230243 2,-1.235591 2,-2.449219 v -6 c 0,-1.384735 -1.115265,-2.5 -2.5,-2.5 z" />
-  <path
-     id="rect10"
-     style="fill:url(#linearGradient14);stroke:none;stroke-width:0.667;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.296742;fill-opacity:1"
-     d="M 39 55 C 37.892001 55 37 55.892001 37 57 L 37 63 C 37 64.107999 37.892001 65 39 65 L 39 85 C 37.892001 85 37 85.892001 37 87 L 37 93 C 37 94.107999 37.892001 95 39 95 L 89 95 C 90.107999 95 91 94.107999 91 93 L 91 87 C 91 85.892001 90.107999 85 89 85 L 89 65 C 90.107999 65 91 64.107999 91 63 L 91 57 C 91 55.892001 90.107999 55 89 55 L 39 55 z " />
-  <path
-     style="fill:#444548;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:0.1524955"
-     d="M 39,65.75 H 89"
-     id="path16" />
-  <path
-     style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:0.296742"
-     d="M 39,65.5 H 89"
-     id="path14" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:url(#linearGradient25);stroke-width:1;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:1;opacity:1"
-     id="rect16"
-     width="54"
-     height="10"
-     x="37"
-     y="55"
-     rx="2"
-     ry="2"
-     sodipodi:type="rect"
-     d="m 39,55.5 h 50 c 0.831259,0 1.5,0.668741 1.5,1.5 v 6 c 0,0.831259 -0.668741,1.5 -1.5,1.5 H 39 c -0.831259,0 -1.5,-0.668741 -1.5,-1.5 v -6 c 0,-0.831259 0.668741,-1.5 1.5,-1.5 z"
-     inkscape:path-effect="#path-effect16" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:url(#linearGradient20);stroke-width:1;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:0.296742"
-     id="path19"
-     width="54"
-     height="10"
-     x="37"
-     y="55"
-     rx="2"
-     ry="2"
-     sodipodi:type="rect"
-     d="m 39,55.5 h 50 c 0.831259,0 1.5,0.668741 1.5,1.5 v 6 c 0,0.831259 -0.668741,1.5 -1.5,1.5 H 39 c -0.831259,0 -1.5,-0.668741 -1.5,-1.5 v -6 c 0,-0.831259 0.668741,-1.5 1.5,-1.5 z"
-     inkscape:path-effect="#path-effect20"
-     transform="translate(0,30)" />
+  <rect
+     style="fill:#2d2f36;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.297752;paint-order:normal"
+     id="rect6"
+     width="55"
+     height="11"
+     x="36.5"
+     y="84.5"
+     rx="2.5"
+     ry="2.5" />
+  <rect
+     style="fill:#444548;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.297752;paint-order:normal;fill-opacity:1"
+     id="rect7"
+     width="55"
+     height="11"
+     x="36.5"
+     y="50.5"
+     rx="2.5"
+     ry="2.5" />
   <circle
-     style="fill:#df8814;fill-opacity:1;stroke:none;stroke-width:0.829176;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:0.296742"
+     style="fill:#df8814;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:0.297752;paint-order:stroke markers fill"
      id="path20"
-     cx="83.5"
-     cy="60"
-     r="2.8781252" />
+     cx="45"
+     cy="56"
+     r="3" />
   <path
-     style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:0.15000001"
-     d="M 39,84.5 H 89"
-     id="path28" />
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient12);stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="rect9"
+     width="55"
+     height="11"
+     x="36.5"
+     y="50.5"
+     rx="2.5"
+     ry="2.5"
+     inkscape:path-effect="#path-effect13"
+     sodipodi:type="rect"
+     d="m 39,51.5 h 50 c 0.831521,0 1.5,0.668479 1.5,1.5 v 6 c 0,0.831521 -0.668479,1.5 -1.5,1.5 H 39 c -0.831521,0 -1.5,-0.668479 -1.5,-1.5 v -6 c 0,-0.831521 0.668479,-1.5 1.5,-1.5 z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient3013);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="m 64.003166,11.825537 c -13.004029,0 -24.922599,5.073374 -34.181676,13.411102 l 7.434746,8.160837 c 7.281959,-6.743496 16.829835,-10.496512 26.74693,-10.513509 9.918003,0.01474 19.467534,3.76625 26.751246,10.509183 l 7.430423,-8.156511 C 88.925767,16.898911 77.007194,11.825537 64.003166,11.825537 Z m 0,17.898889 c -8.294307,0.0132 -16.279316,3.155444 -22.364667,8.8009 L 49.133687,46.5 c 4.037686,-3.770258 9.349515,-5.871374 14.869479,-5.881684 5.52236,0.0069 10.83758,2.106645 14.878113,5.877359 l 7.482236,-7.966021 C 80.279919,32.883633 72.296564,29.739889 64.003166,29.724426 Z"
-     id="path4391-5"
-     sodipodi:nodetypes="scccccsccccccc" />
+     style="fill:none;stroke:url(#linearGradient17);stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="rect13"
+     width="55"
+     height="11"
+     x="36.5"
+     y="84.5"
+     rx="2.5"
+     ry="2.5"
+     inkscape:path-effect="#path-effect14"
+     sodipodi:type="rect"
+     d="m 39,85.5 h 50 c 0.831521,0 1.5,0.668479 1.5,1.5 v 6 c 0,0.831521 -0.668479,1.5 -1.5,1.5 H 39 c -0.831521,0 -1.5,-0.668479 -1.5,-1.5 v -6 c 0,-0.831521 0.668479,-1.5 1.5,-1.5 z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient42);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="m 64.001953,30.724609 c 7.705126,0.01437 15.130293,2.81876 20.927734,7.869141 l -6.111328,6.507812 c -4.122833,-3.524207 -9.37122,-5.475622 -14.816406,-5.482421 -5.439828,0.01016 -10.686244,1.962269 -14.806641,5.486328 l -6.123046,-6.515625 c 5.799251,-5.050189 13.226733,-7.85297 20.929687,-7.865235 z"
-     id="path32"
-     inkscape:path-effect="#path-effect34"
-     inkscape:original-d="m 64.003166,29.724426 c -8.294307,0.0132 -16.279316,3.155444 -22.364667,8.8009 L 49.133687,46.5 c 4.037686,-3.770258 9.349515,-5.871374 14.869479,-5.881684 5.52236,0.0069 10.83758,2.106645 14.878113,5.877359 l 7.482236,-7.966021 C 80.279919,32.883633 72.296564,29.739889 64.003166,29.724426 Z" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient41);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="m 64.003906,12.826172 c 12.386703,0 23.776778,4.710519 32.751953,12.496094 l -6.078125,6.669921 C 83.310134,25.504192 73.838342,21.899379 64.001953,21.884766 54.169889,21.901617 44.697919,25.507903 37.332031,31.996094 l -6.078125,-6.675782 c 8.974864,-7.784495 20.364254,-12.49414 32.75,-12.49414 z"
-     id="path29"
-     inkscape:path-effect="#path-effect32"
-     inkscape:original-d="m 64.003166,11.825537 c -13.004029,0 -24.922599,5.073374 -34.181676,13.411102 l 7.434746,8.160837 c 7.281959,-6.743496 16.829835,-10.496512 26.74693,-10.513509 9.918003,0.01474 19.467534,3.76625 26.751246,10.509183 l 7.430423,-8.156511 C 88.925767,16.898911 77.007194,11.825537 64.003166,11.825537 Z" />
+     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.297752;paint-order:normal"
+     d="M 40,62 H 88"
+     id="path21" />
 </svg>

--- a/devices/128/usb-receiver.svg
+++ b/devices/128/usb-receiver.svg
@@ -1,0 +1,637 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg11300"
+   height="128"
+   width="128"
+   version="1.0"
+   viewBox="0 0 128 128"
+   sodipodi:docname="usb-receiver.svg"
+   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="false"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="25.015638"
+     inkscape:cx="59.782605"
+     inkscape:cy="74.873166"
+     inkscape:window-width="2418"
+     inkscape:window-height="1209"
+     inkscape:window-x="54"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300"
+     showguides="true">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata49">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient39">
+      <stop
+         id="stop36"
+         style="stop-color:#ffffff;stop-opacity:0.50104409;"
+         offset="0" />
+      <stop
+         id="stop37"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.6069864" />
+      <stop
+         id="stop38"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop39"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect34"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect32"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect29"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="0"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       id="linearGradient28"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.04849076;"
+         offset="0"
+         id="stop25" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.01;"
+         offset="0.23"
+         id="stop26" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.02;"
+         offset="0.83999997"
+         id="stop27" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.14808641;"
+         offset="1"
+         id="stop28" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect20"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-0.5"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect16"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-0.5"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       id="linearGradient13"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#444548;stop-opacity:1;"
+         offset="0"
+         id="stop13" />
+      <stop
+         style="stop-color:#2d2f36;stop-opacity:1;"
+         offset="1"
+         id="stop14" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="0"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect10"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="0"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect9"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-0.5"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect8"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect7"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="0"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect6"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="0.5"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03153139" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         offset="0"
+         style="stop-color:#545454;stop-opacity:1;"
+         id="stop3734" />
+      <stop
+         offset="0.01900466"
+         style="stop-color:#545454;stop-opacity:0.23529412;"
+         id="stop3736" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#545454;stop-opacity:0.15686275;"
+         id="stop3738" />
+      <stop
+         offset="1"
+         style="stop-color:#545454;stop-opacity:0.39215687;"
+         id="stop3740" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient7374"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(1.2482815,0,0,0.28244155,34.872276,104.84673)"
+       r="22.627001">
+      <stop
+         id="stop23421"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#3b3b3b;stop-opacity:1;"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#242424;stop-opacity:1;"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.4795045,0,0,0.94918704,46.78552,51.080225)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-8"
+       id="linearGradient5466-8-3"
+       y2="45.68882"
+       x2="11.098394"
+       y1="5.9702148"
+       x1="11.098394" />
+    <linearGradient
+       xlink:href="#linearGradient3742"
+       id="linearGradient3730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7339903,0,0,1.3505035,-183.48873,61.607509)"
+       x1="118.57409"
+       y1="3.7037382"
+       x2="118.79462"
+       y2="32.292839" />
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.769231,0,0,3.1538457,-122.7077,3.1651316)"
+       x1="116.83477"
+       y1="-38.101143"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.5999998,0,0,2.6000002,1.6000049,-2.7999916)"
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13"
+       id="linearGradient14"
+       x1="65"
+       y1="55"
+       x2="65"
+       y2="95"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient28"
+       id="linearGradient20"
+       gradientUnits="userSpaceOnUse"
+       x1="65"
+       y1="65"
+       x2="65"
+       y2="55" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient28"
+       id="linearGradient25"
+       x1="64.077774"
+       y1="64.5"
+       x2="64.077774"
+       y2="55.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient4891"
+       id="linearGradient4889"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9283685,0,0,2.9332957,-292.22914,-33.504883)"
+       x1="120.00706"
+       y1="16.029192"
+       x2="120.00706"
+       y2="19.708174" />
+    <linearGradient
+       id="linearGradient4891">
+      <stop
+         id="stop4893"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4895"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.66162539" />
+      <stop
+         id="stop4899"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.9769201,0,0,3.1565158,-298.60711,-40.252268)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5005"
+       id="linearGradient3012"
+       y2="28.251366"
+       x2="120.19312"
+       y1="24.809452"
+       x1="120.19312" />
+    <linearGradient
+       id="linearGradient5005">
+      <stop
+         id="stop5007"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5009"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.6069864" />
+      <stop
+         id="stop5011"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop5013"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4891"
+       id="linearGradient4889-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6947408,0,0,1.6975923,-139.543,-6.2329336)"
+       x1="120.00706"
+       y1="16.029192"
+       x2="120.00706"
+       y2="19.708174" />
+    <linearGradient
+       gradientTransform="matrix(1.7228391,0,0,1.8267769,-143.23413,-10.137862)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5005"
+       id="linearGradient3012-2"
+       y2="28.251366"
+       x2="120.19312"
+       y1="24.809452"
+       x1="120.19312" />
+    <linearGradient
+       xlink:href="#linearGradient853"
+       id="linearGradient3013"
+       x1="63.999996"
+       y1="22.666992"
+       x2="63.999996"
+       y2="111.33398"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57873207,0,0,0.57873207,26.964313,-1.2925777)" />
+    <linearGradient
+       id="linearGradient853">
+      <stop
+         id="stop849"
+         offset="0"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         id="stop851"
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient39"
+       id="radialGradient41"
+       cx="76.218811"
+       cy="-9.3095264"
+       fx="76.218811"
+       fy="-9.3095264"
+       r="33.465588"
+       gradientTransform="matrix(0,-0.73160642,1.0213754,0,73.510475,77.646937)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient39"
+       id="radialGradient42"
+       cx="59.542591"
+       cy="37.915802"
+       fx="59.542591"
+       fy="37.915802"
+       r="21.428688"
+       gradientTransform="matrix(0,-0.41507593,1.5950796,0,3.5232309,64.333837)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <path
+     id="path23417"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
+     d="m 92.245596,116.60691 a 28.245597,6.3908297 0 1 1 -56.491192,0 28.245597,6.3908297 0 1 1 56.491192,0 z" />
+  <rect
+     id="rect3448"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:#000000;stroke-width:1.00000012;stroke-opacity:0.29302326"
+     transform="scale(1,-1)"
+     rx="1.0000001"
+     ry="1.0000001"
+     height="39"
+     width="39"
+     y="-118.5"
+     x="44.5" />
+  <path
+     style="opacity:0.1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 45,95 H 83"
+     id="path4538" />
+  <path
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67441861"
+     d="m 50.5,103.5 v 7 h 9 v -7 z"
+     id="rect3450" />
+  <rect
+     id="rect3458"
+     style="opacity:0.4;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     transform="scale(1,-1)"
+     height="37"
+     width="37"
+     y="-117.5"
+     x="45.5" />
+  <path
+     id="path4655"
+     d="m 68.5,103.5 v 7 h 9 v -7 z"
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67441861" />
+  <path
+     id="path4661"
+     d="M 50,111.5 H 60"
+     style="opacity:0.2;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     style="opacity:0.2;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 68,111.5 H 78"
+     id="path4663" />
+  <rect
+     rx="0.5"
+     ry="0.5"
+     y="99"
+     x="54"
+     height="1"
+     width="2"
+     id="rect4665"
+     style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     rx="0.5"
+     style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4667"
+     width="2"
+     height="1"
+     x="72"
+     y="99"
+     ry="0.5" />
+  <rect
+     rx="0.5"
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4669"
+     width="2"
+     height="1"
+     x="54"
+     y="100"
+     ry="0.5" />
+  <rect
+     ry="0.5"
+     y="100"
+     x="72"
+     height="1"
+     width="2"
+     id="rect4671"
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="0.5" />
+  <path
+     id="path12"
+     style="fill:#373737;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.29674199;stroke-linejoin:miter;fill-opacity:1"
+     d="m 39,54.5 c -1.384735,0 -2.5,1.115265 -2.5,2.5 v 6 c 0,1.213628 0.856057,2.218976 2,2.449219 v 19.101562 c -1.143943,0.230243 -2,1.235591 -2,2.449219 v 6 c 0,1.384735 1.115265,2.5 2.5,2.5 h 50 c 1.384735,0 2.5,-1.115265 2.5,-2.5 v -6 c 0,-1.213628 -0.856057,-2.218976 -2,-2.449219 V 65.449219 c 1.143943,-0.230243 2,-1.235591 2,-2.449219 v -6 c 0,-1.384735 -1.115265,-2.5 -2.5,-2.5 z" />
+  <path
+     id="rect10"
+     style="fill:url(#linearGradient14);stroke:none;stroke-width:0.667;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.296742;fill-opacity:1"
+     d="M 39 55 C 37.892001 55 37 55.892001 37 57 L 37 63 C 37 64.107999 37.892001 65 39 65 L 39 85 C 37.892001 85 37 85.892001 37 87 L 37 93 C 37 94.107999 37.892001 95 39 95 L 89 95 C 90.107999 95 91 94.107999 91 93 L 91 87 C 91 85.892001 90.107999 85 89 85 L 89 65 C 90.107999 65 91 64.107999 91 63 L 91 57 C 91 55.892001 90.107999 55 89 55 L 39 55 z " />
+  <path
+     style="fill:#444548;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:0.1524955"
+     d="M 39,65.75 H 89"
+     id="path16" />
+  <path
+     style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:0.296742"
+     d="M 39,65.5 H 89"
+     id="path14" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient25);stroke-width:1;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:1;opacity:1"
+     id="rect16"
+     width="54"
+     height="10"
+     x="37"
+     y="55"
+     rx="2"
+     ry="2"
+     sodipodi:type="rect"
+     d="m 39,55.5 h 50 c 0.831259,0 1.5,0.668741 1.5,1.5 v 6 c 0,0.831259 -0.668741,1.5 -1.5,1.5 H 39 c -0.831259,0 -1.5,-0.668741 -1.5,-1.5 v -6 c 0,-0.831259 0.668741,-1.5 1.5,-1.5 z"
+     inkscape:path-effect="#path-effect16" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient20);stroke-width:1;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:0.296742"
+     id="path19"
+     width="54"
+     height="10"
+     x="37"
+     y="55"
+     rx="2"
+     ry="2"
+     sodipodi:type="rect"
+     d="m 39,55.5 h 50 c 0.831259,0 1.5,0.668741 1.5,1.5 v 6 c 0,0.831259 -0.668741,1.5 -1.5,1.5 H 39 c -0.831259,0 -1.5,-0.668741 -1.5,-1.5 v -6 c 0,-0.831259 0.668741,-1.5 1.5,-1.5 z"
+     inkscape:path-effect="#path-effect20"
+     transform="translate(0,30)" />
+  <circle
+     style="fill:#df8814;fill-opacity:1;stroke:none;stroke-width:0.829176;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:0.296742"
+     id="path20"
+     cx="83.5"
+     cy="60"
+     r="2.8781252" />
+  <path
+     style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-dasharray:none;stroke-opacity:0.15000001"
+     d="M 39,84.5 H 89"
+     id="path28" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient3013);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 64.003166,11.825537 c -13.004029,0 -24.922599,5.073374 -34.181676,13.411102 l 7.434746,8.160837 c 7.281959,-6.743496 16.829835,-10.496512 26.74693,-10.513509 9.918003,0.01474 19.467534,3.76625 26.751246,10.509183 l 7.430423,-8.156511 C 88.925767,16.898911 77.007194,11.825537 64.003166,11.825537 Z m 0,17.898889 c -8.294307,0.0132 -16.279316,3.155444 -22.364667,8.8009 L 49.133687,46.5 c 4.037686,-3.770258 9.349515,-5.871374 14.869479,-5.881684 5.52236,0.0069 10.83758,2.106645 14.878113,5.877359 l 7.482236,-7.966021 C 80.279919,32.883633 72.296564,29.739889 64.003166,29.724426 Z"
+     id="path4391-5"
+     sodipodi:nodetypes="scccccsccccccc" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient42);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 64.001953,30.724609 c 7.705126,0.01437 15.130293,2.81876 20.927734,7.869141 l -6.111328,6.507812 c -4.122833,-3.524207 -9.37122,-5.475622 -14.816406,-5.482421 -5.439828,0.01016 -10.686244,1.962269 -14.806641,5.486328 l -6.123046,-6.515625 c 5.799251,-5.050189 13.226733,-7.85297 20.929687,-7.865235 z"
+     id="path32"
+     inkscape:path-effect="#path-effect34"
+     inkscape:original-d="m 64.003166,29.724426 c -8.294307,0.0132 -16.279316,3.155444 -22.364667,8.8009 L 49.133687,46.5 c 4.037686,-3.770258 9.349515,-5.871374 14.869479,-5.881684 5.52236,0.0069 10.83758,2.106645 14.878113,5.877359 l 7.482236,-7.966021 C 80.279919,32.883633 72.296564,29.739889 64.003166,29.724426 Z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient41);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 64.003906,12.826172 c 12.386703,0 23.776778,4.710519 32.751953,12.496094 l -6.078125,6.669921 C 83.310134,25.504192 73.838342,21.899379 64.001953,21.884766 54.169889,21.901617 44.697919,25.507903 37.332031,31.996094 l -6.078125,-6.675782 c 8.974864,-7.784495 20.364254,-12.49414 32.75,-12.49414 z"
+     id="path29"
+     inkscape:path-effect="#path-effect32"
+     inkscape:original-d="m 64.003166,11.825537 c -13.004029,0 -24.922599,5.073374 -34.181676,13.411102 l 7.434746,8.160837 c 7.281959,-6.743496 16.829835,-10.496512 26.74693,-10.513509 9.918003,0.01474 19.467534,3.76625 26.751246,10.509183 l 7.430423,-8.156511 C 88.925767,16.898911 77.007194,11.825537 64.003166,11.825537 Z" />
+</svg>

--- a/devices/16/usb-receiver.svg
+++ b/devices/16/usb-receiver.svg
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg11300"
+   height="16"
+   width="16"
+   version="1.0"
+   sodipodi:docname="usb-receiver.svg"
+   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="90.509668"
+     inkscape:cx="7.4909125"
+     inkscape:cy="7.2754659"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     inkscape:window-x="0"
+     inkscape:window-y="225"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata25">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3734" />
+      <stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3736" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3738" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3740" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3742"
+       id="linearGradient3730-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.163584,0,0,0.38091181,-9.2630881,0.26108203)"
+       x1="118.57409"
+       y1="4.5651455"
+       x2="118.57409"
+       y2="30.817942" />
+    <linearGradient
+       gradientTransform="matrix(0.28675946,0,0,0.301894,6.098381,-0.80358462)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-8"
+       id="linearGradient5466-8-3-0"
+       y2="45.68882"
+       x2="11.098394"
+       y1="5.9702148"
+       x1="11.098394" />
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.14345115,0,0,0.25571722,-7.138462,21.283658)"
+       x1="116.7913"
+       y1="-36.30439"
+       x2="116.7913"
+       y2="-28.483252" />
+    <linearGradient
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763-1"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33333333,0,0,0.33333333,0,25.333333)" />
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.26516308,0,0,0.06026566,48.916692,28.466026)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop23423" />
+    </radialGradient>
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(0.33471938,0,0,0.59667354,-43.328632,6.856386)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614-3" />
+    <linearGradient
+       id="linearGradient4614-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606-5" />
+      <stop
+         offset="0.03140453"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608-6" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610-2" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612-9" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect7"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect10"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+  </defs>
+  <rect
+     x="5.5"
+     y="10.5"
+     width="5"
+     height="5"
+     ry="0.5"
+     rx="0.5"
+     style="fill:url(#linearGradient4763-1);fill-opacity:1;stroke:none;stroke-width:1"
+     id="rect3448-7-9" />
+  <rect
+     x="5.5"
+     y="10.5"
+     width="5"
+     height="5"
+     ry="0.5"
+     rx="0.5"
+     style="opacity:0.4;fill:none;stroke:#000000;stroke-width:1;stroke-opacity:1"
+     id="rect3448-9-2" />
+  <path
+     id="rect3450-0"
+     d="m 6.5,12.499999 v -1 h 1 v 1 z m 2,0 v -1 h 1 v 1 z"
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     x="6.5"
+     y="11.5"
+     width="3"
+     height="3"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458-2" />
+  <rect
+     id="rect5391-3"
+     style="opacity:1;vector-effect:none;fill:#444548;fill-opacity:0.99173927;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.29970598;marker:none"
+     rx="0.99999994"
+     ry="1"
+     height="8.5"
+     width="7.0000782"
+     y="5"
+     x="4.4999609" />
+  <path
+     style="opacity:1;fill:none;fill-opacity:0.991739;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.596971"
+     d="m 5,8 v 2.5"
+     id="path1" />
+  <path
+     style="opacity:1;fill:none;fill-opacity:0.991739;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.596971"
+     d="m 11,8 v 2.5"
+     id="path2" />
+  <path
+     style="opacity:1;fill:none;fill-opacity:0.991739;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.147506"
+     d="m 5.5,6 h 5"
+     id="path5"
+     sodipodi:nodetypes="cc" />
+  <rect
+     style="opacity:1;fill:#000000;fill-opacity:0.302084;stroke:none;stroke-width:0.912872;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.147506"
+     id="rect8"
+     width="6"
+     height="2.5"
+     x="5"
+     y="8"
+     rx="0"
+     ry="0" />
+  <path
+     style="opacity:1;fill:none;fill-opacity:0.991739;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.147506"
+     d="m 5.5,11 h 5"
+     id="path8"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="opacity:1;fill:#000000;fill-opacity:0.302084;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.29970601"
+     d="m 5,8.5 h 6"
+     id="path10" />
+</svg>

--- a/devices/24/usb-receiver.svg
+++ b/devices/24/usb-receiver.svg
@@ -4,52 +4,12 @@
    width="24"
    height="24"
    id="svg2"
-   sodipodi:docname="usb-receiver.svg"
-   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="16"
-     inkscape:cx="21.59375"
-     inkscape:cy="17.28125"
-     inkscape:window-width="1920"
-     inkscape:window-height="1080"
-     inkscape:window-x="114"
-     inkscape:window-y="179"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg2">
-    <inkscape:grid
-       id="grid1"
-       units="px"
-       originx="0"
-       originy="0"
-       spacingx="1"
-       spacingy="1"
-       empcolor="#0099e5"
-       empopacity="0.30196078"
-       color="#0099e5"
-       opacity="0.14901961"
-       empspacing="5"
-       dotted="false"
-       gridanglex="30"
-       gridanglez="30"
-       visible="false" />
-  </sodipodi:namedview>
   <metadata
      id="metadata88">
     <rdf:RDF>
@@ -63,72 +23,6 @@
   </metadata>
   <defs
      id="defs4">
-    <linearGradient
-       id="linearGradient12"
-       inkscape:collect="always">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.2;"
-         offset="0"
-         id="stop10" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="0.27945617"
-         id="stop11" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="0.31193358"
-         id="stop12" />
-    </linearGradient>
-    <inkscape:path-effect
-       effect="offset"
-       id="path-effect10"
-       is_visible="true"
-       lpeversion="1.2"
-       linejoin_type="miter"
-       unit="px"
-       offset="-1"
-       miter_limit="4"
-       attempt_force_join="false"
-       update_on_knot_move="true" />
-    <inkscape:path-effect
-       effect="offset"
-       id="path-effect7"
-       is_visible="true"
-       lpeversion="1.2"
-       linejoin_type="miter"
-       unit="px"
-       offset="-1"
-       miter_limit="4"
-       attempt_force_join="false"
-       update_on_knot_move="true" />
-    <linearGradient
-       id="linearGradient4075">
-      <stop
-         id="stop4077"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4079"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
-      <stop
-         id="stop4081"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
-      <stop
-         id="stop4083"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="22.553417"
-       y1="6.6305909"
-       x2="22.553417"
-       y2="41.943768"
-       id="linearGradient4161-4"
-       xlink:href="#linearGradient4075"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.21462027,0,0,0.42391297,11.25048,-0.78050762)" />
     <linearGradient
        y2="-26.979191"
        x2="116.7913"
@@ -173,135 +67,7 @@
          id="stop23423" />
     </radialGradient>
     <linearGradient
-       x1="11.098394"
-       y1="5.9702148"
-       x2="11.098394"
-       y2="45.68882"
-       id="linearGradient5466-8-3-0"
-       xlink:href="#linearGradient3600-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.47793243,0,0,0.42768318,8.8306347,-1.55508)" />
-    <linearGradient
-       id="linearGradient3600-8">
-      <stop
-         id="stop3602-2"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604-5"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       id="radialGradient7374-3"
-       gradientUnits="userSpaceOnUse"
-       cy="41.636002"
-       cx="23.334999"
-       gradientTransform="matrix(0.39774462,0,0,0.0903985,-18.281076,19.690573)"
-       r="22.627001">
-      <stop
-         id="stop23421-6"
-         offset="0" />
-      <stop
-         id="stop23423-7"
-         style="stop-opacity:0"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       xlink:href="#linearGradient4614"
-       id="linearGradient4604-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.43035349,0,0,0.7671517,-54.42096,6.3788262)"
-       x1="116.7913"
-       y1="-37.80846"
-       x2="116.7913"
-       y2="-26.979191" />
-    <linearGradient
-       id="linearGradient24">
-      <stop
-         id="stop21"
-         style="stop-color:#ffffff;stop-opacity:0.15421827;"
-         offset="0" />
-      <stop
-         id="stop22"
-         style="stop-color:#ffffff;stop-opacity:0.02;"
-         offset="0.20387693" />
-      <stop
-         id="stop23"
-         style="stop-color:#ffffff;stop-opacity:0.02;"
-         offset="0.80686229" />
-      <stop
-         id="stop24"
-         style="stop-color:#ffffff;stop-opacity:0.08116093;"
-         offset="1" />
-    </linearGradient>
-    <inkscape:path-effect
-       effect="offset"
-       id="path-effect4"
-       is_visible="true"
-       lpeversion="1.2"
-       linejoin_type="miter"
-       unit="px"
-       offset="-1"
-       miter_limit="4"
-       attempt_force_join="false"
-       update_on_knot_move="true" />
-    <inkscape:path-effect
-       effect="offset"
-       id="path-effect19"
-       is_visible="true"
-       lpeversion="1.2"
-       linejoin_type="miter"
-       unit="px"
-       offset="-1"
-       miter_limit="4"
-       attempt_force_join="false"
-       update_on_knot_move="true" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient12"
-       id="linearGradient8"
-       x1="12"
-       y1="14"
-       x2="12"
-       y2="18"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient12"
-       id="linearGradient10"
-       gradientUnits="userSpaceOnUse"
-       x1="12"
-       y1="14"
-       x2="12"
-       y2="18" />
-    <radialGradient
-       id="radialGradient7374-3-3"
-       gradientUnits="userSpaceOnUse"
-       cy="41.636002"
-       cx="23.334999"
-       gradientTransform="matrix(0.39774462,0,0,0.0903985,23.016594,16.71842)"
-       r="22.627001">
-      <stop
-         id="stop23421-6-6"
-         offset="0" />
-      <stop
-         id="stop23423-7-0"
-         style="stop-opacity:0"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       xlink:href="#linearGradient4614"
-       id="linearGradient4604-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.43035349,0,0,0.7671517,-13.12329,9.3509789)"
-       x1="116.7913"
-       y1="-37.80846"
-       x2="116.7913"
-       y2="-26.979191" />
-    <linearGradient
-       id="linearGradient13"
-       inkscape:collect="always">
+       id="linearGradient13">
       <stop
          style="stop-color:#444548;stop-opacity:1;"
          offset="0"
@@ -311,30 +77,7 @@
          offset="1"
          id="stop14" />
     </linearGradient>
-    <inkscape:path-effect
-       effect="offset"
-       id="path-effect4-2"
-       is_visible="true"
-       lpeversion="1.2"
-       linejoin_type="miter"
-       unit="px"
-       offset="-1"
-       miter_limit="4"
-       attempt_force_join="false"
-       update_on_knot_move="true" />
-    <inkscape:path-effect
-       effect="offset"
-       id="path-effect19-3"
-       is_visible="true"
-       lpeversion="1.2"
-       linejoin_type="miter"
-       unit="px"
-       offset="-1"
-       miter_limit="4"
-       attempt_force_join="false"
-       update_on_knot_move="true" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient13"
        id="linearGradient16"
        x1="12"
@@ -419,28 +162,19 @@
      d="m 8,11 h 8"
      id="path6" />
   <path
-     style="fill:none;fill-opacity:1;stroke:url(#linearGradient8);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-     id="rect7"
-     width="11.000039"
-     height="5"
-     x="6.4999609"
-     y="13.5"
-     rx="1"
-     ry="1"
-     inkscape:path-effect="#path-effect7"
-     sodipodi:type="rect"
-     d="m 7.5,14.5 h 9 v 3 h -9 z" />
+     style="fill:none;fill-opacity:0.302084;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.15000001;stroke-dasharray:none"
+     d="m 7.5,6.5 h 9"
+     id="path1" />
   <path
-     style="fill:none;fill-opacity:1;stroke:url(#linearGradient10);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-     id="path9"
-     width="11.000039"
-     height="5"
-     x="6.4999609"
-     y="13.5"
-     rx="1"
-     ry="1"
-     inkscape:path-effect="#path-effect10"
-     sodipodi:type="rect"
-     d="m 7.5,14.5 h 9 v 3 h -9 z"
-     transform="translate(0,-8)" />
+     style="fill:none;fill-opacity:0.302084;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.15"
+     d="m 7.5,14.5 h 9"
+     id="path2" />
+  <path
+     style="fill:none;fill-opacity:0.302084;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.05"
+     d="m 7.5,9.5 h 9"
+     id="path3" />
+  <path
+     style="fill:none;fill-opacity:0.302084;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.05"
+     d="m 7.5,17.5 h 9"
+     id="path4" />
 </svg>

--- a/devices/24/usb-receiver.svg
+++ b/devices/24/usb-receiver.svg
@@ -1,0 +1,446 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.0"
+   width="24"
+   height="24"
+   id="svg2"
+   sodipodi:docname="usb-receiver.svg"
+   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="21.59375"
+     inkscape:cy="17.28125"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     inkscape:window-x="114"
+     inkscape:window-y="179"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata88">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient12"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.2;"
+         offset="0"
+         id="stop10" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0.27945617"
+         id="stop11" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0.31193358"
+         id="stop12" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect10"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect7"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       id="linearGradient4075">
+      <stop
+         id="stop4077"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4079"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4081"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4083"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="22.553417"
+       y1="6.6305909"
+       x2="22.553417"
+       y2="41.943768"
+       id="linearGradient4161-4"
+       xlink:href="#linearGradient4075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21462027,0,0,0.42391297,11.25048,-0.78050762)" />
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(0.33471938,0,0,0.59667354,-23.328651,0.35638626)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606" />
+      <stop
+         offset="0.03140453"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612" />
+    </linearGradient>
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.26516308,0,0,0.06026566,48.916692,28.466026)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop23423" />
+    </radialGradient>
+    <linearGradient
+       x1="11.098394"
+       y1="5.9702148"
+       x2="11.098394"
+       y2="45.68882"
+       id="linearGradient5466-8-3-0"
+       xlink:href="#linearGradient3600-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.47793243,0,0,0.42768318,8.8306347,-1.55508)" />
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         id="stop3602-2"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient7374-3"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.39774462,0,0,0.0903985,-18.281076,19.690573)"
+       r="22.627001">
+      <stop
+         id="stop23421-6"
+         offset="0" />
+      <stop
+         id="stop23423-7"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43035349,0,0,0.7671517,-54.42096,6.3788262)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient24">
+      <stop
+         id="stop21"
+         style="stop-color:#ffffff;stop-opacity:0.15421827;"
+         offset="0" />
+      <stop
+         id="stop22"
+         style="stop-color:#ffffff;stop-opacity:0.02;"
+         offset="0.20387693" />
+      <stop
+         id="stop23"
+         style="stop-color:#ffffff;stop-opacity:0.02;"
+         offset="0.80686229" />
+      <stop
+         id="stop24"
+         style="stop-color:#ffffff;stop-opacity:0.08116093;"
+         offset="1" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect4"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect19"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12"
+       id="linearGradient8"
+       x1="12"
+       y1="14"
+       x2="12"
+       y2="18"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12"
+       id="linearGradient10"
+       gradientUnits="userSpaceOnUse"
+       x1="12"
+       y1="14"
+       x2="12"
+       y2="18" />
+    <radialGradient
+       id="radialGradient7374-3-3"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.39774462,0,0,0.0903985,23.016594,16.71842)"
+       r="22.627001">
+      <stop
+         id="stop23421-6-6"
+         offset="0" />
+      <stop
+         id="stop23423-7-0"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43035349,0,0,0.7671517,-13.12329,9.3509789)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient13"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#444548;stop-opacity:1;"
+         offset="0"
+         id="stop13" />
+      <stop
+         style="stop-color:#2d2f36;stop-opacity:1;"
+         offset="1"
+         id="stop14" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect4-2"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect19-3"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13"
+       id="linearGradient16"
+       x1="12"
+       y1="9"
+       x2="12"
+       y2="15"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g4579"
+     transform="translate(-43.104077,-8.3392264)">
+    <path
+       id="path23417"
+       style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:0.99999994"
+       d="m 61.104077,30.975341 a 6.0000001,1.3636364 0 1 1 -12,0 6.0000001,1.3636364 0 1 1 12,0 z" />
+  </g>
+  <rect
+     x="7.5"
+     y="-23.5"
+     width="9"
+     height="9"
+     ry="1"
+     rx="1"
+     transform="scale(1,-1)"
+     style="fill:#e6e6e6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.30232558"
+     id="rect3448" />
+  <g
+     id="g4576"
+     style="opacity:0.2">
+    <rect
+       y="20"
+       x="9"
+       height="2"
+       width="2"
+       id="rect4570"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4" />
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4"
+       id="rect4572"
+       width="2"
+       height="2"
+       x="13"
+       y="20" />
+  </g>
+  <rect
+     x="8.4944277"
+     y="-22.472153"
+     width="7"
+     height="7"
+     transform="scale(1,-1)"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458" />
+  <rect
+     style="fill:url(#linearGradient16);fill-opacity:1;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.29608"
+     id="rect6"
+     width="10"
+     height="6"
+     x="7"
+     y="9"
+     rx="0"
+     ry="0" />
+  <rect
+     style="fill:#2d2f36;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.29608;fill-opacity:1;stroke-dasharray:none"
+     id="rect1"
+     width="11.000039"
+     height="5"
+     x="6.4999609"
+     y="13.5"
+     rx="1"
+     ry="1" />
+  <rect
+     style="fill:#444548;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.29608;stroke-dasharray:none"
+     id="rect5"
+     width="11.000039"
+     height="5"
+     x="6.4999609"
+     y="5.5"
+     rx="1"
+     ry="1" />
+  <path
+     style="fill:#2d2f36;fill-opacity:1;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.29608"
+     d="m 8,11 h 8"
+     id="path6" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient8);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect7"
+     width="11.000039"
+     height="5"
+     x="6.4999609"
+     y="13.5"
+     rx="1"
+     ry="1"
+     inkscape:path-effect="#path-effect7"
+     sodipodi:type="rect"
+     d="m 7.5,14.5 h 9 v 3 h -9 z" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient10);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path9"
+     width="11.000039"
+     height="5"
+     x="6.4999609"
+     y="13.5"
+     rx="1"
+     ry="1"
+     inkscape:path-effect="#path-effect10"
+     sodipodi:type="rect"
+     d="m 7.5,14.5 h 9 v 3 h -9 z"
+     transform="translate(0,-8)" />
+</svg>

--- a/devices/32/usb-receiver.svg
+++ b/devices/32/usb-receiver.svg
@@ -1,0 +1,462 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg2"
+   height="32"
+   width="32"
+   version="1.0"
+   sodipodi:docname="usb-receiver.svg"
+   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="32.03125"
+     inkscape:cy="18.59375"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     inkscape:window-x="80"
+     inkscape:window-y="155"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata88">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient24">
+      <stop
+         id="stop21"
+         style="stop-color:#ffffff;stop-opacity:0.15421827;"
+         offset="0" />
+      <stop
+         id="stop22"
+         style="stop-color:#ffffff;stop-opacity:0.02;"
+         offset="0.20387693" />
+      <stop
+         id="stop23"
+         style="stop-color:#ffffff;stop-opacity:0.02;"
+         offset="0.80686229" />
+      <stop
+         id="stop24"
+         style="stop-color:#ffffff;stop-opacity:0.08116093;"
+         offset="1" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect19"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       id="linearGradient15">
+      <stop
+         id="stop10"
+         style="stop-color:#ffffff;stop-opacity:0.15421827;"
+         offset="0" />
+      <stop
+         id="stop11"
+         style="stop-color:#ffffff;stop-opacity:0.02;"
+         offset="0.28721026" />
+      <stop
+         id="stop12"
+         style="stop-color:#ffffff;stop-opacity:0.02;"
+         offset="0.66945094" />
+      <stop
+         id="stop15"
+         style="stop-color:#ffffff;stop-opacity:0.08116093;"
+         offset="1" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect4"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       id="linearGradient4075">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4077" />
+      <stop
+         offset="0.03367912"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4079" />
+      <stop
+         offset="0.99223143"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4081" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4083" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.26232885,0,0,0.42474288,18.083588,5.1837037)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4075"
+       id="linearGradient4161-4"
+       y2="41.946075"
+       x2="11.11739"
+       y1="-7.4956021"
+       x1="11.11739" />
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43035349,0,0,0.7671517,-29.42096,-0.1211738)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03140453" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.996155"
+       x2="16.875002"
+       y1="0"
+       x1="17"
+       id="linearGradient4616"
+       xlink:href="#linearGradient3600-8" />
+    <radialGradient
+       id="radialGradient7374-3"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.39774462,0,0,0.0903985,6.718924,26.190573)"
+       r="22.627001">
+      <stop
+         id="stop23421-6"
+         offset="0" />
+      <stop
+         id="stop23423-7"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient13"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#444548;stop-opacity:1;"
+         offset="0"
+         id="stop13" />
+      <stop
+         style="stop-color:#2d2f36;stop-opacity:1;"
+         offset="1"
+         id="stop14" />
+    </linearGradient>
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.48613231,0,0,0.11048705,34.017183,26.866879)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop23423" />
+    </radialGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-44.395805"
+       x2="25"
+       y1="-35"
+       x1="25"
+       id="linearGradient4763"
+       xlink:href="#linearGradient7056"
+       gradientTransform="translate(21.360721,13.031309)" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         id="stop7064"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(0.62162171,0,0,1.108108,-20.239283,11.927167)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604-6"
+       xlink:href="#linearGradient4614-7" />
+    <linearGradient
+       id="linearGradient4614-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606-5" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608-3" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9">
+      <stop
+         id="stop6"
+         style="stop-color:#ffffff;stop-opacity:0.15421827;"
+         offset="0" />
+      <stop
+         id="stop7"
+         style="stop-color:#ffffff;stop-opacity:0.0492001;"
+         offset="0.19412513" />
+      <stop
+         id="stop8"
+         style="stop-color:#ffffff;stop-opacity:0.05365422;"
+         offset="0.84586936" />
+      <stop
+         id="stop9"
+         style="stop-color:#ffffff;stop-opacity:0.08116093;"
+         offset="1" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect20"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13"
+       id="linearGradient4"
+       x1="16"
+       y1="11"
+       x2="16"
+       y2="20"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.66666669,0,6.6666668)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient24"
+       id="linearGradient18"
+       x1="16"
+       y1="9"
+       x2="16"
+       y2="12"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient24"
+       id="linearGradient19"
+       gradientUnits="userSpaceOnUse"
+       x1="16"
+       y1="9"
+       x2="16"
+       y2="12" />
+  </defs>
+  <path
+     id="path23417"
+     style="opacity:0.3;fill:url(#radialGradient7374-3);fill-rule:evenodd;stroke-width:0.99999988"
+     d="m 25,29.954546 c 0,2.727271 -18,2.727271 -18,0 0,-2.727271 18,-2.727271 18,0 z" />
+  <rect
+     id="rect3448"
+     style="fill:#e6e6e6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.30232562"
+     transform="scale(1,-1)"
+     rx="1"
+     ry="1"
+     height="11"
+     width="11"
+     y="-30.5"
+     x="10.5" />
+  <path
+     style="opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4"
+     d="m 13,27 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m -3.5,0.5 h 1 v 1 h -1 z m 4,0 h 1 v 1 h -1 z"
+     id="rect4570" />
+  <rect
+     id="rect3458"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     transform="scale(1,-1)"
+     height="9"
+     width="9"
+     y="-29.472153"
+     x="11.494428" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path4034"
+     d="M 10,1.46875 C 10,1.46875 9.4741176,1.508235 9.5,2 v 21.5 h 13 V 2 C 22.473926,1.4516678 22,1.46875 22,1.46875 Z" />
+  <g
+     id="g4622"
+     style="opacity:0.2"
+     transform="translate(4,7)">
+    <path
+       id="rect4618"
+       d="m 9.5,20.5 v 1 h 1 v -1 z m 4,0 v 1 h 1 v -1 z"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4" />
+  </g>
+  <path
+     id="path4666"
+     d="M 11,25 H 21"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.1" />
+  <rect
+     style="fill:url(#linearGradient4);stroke:#000000;stroke-width:0.925822;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.3;paint-order:normal"
+     id="rect3"
+     width="12"
+     height="6"
+     x="10"
+     y="14"
+     rx="0"
+     ry="0" />
+  <rect
+     style="fill:#2d2f36;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.3;paint-order:normal;fill-opacity:1"
+     id="rect1"
+     width="15"
+     height="5"
+     x="8.5"
+     y="19.5"
+     rx="1"
+     ry="1" />
+  <rect
+     style="fill:#444548;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.3;paint-order:normal"
+     id="rect2"
+     width="15"
+     height="5"
+     x="8.5"
+     y="9"
+     rx="1"
+     ry="1" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient18);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="rect4"
+     width="15"
+     height="5"
+     x="8.5"
+     y="8"
+     rx="1"
+     ry="1"
+     inkscape:path-effect="#path-effect4"
+     sodipodi:type="rect"
+     d="m 9.5,9 h 13 v 3 h -13 z"
+     transform="translate(0,1)" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient19);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="path18"
+     width="15"
+     height="5"
+     x="8.5"
+     y="8"
+     rx="1"
+     ry="1"
+     inkscape:path-effect="#path-effect19"
+     sodipodi:type="rect"
+     d="m 9.5,9 h 13 v 3 h -13 z"
+     transform="translate(0,11.5)" />
+  <path
+     style="fill:#df8814;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.29608;paint-order:normal"
+     d="M 11,14.5 H 21"
+     id="path21" />
+</svg>

--- a/devices/48/usb-receiver.svg
+++ b/devices/48/usb-receiver.svg
@@ -1,0 +1,411 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 48 48"
+   version="1.0"
+   width="48"
+   height="48"
+   id="svg11300"
+   sodipodi:docname="usb-receiver.svg"
+   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.351722"
+     inkscape:cx="2.8630017"
+     inkscape:cy="37.4833"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     inkscape:window-x="302"
+     inkscape:window-y="137"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata49">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3">
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect20"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         id="stop3734"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3736"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.01900466" />
+      <stop
+         id="stop3738"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop3740"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.48613231,0,0,0.11048705,12.656462,39.898188)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop23423" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         id="stop3602-2"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.098394"
+       y1="5.9702148"
+       x2="11.098394"
+       y2="45.68882"
+       id="linearGradient5466-8-3"
+       xlink:href="#linearGradient3600-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95586485,0,0,0.83020854,17.661268,-2.959857)" />
+    <linearGradient
+       y2="31.67935"
+       x2="118.57409"
+       y1="3.7037382"
+       x1="118.57409"
+       gradientTransform="matrix(0.62162171,0,0,1.108108,-41.600004,-1.104142)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3730"
+       xlink:href="#linearGradient3742" />
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(0.62162171,0,0,1.108108,-41.600004,-1.104142)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         id="stop7064"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-44.395805"
+       x2="25"
+       y1="-35"
+       x1="25"
+       id="linearGradient4763"
+       xlink:href="#linearGradient7056" />
+    <radialGradient
+       id="radialGradient7374-6"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.61871386,0,0,0.14061988,-34.200361,36.46171)"
+       r="22.627001">
+      <stop
+         id="stop23421-7"
+         offset="0" />
+      <stop
+         id="stop23423-5"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2666667,0,0,1.2666667,-51.163131,13.36667)"
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763-3"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81288992,0,0,1.4490643,-106.54775,13.440742)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient13"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#444548;stop-opacity:1;"
+         offset="0"
+         id="stop13" />
+      <stop
+         style="stop-color:#2d2f36;stop-opacity:1;"
+         offset="1"
+         id="stop14" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9">
+      <stop
+         id="stop6"
+         style="stop-color:#ffffff;stop-opacity:0.15421827;"
+         offset="0" />
+      <stop
+         id="stop7"
+         style="stop-color:#ffffff;stop-opacity:0.0492001;"
+         offset="0.19412513" />
+      <stop
+         id="stop8"
+         style="stop-color:#ffffff;stop-opacity:0.05365422;"
+         offset="0.84586936" />
+      <stop
+         id="stop9"
+         style="stop-color:#ffffff;stop-opacity:0.08116093;"
+         offset="1" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect4"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect5"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13"
+       id="linearGradient12"
+       x1="24"
+       y1="20"
+       x2="24"
+       y2="28"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9"
+       id="linearGradient17"
+       x1="24"
+       y1="13"
+       x2="24"
+       y2="20"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9"
+       id="linearGradient20"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="13"
+       x2="24"
+       y2="20" />
+  </defs>
+  <rect
+     style="fill:url(#linearGradient12);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.297752"
+     id="rect8"
+     width="18"
+     height="8"
+     x="15"
+     y="20"
+     rx="0"
+     ry="0" />
+  <path
+     d="m 35,44.4986 a 11,2.5 0 1 1 -22,0 11,2.5 0 1 1 22,0 z"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:0.99999994"
+     id="path23417" />
+  <rect
+     x="16.5"
+     y="-44.5"
+     width="15"
+     height="15"
+     ry="1"
+     rx="1"
+     transform="scale(1,-1)"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:none"
+     id="rect3448" />
+  <rect
+     x="16.5"
+     y="-44.5"
+     width="15"
+     height="15"
+     ry="1"
+     rx="1"
+     transform="scale(1,-1)"
+     style="opacity:0.4;fill:none;stroke:#000000;stroke-opacity:1"
+     id="rect3448-9" />
+  <path
+     id="rect3450"
+     d="m 19.5,38.5 v 3 h 3 v -3 z m 6,0 v 3 h 3 v -3 z"
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598849;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     x="17.5"
+     y="-43.5"
+     width="13"
+     height="13"
+     transform="scale(1,-1)"
+     style="opacity:0.6;fill:none;stroke:url(#linearGradient4604);font-variant-east_asian:normal;fill-opacity:1;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458" />
+  <rect
+     style="fill:#2d2f36;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.297752"
+     id="rect6"
+     width="21"
+     height="8"
+     x="13.5"
+     y="27.5"
+     rx="2"
+     ry="2" />
+  <rect
+     style="fill:#444548;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.297752"
+     id="rect7"
+     width="21"
+     height="8"
+     x="13.5"
+     y="12.5"
+     rx="2"
+     ry="2" />
+  <path
+     style="fill:#444548;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.297752"
+     d="M 16,21 H 32"
+     id="path12" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient17);stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect12"
+     width="21"
+     height="8"
+     x="13.5"
+     y="12.5"
+     rx="2"
+     ry="2"
+     inkscape:path-effect="#path-effect12"
+     sodipodi:type="rect"
+     d="m 15.5,13.5 h 17 c 0.554522,0 1,0.445478 1,1 v 4 c 0,0.554522 -0.445478,1 -1,1 h -17 c -0.554522,0 -1,-0.445478 -1,-1 v -4 c 0,-0.554522 0.445478,-1 1,-1 z" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient20);stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path19"
+     width="21"
+     height="8"
+     x="13.5"
+     y="12.5"
+     rx="2"
+     ry="2"
+     inkscape:path-effect="#path-effect20"
+     sodipodi:type="rect"
+     d="m 15.5,13.5 h 17 c 0.554522,0 1,0.445478 1,1 v 4 c 0,0.554522 -0.445478,1 -1,1 h -17 c -0.554522,0 -1,-0.445478 -1,-1 v -4 c 0,-0.554522 0.445478,-1 1,-1 z"
+     transform="translate(0,15)" />
+  <circle
+     style="fill:#df8814;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.30000001;paint-order:stroke markers fill"
+     id="path20"
+     cx="18"
+     cy="16.5"
+     r="2" />
+</svg>

--- a/devices/64/usb-receiver.svg
+++ b/devices/64/usb-receiver.svg
@@ -1,0 +1,434 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg11300"
+   height="64"
+   width="64"
+   version="1.0"
+   viewBox="0 0 64 64"
+   sodipodi:docname="usb-receiver.svg"
+   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="3.8028789"
+     inkscape:cx="-56.141678"
+     inkscape:cy="2.2351488"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     inkscape:window-x="175"
+     inkscape:window-y="107"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300"
+     showgrid="false">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata49">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient9">
+      <stop
+         id="stop6"
+         style="stop-color:#ffffff;stop-opacity:0.15421827;"
+         offset="0" />
+      <stop
+         id="stop7"
+         style="stop-color:#ffffff;stop-opacity:0.0492001;"
+         offset="0.19412513" />
+      <stop
+         id="stop8"
+         style="stop-color:#ffffff;stop-opacity:0.05365422;"
+         offset="0.84586936" />
+      <stop
+         id="stop9"
+         style="stop-color:#ffffff;stop-opacity:0.08116093;"
+         offset="1" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect5"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect4"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3734" />
+      <stop
+         offset="0.01900466"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3736" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3738" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3740" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient7374"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.61871386,0,0,0.14061988,17.56277,53.961714)"
+       r="22.627001">
+      <stop
+         id="stop23421"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2289726,0,0,1.0632918,22.850217,-0.1995066)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-8"
+       id="linearGradient5466-8-3"
+       y2="45.68882"
+       x2="11.098394"
+       y1="5.9702148"
+       x1="11.098394" />
+    <linearGradient
+       xlink:href="#linearGradient3742"
+       id="linearGradient3730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81791996,0,0,1.4890166,-55.31544,0.6569973)"
+       x1="118.57409"
+       y1="3.7037382"
+       x2="118.57409"
+       y2="31.67935" />
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81288992,0,0,1.4490643,-54.78462,-4.0592618)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2666667,0,0,1.2666667,0.6,-4.1333342)"
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient13"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#444548;stop-opacity:1;"
+         offset="0"
+         id="stop13" />
+      <stop
+         style="stop-color:#2d2f36;stop-opacity:1;"
+         offset="1"
+         id="stop14" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect16"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-0.5"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect20"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-0.5"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       xlink:href="#linearGradient853"
+       id="linearGradient3013"
+       x1="63.999996"
+       y1="22.666992"
+       x2="63.999996"
+       y2="111.33398"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57873207,0,0,0.57873207,-84.974781,-29.158463)" />
+    <linearGradient
+       id="linearGradient853">
+      <stop
+         id="stop849"
+         offset="0"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         id="stop851"
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient39">
+      <stop
+         id="stop36"
+         style="stop-color:#ffffff;stop-opacity:0.50104409;"
+         offset="0" />
+      <stop
+         id="stop37"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.6069864" />
+      <stop
+         id="stop38"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop39"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect34"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <inkscape:path-effect
+       effect="offset"
+       id="path-effect32"
+       is_visible="true"
+       lpeversion="1.2"
+       linejoin_type="miter"
+       unit="px"
+       offset="-1"
+       miter_limit="4"
+       attempt_force_join="false"
+       update_on_knot_move="true" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9"
+       id="linearGradient6"
+       x1="31"
+       y1="24"
+       x2="31"
+       y2="30"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9"
+       id="linearGradient11"
+       x1="31"
+       y1="42.5"
+       x2="31"
+       y2="48.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13"
+       id="linearGradient16"
+       x1="31"
+       y1="30"
+       x2="31"
+       y2="43"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0909091,0,0,1,-2.8181818,0)" />
+  </defs>
+  <path
+     id="path23417"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
+     d="m 46,59.816784 a 14.000001,3.1818183 0 1 1 -28.000001,0 14.000001,3.1818183 0 1 1 28.000001,0 z" />
+  <rect
+     id="rect3448"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:#000000;stroke-width:1.00000012;stroke-opacity:0.29302326"
+     transform="scale(1,-1)"
+     rx="1.0000001"
+     ry="1.0000001"
+     height="19"
+     width="19"
+     y="-60.500004"
+     x="21.5" />
+  <path
+     style="opacity:0.1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 22,49.5 H 40"
+     id="path4538" />
+  <path
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67441863"
+     d="m 24.5,53.5 v 4 h 4 v -4 z m 9,0 v 4 h 4 v -4 z"
+     id="rect3450" />
+  <rect
+     id="rect3458"
+     style="opacity:0.4;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     transform="scale(1,-1)"
+     height="17"
+     width="17"
+     y="-59.5"
+     x="22.5" />
+  <rect
+     style="fill:url(#linearGradient16);stroke:#000000;stroke-width:1.04447;stroke-opacity:0.297413"
+     id="rect3"
+     width="24"
+     height="13"
+     x="19"
+     y="30"
+     rx="0"
+     ry="0" />
+  <rect
+     style="fill:#2d2f36;fill-opacity:1;stroke:#000000;stroke-opacity:0.297413"
+     id="rect1"
+     width="27"
+     height="8"
+     x="17.5"
+     y="41.5"
+     rx="2.5"
+     ry="2.5" />
+  <rect
+     style="fill:#444548;fill-opacity:1;stroke:#000000;stroke-opacity:0.3"
+     id="rect2"
+     width="27"
+     height="8"
+     x="17.5"
+     y="23"
+     rx="2.5"
+     ry="2.5" />
+  <circle
+     style="fill:#df8814;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-opacity:0.297413;paint-order:stroke markers fill;stroke-dasharray:none"
+     id="path17"
+     cx="22"
+     cy="27"
+     r="2" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient6);stroke-opacity:1"
+     id="rect4"
+     width="27"
+     height="8"
+     x="17.5"
+     y="23"
+     rx="2.5"
+     ry="2.5"
+     inkscape:path-effect="#path-effect4"
+     sodipodi:type="rect"
+     d="m 20,24 h 22 c 0.831521,0 1.5,0.668479 1.5,1.5 v 3 C 43.5,29.331521 42.831521,30 42,30 H 20 c -0.831521,0 -1.5,-0.668479 -1.5,-1.5 v -3 C 18.5,24.668479 19.168479,24 20,24 Z" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient11);stroke-opacity:1"
+     id="rect5"
+     width="27"
+     height="8"
+     x="17.5"
+     y="41.5"
+     rx="2.5"
+     ry="2.5"
+     inkscape:path-effect="#path-effect5"
+     sodipodi:type="rect"
+     d="m 20,42.5 h 22 c 0.831521,0 1.5,0.668479 1.5,1.5 v 3 c 0,0.831521 -0.668479,1.5 -1.5,1.5 H 20 c -0.831521,0 -1.5,-0.668479 -1.5,-1.5 v -3 c 0,-0.831521 0.668479,-1.5 1.5,-1.5 z" />
+  <path
+     style="fill:#df8814;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:0.297413;paint-order:stroke markers fill"
+     d="M 20,31.5 H 42.035475"
+     id="path18" />
+</svg>


### PR DESCRIPTION
This adds icons for the USB universal mouse/keyboard receiver, closing #1240 . The set uses `drive-removeable-media-usb` as a base.