### PR TITLE
Actions: Refresh revert icon

### DIFF
--- a/actions/24/document-revert.svg
+++ b/actions/24/document-revert.svg
@@ -1,267 +1,289 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="24"
+   id="svg4157"
    height="24"
-   id="svg3828">
-  <defs
-     id="defs3830">
-    <linearGradient
-       id="linearGradient3977">
-      <stop
-         id="stop3979"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3981"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03626217" />
-      <stop
-         id="stop3983"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3985"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600-4">
-      <stop
-         id="stop3602-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604-6"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.99999"
-       y1="5.5641499"
+   width="24"
+   version="1.1"
+   xml:space="preserve"
+   sodipodi:docname="document-revert.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview323"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="-1.671875"
+     inkscape:cy="13.328125"
+     inkscape:window-width="1278"
+     inkscape:window-height="752"
+     inkscape:window-x="352"
+     inkscape:window-y="236"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4157" /><defs
+     id="defs4159"><linearGradient
+       inkscape:collect="always"
+       id="linearGradient38830"><stop
+         style="stop-color:#ff8c82;stop-opacity:1"
+         offset="0"
+         id="stop38826" /><stop
+         style="stop-color:#ed5353;stop-opacity:1"
+         offset="1"
+         id="stop38828" /></linearGradient><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945945,0.97297429,0.97297586)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.167725"
        x2="23.99999"
-       y2="43"
-       id="linearGradient3013"
-       xlink:href="#linearGradient3977"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)" />
-    <linearGradient
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336"
-       id="linearGradient3016"
-       xlink:href="#linearGradient3600-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48571543,0,0,0.45629666,0.3428289,0.3488617)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3021"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3024"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)" />
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient3027"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)" />
-    <linearGradient
-       x1="38.940514"
-       y1="15.991243"
-       x2="20.576487"
-       y2="15.991243"
-       id="linearGradient3037"
-       xlink:href="#linearGradient4087"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.42848511,-0.45965715,0,17.287134,22.634688)" />
-    <linearGradient
-       id="linearGradient4087">
-      <stop
-         id="stop4089"
+       y1="6.7566175"
+       x1="23.99999" /><linearGradient
+       id="linearGradient4095"><stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4091"
+         id="stop4097" /><stop
+         offset="0.03537823"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.51153916" />
-      <stop
-         id="stop4093"
+         id="stop4100" /><stop
+         offset="0.96216732"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.58522105" />
-      <stop
-         id="stop4095"
+         id="stop4102" /><stop
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.731871"
-       y1="4.4175272"
-       x2="23.731871"
-       y2="42.03978"
-       id="linearGradient3040"
-       xlink:href="#linearGradient3846"
+         id="stop4104" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.39222363,0,0,0.36562471,17.986391,2.8539844)" />
-    <linearGradient
-       id="linearGradient3846">
-      <stop
-         id="stop3848"
-         style="stop-color:#fff3cb;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3850"
-         style="stop-color:#fdde76;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3852"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3854"
-         style="stop-color:#e48b20;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="35.998066"
-       y1="37.038586"
-       x2="35.998066"
-       y2="4.0044417"
-       id="linearGradient3042"
-       xlink:href="#linearGradient3856"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-166-749-9"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-2" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-2" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.39222363,0,0,0.36562471,17.986391,2.8539844)" />
-    <linearGradient
-       id="linearGradient3856">
-      <stop
-         id="stop3858"
-         style="stop-color:#b67926;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3860"
-         style="stop-color:#eab41a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient8662">
-      <stop
-         id="stop8664"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8666"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="24.837126"
-       cy="36.421127"
-       r="15.644737"
-       fx="24.837126"
-       fy="36.421127"
-       id="radialGradient3087"
-       xlink:href="#linearGradient8662"
+       xlink:href="#linearGradient3688-464-309-7-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-464-309-7-6"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-75" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4-9" /></linearGradient><linearGradient
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.38351555,0,0,-0.25567694,0.456539,24.312047)" />
-  </defs>
-  <metadata
-     id="metadata3833">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <rect
-     width="16.999998"
-     height="2"
-     x="3.5000007"
-     y="22"
-     id="rect2879"
-     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
-     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z"
-     id="path2881"
-     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
-     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z"
-     id="path2883"
-     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
-     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z"
-     id="path4160-3"
-     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
-  <path
-     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z"
-     id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-  <path
-     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z"
-     id="path4160-3-1"
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-  <path
-     d="M 15.981963,15 A 6.0000001,4.0000001 0 1 0 3.9819629,15 6.0000001,4.0000001 0 0 0 15.981963,15 z"
-     id="path3501"
-     style="opacity:0.14117647;fill:url(#radialGradient3087);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
-     d="m 11.981962,17 c 4.980222,-3.367056 2.051119,-9.5507276 -3.5,-9.4999996 l 0,-3.000485 -7,5 7,4.9999996 0,-2.976351 c 3.580248,-0.139062 5.559516,3.12742 3,5.476836 z"
+       xlink:href="#linearGradient3702-501-757-1"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" /><linearGradient
+       id="linearGradient3702-501-757-1"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-2" /><stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-89" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-36" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1271"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-41.857271,-23.833435)"
+       x1="70.385941"
+       y1="51.425007"
+       x2="70.385941"
+       y2="29.002073" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46014931,0,0,0.44257234,-22.052748,0.86281849)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" /><linearGradient
+       id="linearGradient971"><stop
+         id="stop963"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop965"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.51999998" /><stop
+         id="stop967"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.51999998" /><stop
+         id="stop969"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient38830"
+       id="linearGradient38832"
+       x1="4.9768834"
+       y1="6.9176826"
+       x2="4.9768834"
+       y2="18.920067"
+       gradientUnits="userSpaceOnUse" /><linearGradient
+       xlink:href="#linearGradient971"
+       id="linearGradient983-3-2-6-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68959699,0,0,0.63823543,7.4827169,-7.4354028)"
+       x1="-2.5213938"
+       y1="22.402153"
+       x2="-2.5213938"
+       y2="35.268829" /><linearGradient
+       y2="35.272106"
+       x2="5.8849864"
+       y1="27.314026"
+       x1="5.8849864"
+       gradientTransform="matrix(0.58211157,0,0,0.78035649,6.534497,-11.340567)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1903-0-3"
+       xlink:href="#linearGradient2181" /><linearGradient
+       id="linearGradient2181"><stop
+         id="stop2173"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop2175"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.58888781" /><stop
+         id="stop2177"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" /><stop
+         id="stop2179"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" /></linearGradient><linearGradient
+       xlink:href="#linearGradient50"
+       id="linearGradient1903-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.64709675,0,0,1,6.3930112,-17.610674)"
+       x1="5.8849864"
+       y1="20.383398"
+       x2="5.8849864"
+       y2="38.171688" /><linearGradient
+       id="linearGradient50"><stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop42" /><stop
+         offset="0.501194"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop44" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop46" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop48" /></linearGradient></defs><metadata
+     id="metadata4162"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><g
+     transform="matrix(0.5789476,0,0,0.42857134,-1.894738,2.8571464)"
+     id="g3712-8"
+     style="opacity:0.4"><rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801-6"
+       style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" /><rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1)"
+       id="rect3696-20"
+       style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" /><rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700-5"
+       style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" /></g><rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1338);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9-5"
+     y="3"
+     x="3"
+     ry="1.5"
+     rx="1.5"
+     height="18"
+     width="18" /><rect
+     width="19.000002"
+     height="19.000002"
+     rx="2"
+     ry="2"
+     x="2.4999981"
+     y="2.5000257"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1271);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variation-settings:normal;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" /><rect
+     width="17"
+     height="17"
+     x="3.4999995"
+     y="3.4999995"
+     id="rect6741-9"
+     style="opacity:1;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" /><path
+     style="color:#000000;fill:#ed5353;fill-opacity:0.999123;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none;paint-order:fill markers stroke"
+     d="m 8.1423945,39.053656 a 0.75,0.75 0 0 0 -0.652344,0.835937 0.75,0.75 0 0 0 0.835938,0.652344 c 1.565414,-0.19221 3.0574455,0.679244 3.6601555,2.136719 0.60271,1.457474 0.161926,3.130048 -1.082031,4.099609 -1.2439575,0.969561 -2.9720995,0.989181 -4.238281,0.04883 a 0.75,0.75 0 0 0 -1.0507812,0.154297 0.75,0.75 0 0 0 0.15625,1.048828 c 1.8019337,1.33824 4.2843802,1.309494 6.0546872,-0.07031 1.770307,-1.379806 2.404605,-3.779351 1.546875,-5.853516 -0.857731,-2.074169 -3.002685,-3.326277 -5.2304685,-3.052738 z"
+     id="path1281" /><path
+     style="fill:#ed5353;fill-opacity:1;stroke:#ed5353;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.999123;paint-order:fill markers stroke;stop-color:#000000"
+     d="m 9.2517415,37.430609 -3.0000001,2.5 3.0000001,2.5 z"
+     id="path2212"
+     sodipodi:nodetypes="cccc" /><path
      id="path3503"
-     style="fill:url(#linearGradient3040);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3042);stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-  <path
-     d="M 12.938624,15.258273 C 14.695476,13.199411 13.163641,7.8236994 7.543561,8.5590324 l -0.0616,-2.197396 -4.369328,3.137879 4.369328,3.0644276 0,-2.059765 c 6.167442,-0.329165 5.981488,3.921804 5.456662,4.754095 z"
+     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient38832);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 6.7363281 4.75 C 6.5582468 4.7533399 6.3832379 4.8208647 6.2460938 4.9453125 L 0.74609375 9.9453125 C 0.41920728 10.242864 0.41920728 10.757136 0.74609375 11.054688 L 6.2460938 16.054688 C 6.7278036 16.491461 7.4991504 16.150242 7.5 15.5 L 7.5 12.523438 C 11.06896 12.39591 13.037676 15.654496 10.482422 18 L 10.982422 18 C 15.957334 14.636534 13.039614 8.4625844 7.5 8.5 L 7.5 5.5 C 7.4997274 5.203105 7.3243605 4.9343112 7.0527344 4.8144531 C 6.9510626 4.7696275 6.8431769 4.7479961 6.7363281 4.75 z " /><path
+     id="path22303"
+     style="display:block;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;font-variation-settings:normal;opacity:1;vector-effect:none;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M 6.7363281 4.75 C 6.5582468 4.7533399 6.3832379 4.8208647 6.2460938 4.9453125 L 0.74609375 9.9453125 C 0.41920728 10.242864 0.41920728 10.757136 0.74609375 11.054688 L 6.2460938 16.054688 C 6.7278036 16.491461 7.4991504 16.150242 7.5 15.5 L 7.5 12.523438 C 11.06896 12.39591 13.037676 15.654496 10.482422 18 L 10.982422 18 C 15.957334 14.636534 13.039614 8.4625844 7.5 8.5 L 7.5 5.5 C 7.4997274 5.203105 7.3243605 4.9343112 7.0527344 4.8144531 C 6.9510626 4.7696275 6.8431769 4.7479961 6.7363281 4.75 z " /><path
+     d="m 7.4999758,11.504937 c -0.567826,1.71e-4 -0.999815,0.472028 -1,1 v 2.45 l -4.88,-4.45 4.88,-4.4500002 v 2.45 c 0,0.599342 0.4914219,0.9998462 1,1"
+     style="font-variation-settings:normal;opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient983-3-2-6-9);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path873-5-5-2-6-1"
+     sodipodi:nodetypes="cccccsc" /><path
+     style="font-variation-settings:normal;display:block;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1903-0-3);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="M 12.46052,14.086915 C 12.869447,12.435213 11.129723,9.4917809 7.4999758,9.5049368"
+     id="path2071"
+     sodipodi:nodetypes="cc" /><path
+     style="font-variation-settings:normal;display:block;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1903-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="m 7.4999758,11.504937 c 5.1278822,0.167226 4.9144212,3.415117 4.8000262,4.366904"
      id="path3505"
-     style="opacity:0.8;fill:none;stroke:url(#linearGradient3037);stroke-width:0.96392483;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-</svg>
+     sodipodi:nodetypes="cc" /></svg>


### PR DESCRIPTION
Use new document shape, rounded arrow, newer style gradients. Make red to indicate risky action and differentiate it from the undo icon.

I'll throw some other options at the bottom, let me know which one is liked best and if this style is okay to go with and I will finish the other sizes. Thanks!

Current:
![document-revert-current](https://github.com/elementary/icons/assets/1984060/1d04b71d-f4d4-4cc4-9075-d55d20300648)

Proposed:
![document-revert](https://github.com/elementary/icons/assets/1984060/31b3dc6f-553f-4303-93dc-f8a8fcb53cc9)

![prop1](https://github.com/elementary/icons/assets/1984060/31f6075e-728f-44e4-b82c-f859c48f154d)

Other options:

Keep yellow arrow, use new document shape:
![document-revert-yellow](https://github.com/elementary/icons/assets/1984060/f5204300-cf20-428a-b24b-93f65cffcd49)

Keep document shape, use red arrow:
![document-revert-doc](https://github.com/elementary/icons/assets/1984060/3db0800f-2e40-4309-8e7d-4185291185a5)

Tried keeping the document shape on that last one, wasn't sure if overusing the square document would be too confusing with import, export, save, and revert.