### PR TITLE
Actions: Refresh and add color to session icons

### DIFF
--- a/actions/32/system-lock-screen.svg
+++ b/actions/32/system-lock-screen.svg
@@ -1,99 +1,120 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4248"
-   height="32"
+   version="1.1"
    width="32"
-   version="1.1">
+   height="32"
+   id="svg4248"
+   sodipodi:docname="system-lock-screen.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1474"
+     inkscape:window-height="890"
+     id="namedview29"
+     showgrid="false"
+     inkscape:zoom="17.52299"
+     inkscape:cx="-5.4499831"
+     inkscape:cy="22.513281"
+     inkscape:window-x="375"
+     inkscape:window-y="46"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4248"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4250">
     <linearGradient
        id="linearGradient4011-4">
       <stop
-         offset="0"
+         id="stop4013-8"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4013-8" />
+         offset="0" />
       <stop
-         offset="0.507761"
+         id="stop4015-5"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4015-5" />
+         offset="0.507761" />
       <stop
-         offset="0.83456558"
+         id="stop4017-6"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4017-6" />
+         offset="0.83456558" />
       <stop
-         offset="1"
+         id="stop4019-1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4019-1" />
+         offset="1" />
     </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-36.346075,-2.5039314)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4011-4"
-       id="linearGradient3089"
-       y2="44.340794"
-       x2="71.204407"
-       y1="6.2375584"
-       x1="71.204407" />
-    <radialGradient
-       gradientTransform="matrix(0,4.7500023,-5.0249359,-1.3352823e-7,58.459621,-17.585409)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       id="radialGradient3092"
-       fy="8.4497671"
-       fx="0.96534902"
-       r="19.99999"
-       cy="8.4497671"
-       cx="0.96534902" />
     <linearGradient
        id="linearGradient3820-7-2-2">
       <stop
-         offset="0"
+         id="stop3822-2-6-36"
          style="stop-color:#3d3d3d;stop-opacity:1"
-         id="stop3822-2-6-36" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop3864-8-7-6"
          style="stop-color:#686868;stop-opacity:0.49803922"
-         id="stop3864-8-7-6" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop3824-1-2-4"
          style="stop-color:#686868;stop-opacity:0"
-         id="stop3824-1-2-4" />
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407"
+       gradientTransform="matrix(0.7297297,0,0,0.72972954,-36.346081,-2.5039311)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3540"
+       xlink:href="#linearGradient4011-4" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient930"
+       id="linearGradient932"
+       x1="10.860361"
+       y1="2.9666989"
+       x2="10.860361"
+       y2="20.846098"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.45,0,0,1.45,-1.3999995,-1.4000002)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient930">
+      <stop
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop926" />
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop928" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)"
+       gradientTransform="matrix(0.17524541,0,0,0.05574586,-1.376811,18.121549)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3820-7-2-2"
-       id="radialGradient3315"
+       id="radialGradient4277"
        fy="186.17059"
        fx="99.157013"
        r="62.769119"
        cy="186.17059"
        cx="99.157013" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         offset="0"
-         style="stop-color:#919caf;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-3" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#68758e;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#485a6c;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#444c5c;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-0" />
-    </linearGradient>
   </defs>
   <metadata
      id="metadata4253">
@@ -103,128 +124,37 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none"
+     d="m 27,28.499785 a 11,3.4991173 0 1 1 -21.9999996,0 11,3.4991173 0 1 1 21.9999996,0 z"
      id="path3818-0-2"
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     style="color:#000000;fill:url(#radialGradient3092);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path2555"
-     d="M 16.000002,1.4999989 C 7.9994024,1.4999989 1.5,7.9993978 1.5,15.999998 1.5,24.0006 7.9994024,30.500002 16.000002,30.5 24.000599,30.5 30.500007,24.0006 30.5,15.999998 30.5,7.9993978 24.000599,1.4999989 16.000002,1.4999989 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
+     id="path2555-3"
+     d="m 16.000001,1.4999999 c -8.0005983,0 -14.5000008,6.4993986 -14.5000008,14.4999981 0,8.000603 6.4994025,14.500003 14.5000008,14.500002 C 24.000599,30.5 30.500008,24.000601 30.5,15.999998 30.5,7.9993985 24.000599,1.4999999 16.000001,1.4999999 Z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="path2555-6"
-     d="M 16.000002,1.4999989 C 7.999402,1.4999989 1.5,7.9993981 1.5,15.999999 1.5,24.000599 7.999402,30.500002 16.000002,30.5 24.000598,30.5 30.500008,24.000599 30.5,15.999999 30.5,7.9993981 24.000598,1.4999989 16.000002,1.4999989 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655-4"
+     d="m 29.500001,15.999517 c 0,7.456083 -6.044601,13.500475 -13.499829,13.500475 -7.4559114,0 -13.500173,-6.04446 -13.500173,-13.500475 0,-7.4557374 6.0442616,-13.4995175 13.500173,-13.4995175 7.455228,0 13.499829,6.0437801 13.499829,13.4995175 z" />
   <path
-     style="opacity:0.3;color:#000000;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path8655"
-     d="m 29.5,15.999521 c 0,7.456085 -6.044601,13.500478 -13.499829,13.500478 C 8.54426,29.499999 2.5,23.455537 2.5,15.999521 2.5,8.5437808 8.54426,2.5000002 16.000171,2.5000002 23.455399,2.5000002 29.5,8.5437808 29.5,15.999521 l 0,0 z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path2555-6-0"
+     d="M 16.000002,1.5 C 7.999402,1.5 1.5,7.9993994 1.5,16.000001 c 0,8.000599 6.499402,14.500002 14.500002,14.5 8.000597,0 14.500006,-6.499401 14.499998,-14.5 C 30.5,7.9993994 24.000599,1.5 16.000002,1.5 Z" />
   <path
-     d="m 15,8.0058594 c -1.340693,0 -2.557848,0.6453207 -3.460938,1.5546875 C 10.635973,10.469914 10.005859,11.680071 10.005859,13 l 0,2 a 0.99362253,0.99362253 0 0 0 0,0.0059 l -0.0059,0 A 0.99362253,0.99362253 0 0 0 9.0058594,16 l 0,2.25 a 0.99362253,0.99362253 0 0 0 0.033203,0.25 0.99362253,0.99362253 0 0 0 -0.033203,0.25 l 0,1.25 0,0.25 a 0.99362253,0.99362253 0 0 0 0.033203,0.25 0.99362253,0.99362253 0 0 0 -0.033203,0.25 l 0,1.5 a 0.99362253,0.99362253 0 0 0 0.033203,0.25 0.99362253,0.99362253 0 0 0 -0.033203,0.25 l 0,0.25 0,0.5 c 0,1.364227 1.1299136,2.494141 2.4941406,2.494141 l 9,0 c 1.364227,0 2.494141,-1.129914 2.494141,-2.494141 l 0,-0.5 0,-0.25 a 0.99362253,0.99362253 0 0 0 -0.0332,-0.25 0.99362253,0.99362253 0 0 0 0.0332,-0.25 l 0,-1.5 a 0.99362253,0.99362253 0 0 0 -0.0332,-0.25 0.99362253,0.99362253 0 0 0 0.0332,-0.25 l 0,-0.25 0,-1.25 a 0.99362253,0.99362253 0 0 0 -0.0332,-0.25 0.99362253,0.99362253 0 0 0 0.0332,-0.25 l 0,-2.25 A 0.99362253,0.99362253 0 0 0 22,15.005859 l -0.0059,0 a 0.99362253,0.99362253 0 0 0 0,-0.0059 l 0,-2 c 0,-1.323403 -0.622744,-2.53832 -1.525391,-3.4472656 C 19.566103,8.6437889 18.344314,8.0058594 17,8.0058594 l -2,0 z m 0,3.9882816 2,0 c 0.243823,0 0.485043,0.125113 0.693359,0.357421 0.208317,0.232309 0.3125,0.569757 0.3125,0.648438 l 0,2 a 0.99362253,0.99362253 0 0 0 0,0.0059 l -4.011718,0 a 0.99362253,0.99362253 0 0 0 0,-0.0059 l 0,-2 c 0,0.0641 0.09812,-0.351605 0.316406,-0.611328 C 14.528828,12.128949 14.768715,11.994141 15,11.994141 Z"
-     id="path4470"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <g
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-     transform="translate(8,9)"
-     id="g3398-6">
-    <g
-       id="layer9-0"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)">
-      <path
-         d="m 400.0004,-542 c -2.01566,0 -4,2.02594 -4,4 l 0,2 10,0 0,-2 c 0,-1.99486 -1.96353,-4 -4,-4 z m 0,2 2,0 c 1.15731,0 2,1.17009 2,2 l 0,2 -6,0 0,-2 c 0,-0.66713 0.80108,-2 2,-2 z"
-         id="path14438-6"
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0" />
-      <path
-         d="m 395.0004,-535 0,2.25 2.25,0 0,0.5 -2.25,0 0,1.25 0,0.25 2.25,0 0,0.5 -2.25,0 0,1.5 2.25,0 0,0.5 -2.25,0 0,0.25 0,0.5 c 0,0.831 0.669,1.5 1.5,1.5 l 9,0 c 0.831,0 1.5,-0.669 1.5,-1.5 l 0,-0.5 0,-0.25 -2.25,0 0,-0.5 2.25,0 0,-1.5 -2.25,0 0,-0.5 2.25,0 0,-0.25 0,-1.25 -2.25,0 0,-0.5 2.25,0 0,-2.25 z"
-         id="path14440-2"
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0" />
-    </g>
-    <g
-       id="layer10-6"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       id="layer11-1"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="layer13-8"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       id="layer14-7"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="layer15-9"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="g71291-2"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="g4953-0"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="layer12-2"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-  </g>
-  <g
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-     transform="translate(8,7.999999)"
-     id="g3398">
-    <g
-       id="layer9"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)">
-      <path
-         d="m 400.0004,-542 c -2.01566,0 -4,2.02594 -4,4 l 0,2 10,0 0,-2 c 0,-1.99486 -1.96353,-4 -4,-4 z m 0,2 2,0 c 1.15731,0 2,1.17009 2,2 l 0,2 -6,0 0,-2 c 0,-0.66713 0.80108,-2 2,-2 z"
-         id="path14438"
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0" />
-      <path
-         d="m 395.0004,-535 0,2.25 2.25,0 0,0.5 -2.25,0 0,1.25 0,0.25 2.25,0 0,0.5 -2.25,0 0,1.5 2.25,0 0,0.5 -2.25,0 0,0.25 0,0.5 c 0,0.831 0.669,1.5 1.5,1.5 l 9,0 c 0.831,0 1.5,-0.669 1.5,-1.5 l 0,-0.5 0,-0.25 -2.25,0 0,-0.5 2.25,0 0,-1.5 -2.25,0 0,-0.5 2.25,0 0,-0.25 0,-1.25 -2.25,0 0,-0.5 2.25,0 0,-2.25 z"
-         id="path14440"
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0" />
-    </g>
-    <g
-       id="layer10"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       id="layer11"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="layer13"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       id="layer14"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="layer15"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="g71291"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="g4953"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-    <g
-       id="layer12"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-       transform="translate(-393.0004,542)" />
-  </g>
+     style="color:#000000;opacity:1;fill:#206b00;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none;fill-opacity:0.15000001"
+     d="m 15,8 c -2.210591,0 -4,1.8274253 -4,4.017578 V 15 h -1 c -0.5522619,5.5e-5 -0.9999448,0.447738 -1,1 v 7 c 0,1.090702 0.9092983,2 2,2 h 10 c 1.090702,0 2,-0.909297 2,-2 v -7 c -5.5e-5,-0.552262 -0.447738,-0.999945 -1,-1 H 21 V 12.017578 C 21,9.8188772 19.205508,8 17,8 Z m 0.332031,4 h 1.335938 C 16.854389,12 17,12.147863 17,12.349609 V 15 H 15 V 12.349609 C 15,12.147862 15.145611,12 15.332031,12 Z"
+     id="path13599"
+     sodipodi:nodetypes="sscccsssscccssssssccss" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#206b00;fill-opacity:0.30000001;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 15,9 c -1.662,0 -3,1.367643 -3,3.016972 V 16 h 1.999985 v -3.650498 c 0,-0.738137 0.593893,-1.349003 1.332031,-1.349003 h 1.335968 c 0.738138,0 1.332032,0.610866 1.332032,1.349003 V 16 H 20 V 12.016972 C 20,10.354972 18.661999,9 17,9 Z m -5,7 v 7 c 0,0.554 0.446,1 1,1 h 10 c 0.553999,0 1,-0.446 1,-1 v -7 z"
+     id="path873"
+     sodipodi:nodetypes="ssccssssccsssccssccc" />
+  <path
+     id="rect4382-7"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 15 8 C 13.338002 8 12 9.3682503 12 11.017578 L 12 15 L 11 15 C 10.446001 15 10 15.446001 10 16 L 10 22 C 10 22.553999 10.446001 23 11 23 L 21 23 C 21.553999 23 22 22.553999 22 22 L 22 16 C 22 15.446001 21.553999 15 21 15 L 20 15 L 20 11.017578 C 20 9.3555794 18.661997 8 17 8 L 15 8 z M 15.332031 10 L 16.667969 10 C 17.406106 10 18 10.611473 18 11.349609 L 18 15 L 14 15 L 14 11.349609 C 14 10.611473 14.593894 10 15.332031 10 z " />
 </svg>

--- a/actions/32/system-log-out.svg
+++ b/actions/32/system-log-out.svg
@@ -1,55 +1,103 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4248"
-   height="32"
+   version="1.2"
    width="32"
-   version="1.1">
+   height="32"
+   id="svg2"
+   sodipodi:docname="system-log-out.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1273"
+     inkscape:window-height="871"
+     id="namedview27"
+     showgrid="false"
+     inkscape:zoom="8.2604165"
+     inkscape:cx="-11.500631"
+     inkscape:cy="12.953342"
+     inkscape:window-x="621"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4250">
+     id="defs4">
     <linearGradient
-       id="linearGradient4011-4">
+       id="linearGradient4011">
       <stop
-         offset="0"
+         id="stop4013"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4013-8" />
+         offset="0" />
       <stop
-         offset="0.507761"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4015-5" />
+         offset="0.507761" />
       <stop
-         offset="0.83456558"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4017-6" />
+         offset="0.83456558" />
       <stop
-         offset="1"
+         id="stop4019"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4019-1" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-36.346075,-2.5039314)"
+       gradientTransform="matrix(0,0.70731705,-0.70731705,0,32.975609,-0.97560825)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4011-4"
-       id="linearGradient3089"
+       y2="23.999998"
+       x2="43.523811"
+       y1="23.999998"
+       x1="4.6204333"
+       id="linearGradient887"
+       xlink:href="#linearGradient885" />
+    <linearGradient
+       id="linearGradient885">
+      <stop
+         id="stop881"
+         offset="0"
+         style="stop-color:#ffa154;stop-opacity:1" />
+      <stop
+         id="stop883"
+         offset="1"
+         style="stop-color:#f37329;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72972976,0,0,0.72972962,-36.34608,-2.5039287)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4011"
+       id="linearGradient3019"
        y2="44.340794"
        x2="71.204407"
        y1="6.2375584"
        x1="71.204407" />
     <radialGradient
-       gradientTransform="matrix(0,4.7500023,-5.0249359,-1.3352823e-7,58.459621,-17.585409)"
+       gradientTransform="matrix(0.17524541,0,0,0.05574929,-1.3768111,18.121125)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
-       id="radialGradient3092"
-       fy="8.4497671"
-       fx="0.96534902"
-       r="19.99999"
-       cy="8.4497671"
-       cx="0.96534902" />
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient4277"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
     <linearGradient
        id="linearGradient3820-7-2-2">
       <stop
@@ -65,75 +113,47 @@
          style="stop-color:#686868;stop-opacity:0"
          id="stop3824-1-2-4" />
     </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3820-7-2-2"
-       id="radialGradient3315"
-       fy="186.17059"
-       fx="99.157013"
-       r="62.769119"
-       cy="186.17059"
-       cx="99.157013" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
-      <stop
-         offset="0"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1" />
-      <stop
-         offset="1"
-         style="stop-color:#ac441f;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6" />
-    </linearGradient>
   </defs>
   <metadata
-     id="metadata4253">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none"
+     d="M 27,28.5 A 11,3.4993327 0 1 1 5.0000004,28.5 11,3.4993327 0 1 1 27,28.5 Z"
      id="path3818-0-2"
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     style="color:#000000;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate"
      id="path2555"
-     d="M 16.000002,1.4999989 C 7.9994024,1.4999989 1.5,7.9993978 1.5,15.999998 1.5,24.0006 7.9994024,30.500002 16.000002,30.5 24.000599,30.5 30.500007,24.0006 30.5,15.999998 30.5,7.9993978 24.000599,1.4999989 16.000002,1.4999989 z" />
+     d="M 30.5,16.000002 C 30.5,7.9994035 24.000602,1.5000008 16,1.5000008 c -8.0005982,0 -14.5000025,6.4994027 -14.4999996,14.5000012 0,8.000596 6.4994014,14.500005 14.4999996,14.499997 8.000602,0 14.5,-6.499401 14.5,-14.499997 z" />
   <path
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path2555-6"
-     d="M 16.000002,1.4999989 C 7.999402,1.4999989 1.5,7.9993981 1.5,15.999999 1.5,24.000599 7.999402,30.500002 16.000002,30.5 24.000598,30.5 30.500008,24.000599 30.5,15.999999 30.5,7.9993981 24.000598,1.4999989 16.000002,1.4999989 z" />
-  <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     d="m 29.5,15.999521 c 0,7.456085 -6.044601,13.500478 -13.499829,13.500478 C 8.54426,29.499999 2.5,23.455537 2.5,15.999521 2.5,8.5437808 8.54426,2.5000002 16.000171,2.5000002 23.455399,2.5000002 29.5,8.5437808 29.5,15.999521 l 0,0 z" />
+     d="m 29.500001,15.999521 c 0,7.456084 -6.044602,13.500477 -13.499831,13.500477 -7.4559094,0 -13.5001709,-6.044462 -13.5001709,-13.500477 0,-7.4557386 6.0442615,-13.4995188 13.5001709,-13.4995188 7.455229,0 13.499831,6.0437802 13.499831,13.4995188 z" />
   <path
-     transform="translate(0,0.5000005)"
-     d="m 17,8.5 c -0.555304,0 -1.086305,0.278461 -1.402344,0.6308594 -0.316038,0.3523984 -0.47343,0.7472259 -0.568359,1.1269526 A 1.0001005,1.0001005 0 0 0 15,10.5 v 3 H 8 c -1.0907018,0 -2,0.909297 -2,2 v 3 c 0,1.090703 0.909297,2 2,2 h 7 v 3 c 0,1.090703 0.909297,2 2,2 0.588276,0 1.131344,-0.260731 1.496094,-0.671875 l -0.06836,0.06836 6.978516,-6.478515 a 1.0001005,1.0001005 0 0 0 0.04687,-0.04687 C 25.788265,18.016111 26,17.527535 26,17 26,16.472465 25.788265,15.983889 25.453125,15.628906 a 1.0001005,1.0001005 0 0 0 -0.04687,-0.04687 l -6.978516,-6.4785154 0.06836,0.068359 C 18.131345,8.7607339 17.588277,8.5 17,8.5 Z"
-     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#ae2109;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1"
-     id="path873-5-3-3-6" />
+     style="color:#000000;fill:#a62100;-inkscape-stroke:none;fill-opacity:0.15000001"
+     d="M 17.037109,9.25 C 15.938321,9.25 15,10.152614 15,11.263672 V 14 H 9.0390625 9.0371094 C 7.9379924,13.999994 7,14.90131 7,16.011719 v 1.976562 C 7,19.099338 7.9383193,20 9.0371094,20 H 15 v 2.736328 c 0,1.111058 0.938321,2.013672 2.037109,2.013672 0.592626,0 1.142972,-0.255848 1.517578,-0.667969 l 5.869141,-5.693359 0.01172,-0.01172 C 24.779425,18.02147 25,17.523712 25,16.986328 25,16.448919 24.779391,15.953124 24.435547,15.597656 l -0.01172,-0.01172 -5.914062,-5.7148442 0.04492,0.046875 C 18.180093,9.5058824 17.629756,9.25 17.037109,9.25 Z"
+     id="path7957"
+     sodipodi:nodetypes="ssccsssscsscccsccccs" />
   <path
-     d="m 17.000117,10.000001 c -0.554,0 -0.865639,0.462541 -1,1 v 4 H 8.0001407 c -0.554,0 -1,0.445999 -1,1 V 19 c 0,0.553999 0.446,1 1,1 h 7.9999763 v 4 c 0,0.554 0.446,1 1,1 0.298584,0 0.565122,-0.129746 0.748047,-0.335938 l 6.978257,-6.478516 C 24.895504,18.006452 24.999859,17.76574 24.999859,17.5 c 0,-0.265741 -0.104355,-0.506452 -0.273438,-0.685547 L 17.748164,10.335938 C 17.565239,10.129747 17.298701,10 17.000117,10.000001 Z"
-     style="font-variation-settings:normal;opacity:0.3;vector-effect:none;fill:#ae2109;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1"
-     id="path873-5-3-3" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-6"
+     d="m 16.000002,1.4999993 c -8.000599,0 -14.5000018,6.4993997 -14.5000018,14.4999967 0,8.000604 6.4994028,14.500005 14.5000018,14.500005 C 24.0006,30.500001 30.500007,24.0006 30.5,15.999996 30.5,7.999399 24.0006,1.4999993 16.000002,1.4999993 Z" />
   <path
-     id="path873-5-3"
-     style="opacity:1;fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     d="m 17.000117,9 c -0.554,0 -0.865639,0.462541 -1,1 v 4 H 8.0001407 c -0.554,0 -1,0.446 -1,1 v 3 c 0,0.554 0.446,1 1,1 h 7.9999763 v 4 c 0,0.554 0.446,1 1,1 0.298584,0 0.565122,-0.129747 0.748047,-0.335938 l 6.978257,-6.478516 C 24.895504,17.006452 24.999859,16.76574 24.999859,16.5 c 0,-0.26574 -0.104355,-0.506452 -0.273438,-0.685547 L 17.748164,9.335938 C 17.565239,9.129747 17.298701,9 17.000117,9 Z" />
+     id="path114055"
+     style="font-variation-settings:normal;fill:#a62100;fill-opacity:0.30000001;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+     d="m 17.037741,23.75 c -0.574957,0 -1.037829,-0.451772 -1.037829,-1.012942 V 19.000472 H 9.03783 C 8.462871,19.000472 8,18.548699 8,17.987528 V 16.012471 C 8,15.4513 8.462871,14.998975 9.03783,14.999529 h 6.962082 V 11.26294 c 0,-0.561168 0.462872,-1.01294 1.037829,-1.01294 0.30988,0 0.5865,0.131436 0.776347,0.340284 l 5.902129,5.702109 C 23.891697,16.473805 24,16.717635 24,16.986813 c 0,0.26918 -0.108293,0.513008 -0.283783,0.69442 l -5.902129,5.728482 C 17.624241,23.618574 17.347621,23.75 17.037741,23.75 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     id="path873-5"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+     d="m 17.037741,22.75 c -0.574957,0 -1.037829,-0.451772 -1.037829,-1.012942 V 18.000472 H 9.03783 C 8.462871,18.000472 8,17.548699 8,16.987528 V 15.012471 C 8,14.4513 8.462871,13.998975 9.03783,13.999529 h 6.962082 V 10.26294 c 0,-0.5611677 0.462872,-1.01294 1.037829,-1.01294 0.30988,0 0.5865,0.1314358 0.776347,0.3402838 l 5.902129,5.7021092 C 23.891697,15.473805 24,15.717635 24,15.986813 c 0,0.26918 -0.108293,0.513008 -0.283783,0.69442 l -5.902129,5.728482 C 17.624241,22.618574 17.347621,22.75 17.037741,22.75 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
 </svg>

--- a/actions/32/system-reboot.svg
+++ b/actions/32/system-reboot.svg
@@ -1,17 +1,45 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
+   version="1.2"
    width="32"
    height="32"
-   id="svg3658">
+   id="svg2"
+   sodipodi:docname="system-reboot.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
+     id="namedview27"
+     showgrid="false"
+     inkscape:zoom="23.363986"
+     inkscape:cx="16.093144"
+     inkscape:cy="21.528861"
+     inkscape:window-x="629"
+     inkscape:window-y="14"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs3660">
+     id="defs4">
     <linearGradient
        id="linearGradient4011">
       <stop
@@ -19,11 +47,11 @@
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.507761" />
       <stop
-         id="stop4017"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456558" />
       <stop
@@ -32,48 +60,23 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3820-7-2-2">
-      <stop
-         id="stop3822-2-6-36"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-6"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-4"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2-2"
-       id="radialGradient4048"
+       gradientTransform="matrix(0,0.70731705,-0.70731705,0,32.97561,-0.97560876)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.11895)"
-       cx="99.157013"
-       cy="186.17059"
-       fx="99.157013"
-       fy="186.17059"
-       r="62.769119" />
+       y2="23.999998"
+       x2="44.5"
+       y1="23.999998"
+       x1="3.4999995"
+       id="linearGradient887"
+       xlink:href="#linearGradient947-5" />
     <linearGradient
-       gradientTransform="matrix(0.72973007,0,0,0.72973007,-36.346113,-2.5039328)"
+       gradientTransform="matrix(0.72972979,0,0,0.72972965,-36.346081,-2.5039294)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
-       id="linearGradient12398-3"
+       id="linearGradient3019"
        y2="44.340794"
        x2="71.204407"
        y1="6.2375584"
        x1="71.204407" />
-    <linearGradient
-       gradientTransform="matrix(1.1113759,0,0,0.83086027,-2249.8942,-2663.1587)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient947-5"
-       id="linearGradient11527-6-5"
-       y2="3241.9966"
-       x2="2035.1652"
-       y1="3208.0737"
-       x1="2035.1652" />
     <linearGradient
        id="linearGradient947-5">
       <stop
@@ -85,45 +88,84 @@
          style="stop-color:#3689e6;stop-opacity:1"
          id="stop945-2" />
     </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.17524541,0,0,0.05574929,-1.376811,18.121125)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient4277"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
+    <linearGradient
+       id="linearGradient3820-7-2-2">
+      <stop
+         offset="0"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         id="stop3822-2-6-36" />
+      <stop
+         offset="0.5"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         id="stop3864-8-7-6" />
+      <stop
+         offset="1"
+         style="stop-color:#686868;stop-opacity:0"
+         id="stop3824-1-2-4" />
+    </linearGradient>
   </defs>
   <metadata
-     id="metadata3663">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="m 27.000001,28.499804 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z"
+     d="M 27,28.5 A 11,3.4993327 0 1 1 5.0000004,28.5 11,3.4993327 0 1 1 27,28.5 Z"
      id="path3818-0-2"
-     style="fill:url(#radialGradient4048);fill-opacity:1;stroke:none" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.98999999;fill:url(#linearGradient11527-6-5);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate"
-     id="path2555-7-8-5-0-9"
-     d="m 15.999999,1.4999997 c -8.000603,0 -14.5,6.4993973 -14.5,14.5000003 0,8.000603 6.499397,14.5 14.5,14.5 C 24.000603,30.5 30.500014,24.000603 30.5,16 30.5,7.999397 24.000603,1.4999997 15.999999,1.4999997 Z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
+     id="path2555"
+     d="M 30.5,16.000003 C 30.5,7.9994029 24.000602,1.5000002 16,1.5000002 7.9994016,1.5000002 1.4999973,7.9994029 1.5000002,16.000003 1.5000002,24.000599 7.9994016,30.500007 16,30.5 c 8.000602,0 14.5,-6.499401 14.5,-14.499997 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient12398-3);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path8655-6-0-9-5-0"
-     d="m 29.5,15.999517 c 0,7.456096 -6.044607,13.500489 -13.499837,13.500489 -7.455912,0 -13.5001626,-6.044464 -13.5001626,-13.500489 0,-7.4557408 6.0442506,-13.4995231 13.5001626,-13.4995231 7.45523,0 13.499837,6.0437824 13.499837,13.4995231 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655"
+     d="m 29.500001,15.99952 c 0,7.456085 -6.044601,13.500478 -13.499831,13.500478 -7.4559097,0 -13.500171,-6.044462 -13.500171,-13.500478 0,-7.455738 6.0442613,-13.4995182 13.500171,-13.4995182 7.45523,0 13.499831,6.0437802 13.499831,13.4995182 z" />
   <path
-     style="fill:none;fill-opacity:1;stroke:#002e99;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;opacity:0.5;color:#000000;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="path2555-4"
-     d="m 16.000001,1.5017981 c -7.9996071,0 -14.4982031,6.4985937 -14.4982031,14.4982009 0,7.999609 6.498596,14.498206 14.4982031,14.498203 7.999605,0 14.498209,-6.498594 14.498201,-14.498203 0,-7.9996072 -6.498596,-14.4982009 -14.498201,-14.4982009 z" />
+     style="color:#000000;fill:#002e99;-inkscape-stroke:none;fill-opacity:0.15000001"
+     d="M 17.777344,6.25 C 16.904975,6.25 16,6.881669 16,7.8886719 v 1.2539062 c -2.452959,0.032461 -4.867665,0.9020869 -6.5996094,2.7636719 -2.5688478,2.76113 -3.1352671,6.845413 -1.4042969,10.191406 1.729644,3.343429 5.3774013,5.266906 9.1308593,4.845703 3.754252,-0.421294 6.879333,-3.1101 7.802734,-6.757812 v -0.002 c 0.301053,-1.192241 -0.435118,-2.427813 -1.626953,-2.730469 h -0.002 c -1.192241,-0.301054 -2.427812,0.435118 -2.730469,1.626953 -0.460219,1.818008 -2.014371,3.17394 -3.945312,3.390625 -1.92992,0.21657 -3.766485,-0.764828 -4.632812,-2.439453 C 11.124142,18.353306 11.39576,16.369481 12.695313,14.972656 13.557441,14.045995 14.767424,13.660709 16,13.630859 v 1.480469 C 16,16.11833 16.904976,16.75 17.777344,16.75 c 0.471475,0 0.918203,-0.162992 1.261718,-0.480469 l 4.392579,-3.574218 0.01172,-0.0098 C 23.75623,12.413826 24,11.981742 24,11.492188 24,11.002634 23.756237,10.57055 23.443359,10.298828 l -0.01367,-0.0098 -4.441406,-3.601563 0.05078,0.042969 C 18.695552,6.4130061 18.248856,6.25 17.777344,6.25 Z"
+     id="path15756"
+     sodipodi:nodetypes="sscssscccccscscsscccsccccs" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.05;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-     id="path4225"
-     d="m 15.939453,6.4980468 a 1.0033192,1.0033192 0 0 0 -0.943359,1.0019531 l 0,1.6269531 c -4.073048,0.5190141 -7.2851565,3.877758 -7.2851565,8.087891 -1e-7,4.565877 3.7231855,8.289062 8.2890625,8.289062 4.565877,0 8.289062,-3.723185 8.289062,-8.289062 a 1.0033192,1.0033192 0 0 0 -1.003906,-1.003906 l -2.427734,0 a 1.0033192,1.0033192 0 0 0 -1.003906,1.003906 c 0,2.140278 -1.713238,3.853515 -3.853516,3.853515 -2.140278,0 -3.853516,-1.713237 -3.853516,-3.853515 0,-1.783521 1.214344,-3.206018 2.84961,-3.652344 l 0,1.222656 a 1.0033192,1.0033192 0 0 0 1.519531,0.859375 l 6.072266,-3.642578 a 1.0033192,1.0033192 0 0 0 0,-1.71875 L 16.515625,6.6406249 A 1.0033192,1.0033192 0 0 0 15.939453,6.4980468 Z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-6"
+     d="M 16.000002,1.5 C 7.9994036,1.5 1.5000001,7.9993989 1.5000001,15.999997 1.5000001,24.0006 7.9994036,30.5 16.000002,30.5 24.0006,30.5 30.500008,24.0006 30.5,15.999997 30.5,7.9993989 24.0006,1.5 16.000002,1.5 Z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-     d="m 16,7.4999989 0,2.4285709 c -4.023791,0 -7.285714,3.2619262 -7.285714,7.2857162 C 8.714286,21.238077 11.976209,24.5 16,24.5 c 4.023791,0 7.285715,-3.261923 7.285715,-7.285714 l -2.428571,0 c 0,2.682527 -2.174616,4.857143 -4.857144,4.857143 -2.682527,0 -4.857143,-2.174616 -4.857143,-4.857143 0,-2.682527 2.174616,-4.857143 4.857143,-4.857143 l 0,2.428572 6.071429,-3.642857 L 16,7.4999989 Z"
-     id="path2984-7" />
+     id="path106791"
+     style="font-variation-settings:normal;vector-effect:none;fill:#002e99;fill-opacity:0.30000001;stroke:none;stroke-width:0.659997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 17.777343,7.25 c -0.430901,0 -0.777344,0.285344 -0.777344,0.638672 v 2.166016 c -0.09122,-0.01006 -0.182118,-0.02429 -0.273438,-0.03125 -2.434726,-0.185643 -4.880409,0.722864 -6.59375,2.564453 -2.2844548,2.45545 -2.785914,6.078059 -1.2480466,9.050781 1.5378676,2.972722 4.7834956,4.686179 8.1308596,4.310547 3.347364,-0.375634 6.124943,-2.76906 6.945313,-6.009766 a 1.25,1.25 0 0 0 -0.904297,-1.517578 1.25,1.25 0 0 0 -1.517579,0.904297 c -0.563023,2.224115 -2.468508,3.876731 -4.802734,4.138672 -2.334225,0.26194 -4.574604,-0.929077 -5.632812,-2.97461 -1.058208,-2.045532 -0.719431,-4.502237 0.859375,-6.199218 1.292859,-1.389634 3.195765,-2.013157 5.037109,-1.71875 v 2.539062 c 0,0.353329 0.346443,0.638672 0.777344,0.638672 0.232238,0 0.439741,-0.08334 0.582031,-0.214844 l 4.427734,-3.605468 c 0.131521,-0.114223 0.212891,-0.268018 0.212891,-0.4375 0,-0.169484 -0.08137,-0.323279 -0.212891,-0.4375 L 18.359374,7.464844 C 18.217094,7.333353 18.009581,7.25 17.777343,7.25 Z" />
   <path
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     d="m 16,6.4999989 0,2.4285709 c -4.023791,0 -7.285714,3.2619262 -7.285714,7.2857162 C 8.714286,20.238077 11.976209,23.5 16,23.5 c 4.023791,0 7.285715,-3.261923 7.285715,-7.285714 l -2.428571,0 c 0,2.682527 -2.174616,4.857143 -4.857144,4.857143 -2.682527,0 -4.857143,-2.174616 -4.857143,-4.857143 0,-2.682527 2.174616,-4.857143 4.857143,-4.857143 l 0,2.428572 6.071429,-3.642857 L 16,6.4999989 Z"
-     id="path2984" />
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.659997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 17.777796,14.75 c -0.430901,0 -0.777797,-0.284449 -0.777797,-0.637778 V 6.887777 c 0,-0.353327 0.346896,-0.637777 0.777797,-0.637777 0.232238,0 0.439549,0.08276 0.581829,0.214253 l 4.427693,3.590478 c 0.13152,0.114222 0.212681,0.267483 0.212681,0.436967 0,0.169483 -0.08116,0.323004 -0.212681,0.437227 l -4.427693,3.606822 C 18.217335,14.66725 18.010034,14.75 17.777796,14.75 Z"
+     sodipodi:nodetypes="sccsccsccs" />
+  <path
+     style="fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+     id="path54251"
+     sodipodi:type="arc"
+     sodipodi:cx="16.100351"
+     sodipodi:cy="16.999893"
+     sodipodi:rx="6.8532171"
+     sodipodi:ry="6.7498751"
+     sodipodi:start="0.2443461"
+     sodipodi:end="5.0963614"
+     sodipodi:arc-type="arc"
+     d="M 22.749999,18.632836 A 6.8532171,6.7498751 0 0 1 16.876158,23.706379 6.8532171,6.7498751 0 0 1 9.9940902,20.064272 6.8532171,6.7498751 0 0 1 11.04763,12.439744 6.8532171,6.7498751 0 0 1 18.667612,10.741518"
+     sodipodi:open="true" />
 </svg>

--- a/actions/32/system-shutdown.svg
+++ b/actions/32/system-shutdown.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg4248">
+   id="svg4248"
+   sodipodi:docname="system-shutdown.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview283"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="13.28125"
+     inkscape:cx="-11.181176"
+     inkscape:cy="26.202353"
+     inkscape:window-width="1384"
+     inkscape:window-height="969"
+     inkscape:window-x="406"
+     inkscape:window-y="50"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4248" />
   <defs
      id="defs4250">
     <linearGradient
@@ -31,25 +54,6 @@
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3089"
-       xlink:href="#linearGradient4011-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-36.346075,-2.5039314)" />
-    <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4.7500023,-5.0249359,-1.3352823e-7,58.459621,-17.585409)" />
     <linearGradient
        id="linearGradient3820-7-2-2">
       <stop
@@ -74,26 +78,37 @@
        id="radialGradient3315"
        xlink:href="#linearGradient3820-7-2-2"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)" />
+       gradientTransform="matrix(0.17524541,0,0,0.05575071,-1.3768101,18.12086)" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
+       id="linearGradient26009">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
+         id="stop26005"
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
+         id="stop26007"
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1" />
     </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26009"
+       id="linearGradient905"
+       gradientUnits="userSpaceOnUse"
+       x1="12.000114"
+       y1="11.722511"
+       x2="12.000114"
+       y2="44.984238"
+       gradientTransform="matrix(1.3811871,0,0,1.3811871,-0.57424597,-11.623744)" />
+    <linearGradient
+       gradientTransform="matrix(0.72972976,0,0,0.72972962,-36.346081,-2.5039289)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4011-4"
+       id="linearGradient3019"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
   </defs>
   <metadata
      id="metadata4253">
@@ -103,36 +118,35 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z"
+     d="m 27.000001,28.5 a 11,3.4994221 0 1 1 -21.9999997,0 11,3.4994221 0 1 1 21.9999997,0 z"
      id="path3818-0-2"
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none" />
+     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none;stroke-width:0.999997" />
   <path
      d="M 16.000002,1.4999989 C 7.9994024,1.4999989 1.5,7.9993978 1.5,15.999998 1.5,24.0006 7.9994024,30.500002 16.000002,30.5 24.000599,30.5 30.500007,24.0006 30.5,15.999998 30.5,7.9993978 24.000599,1.4999989 16.000002,1.4999989 z"
      id="path2555"
-     style="color:#000000;fill:url(#radialGradient3092);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:url(#linearGradient905);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
   <path
      d="M 16.000002,1.4999989 C 7.999402,1.4999989 1.5,7.9993981 1.5,15.999999 1.5,24.000599 7.999402,30.500002 16.000002,30.5 24.000598,30.5 30.500008,24.000599 30.5,15.999999 30.5,7.9993981 24.000598,1.4999989 16.000002,1.4999989 z"
      id="path2555-6"
-     style="opacity:0.5;color:#000000;fill:none;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     style="opacity:1;color:#000000;fill:none;stroke:#7a0000;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.5;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;font-variation-settings:normal;vector-effect:none;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
   <path
-     d="m 29.5,15.999521 c 0,7.456085 -6.044601,13.500478 -13.499829,13.500478 C 8.54426,29.499999 2.5,23.455537 2.5,15.999521 2.5,8.5437808 8.54426,2.5000002 16.000171,2.5000002 23.455399,2.5000002 29.5,8.5437808 29.5,15.999521 l 0,0 z"
-     id="path8655"
-     style="opacity:0.3;color:#000000;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7a0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
      id="path4670"
      d="m 16,5.5996094 c -1.267319,0 -2.316406,1.0529018 -2.316406,2.3183594 l 0,1.8769531 C 13.252925,9.2022089 12.65612,8.7539062 11.876953,8.7539062 c -0.466845,0 -0.798225,0.1605928 -1.003906,0.2578126 a 1.0237971,1.0237971 0 0 0 -0.0918,0.048828 l -0.404297,0.2441406 a 1.0237971,1.0237971 0 0 0 -0.03516,0.021484 C 8.2821498,10.684688 6.8616924,12.794085 6.2910156,15.226562 c -0.01514,0.01491 -0.04687,0.04492 -0.046875,0.04492 -2.51e-5,3.4e-5 -0.1835868,0.421838 -0.1835937,0.421875 a 1.0237971,1.0237971 0 0 0 -0.00391,0.01758 c -0.066296,0.393411 -0.039785,0.473123 -0.00391,0.226562 l 0.00195,-0.0059 c -0.059423,0.396387 -0.1328125,0.847499 -0.1328125,1.365234 0,5.396206 4.543662,9.753906 10.078125,9.753906 5.534463,0 10.078124,-4.3577 10.078125,-9.753906 0,-0.431119 -0.03684,-0.839643 -0.08789,-1.226563 a 1.0237971,1.0237971 0 0 0 -0.002,-0.002 c -0.04045,-0.302128 -0.09539,-0.418861 -0.08594,-0.365234 -0.467856,-2.655869 -2.040082,-4.923185 -4.244141,-6.3769531 a 1.0237971,1.0237971 0 0 0 -0.03516,-0.021484 L 21.21875,9.0605469 a 1.0237971,1.0237971 0 0 0 -0.0918,-0.048828 C 20.921251,8.9144848 20.589881,8.753906 20.123047,8.7539062 c -0.779167,0 -1.375972,0.4483027 -1.806641,1.0410157 l 0,-1.8769531 C 18.316406,6.6525093 17.267318,5.5996094 16,5.5996094 Z m -2.316406,6.9296876 0,3.150391 c 0,1.265457 1.050948,2.316406 2.316406,2.316406 1.265457,0 2.316406,-1.050947 2.316406,-2.316406 l 0,-3.150391 c 0.116688,0.146069 0.211339,0.314752 0.353516,0.429687 0.151019,0.122098 0.330257,0.246125 0.570312,0.347657 l -0.167968,-0.0918 c 1.052465,0.700333 1.827667,1.746309 2.169922,2.947265 0.105703,0.370949 0.128127,0.410259 0.03516,0.06836 0.111003,0.407785 0.167968,0.819053 0.167968,1.267578 0,2.870852 -2.404489,5.203125 -5.445312,5.203125 -3.040823,0 -5.445313,-2.332273 -5.445312,-5.203125 0,-0.448523 0.05696,-0.85979 0.167968,-1.267578 a 1.0237971,1.0237971 0 0 0 0,-0.002 c -0.09024,0.332753 -0.07366,0.315233 0.03516,-0.06641 0.342255,-1.200956 1.117457,-2.246932 2.169922,-2.947265 l -0.167968,0.0918 c 0.240082,-0.101539 0.419311,-0.225578 0.570312,-0.347657 0.142178,-0.114935 0.236828,-0.283617 0.353516,-0.429687 z" />
   <path
      d="m 11.876532,9.7766834 c -0.203664,0 -0.393298,0.080088 -0.565968,0.1617044 l -0.40426,0.2425572 c -1.9842413,1.308779 -3.3827714,3.331283 -3.8000599,5.700089 -4.447e-4,0.0026 -0.039984,-0.0024 -0.040429,0 -0.010994,0.06524 0.00957,0.136365 0,0.202131 -0.059892,0.399517 -0.1212787,0.795031 -0.1212787,1.212784 0,4.822579 4.0542686,8.732051 9.0554606,8.732051 5.001192,0 9.05546,-3.909472 9.05546,-8.732051 0,-0.370962 -0.03347,-0.732435 -0.08085,-1.091506 -0.01495,-0.111667 -0.06144,-0.21328 -0.08085,-0.323409 -0.417287,-2.368806 -1.815817,-4.39131 -3.800058,-5.700089 L 20.689438,9.9383878 c -0.17267,-0.08162 -0.362303,-0.1617044 -0.565967,-0.1617044 -0.736656,0 -1.334063,0.5974066 -1.334063,1.3340626 0,0.419245 0.223064,0.806559 0.52554,1.05108 0.09613,0.07772 0.207949,0.153297 0.323409,0.202131 1.250004,0.83178 2.176339,2.075122 2.587275,3.517077 0.0078,0.02751 0.03293,0.05327 0.04043,0.08085 0.13445,0.493921 0.202131,1.000224 0.202131,1.536194 0,3.4447 -2.895905,6.225629 -6.468186,6.225629 -3.572281,0 -6.4681856,-2.780929 -6.4681856,-6.225629 0,-0.53597 0.067682,-1.042273 0.2021309,-1.536194 0.0078,-0.02876 0.032277,-0.05226 0.040429,-0.08085 0.4109357,-1.441955 1.3372707,-2.685297 2.5872757,-3.517077 0.115456,-0.04883 0.227272,-0.124409 0.323408,-0.202131 0.302477,-0.244521 0.525541,-0.631835 0.525541,-1.05108 0,-0.736656 -0.597407,-1.3340626 -1.334063,-1.3340626 z M 16,6.623443 c 0.716674,0 1.293637,0.5769622 1.293637,1.293637 l 0,7.761823 c 0,0.716675 -0.576963,1.293637 -1.293637,1.293637 -0.716676,0 -1.293638,-0.576962 -1.293638,-1.293637 l 0,-7.761823 c 0,-0.7166748 0.576962,-1.293637 1.293638,-1.293637 z"
      id="path3782-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#7a0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
   <path
      d="m 11.876532,8.7764794 c -0.203664,0 -0.393298,0.080088 -0.565968,0.1617044 l -0.40426,0.2425574 C 8.9220627,10.48952 7.5235326,12.512024 7.1062441,14.88083 c -4.447e-4,0.0026 -0.039984,-0.0024 -0.040429,0 -0.010994,0.06524 0.00957,0.136365 0,0.202131 -0.059892,0.399517 -0.1212787,0.795031 -0.1212787,1.212784 0,4.822579 4.0542686,8.732051 9.0554606,8.732051 5.001192,0 9.05546,-3.909472 9.05546,-8.732051 0,-0.370962 -0.03347,-0.732435 -0.08085,-1.091506 -0.01495,-0.111667 -0.06144,-0.21328 -0.08085,-0.323409 C 24.47647,12.512024 23.07794,10.48952 21.093699,9.1807412 L 20.689438,8.9381838 c -0.17267,-0.08162 -0.362303,-0.1617044 -0.565967,-0.1617044 -0.736656,0 -1.334063,0.5974071 -1.334063,1.3340626 0,0.419245 0.223064,0.806559 0.52554,1.05108 0.09613,0.07772 0.207949,0.153297 0.323409,0.202131 1.250004,0.83178 2.176339,2.075122 2.587275,3.517077 0.0078,0.02751 0.03293,0.05327 0.04043,0.08085 0.13445,0.493921 0.202131,1.000224 0.202131,1.536194 0,3.4447 -2.895905,6.225629 -6.468186,6.225629 -3.572281,0 -6.4681856,-2.780929 -6.4681856,-6.225629 0,-0.53597 0.067682,-1.042273 0.2021309,-1.536194 0.0078,-0.02876 0.032277,-0.05226 0.040429,-0.08085 0.4109357,-1.441955 1.3372707,-2.685297 2.5872757,-3.517077 0.115456,-0.04883 0.227272,-0.124409 0.323408,-0.202131 0.302477,-0.244521 0.525541,-0.631835 0.525541,-1.05108 0,-0.7366555 -0.597407,-1.3340626 -1.334063,-1.3340626 z M 16,5.623239 c 0.716674,0 1.293637,0.5769622 1.293637,1.293637 l 0,7.761823 c 0,0.716675 -0.576963,1.293637 -1.293637,1.293637 -0.716676,0 -1.293638,-0.576962 -1.293638,-1.293637 l 0,-7.761823 c 0,-0.7166748 0.576962,-1.293637 1.293638,-1.293637 z"
      id="path3782"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655"
+     d="m 29.500001,15.999521 c 0,7.456084 -6.044603,13.500477 -13.499832,13.500477 -7.4559087,0 -13.5001702,-6.044462 -13.5001702,-13.500477 0,-7.4557388 6.0442615,-13.4995191 13.5001702,-13.4995191 7.455229,0 13.499832,6.0437802 13.499832,13.4995191 z" />
 </svg>

--- a/actions/48/system-lock-screen.svg
+++ b/actions/48/system-lock-screen.svg
@@ -1,17 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg4031"
    height="48"
    width="48"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="system-lock-screen.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
+     id="namedview31"
+     showgrid="false"
+     inkscape:zoom="16.000001"
+     inkscape:cx="18.687499"
+     inkscape:cy="25.249998"
+     inkscape:window-x="629"
+     inkscape:window-y="14"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4031"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4033">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient930">
+      <stop
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop926" />
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop928" />
+    </linearGradient>
     <linearGradient
        id="linearGradient4011-8">
       <stop
@@ -36,49 +76,10 @@
        x2="71.204407"
        y1="6.2375584"
        x1="71.204407"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611004,-2.7279013)"
+       gradientTransform="matrix(1.0540542,0,0,1.054054,-51.611021,-2.7279011)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3540"
        xlink:href="#linearGradient4011-8" />
-    <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,6.7155205,-7.1042197,-1.8878129e-7,84.029119,-23.48282)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient3300-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       cx="99.189415"
-       cy="185.29727"
-       fx="99.189415"
-       fy="185.29727"
-       r="62.769119" />
     <linearGradient
        id="linearGradient3820-7-2">
       <stop
@@ -90,9 +91,29 @@
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient930"
+       id="linearGradient932"
+       x1="10.860361"
+       y1="2.2959261"
+       x2="10.860361"
+       y2="21.580921"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.05,0,0,2.05,-0.6,-0.5999997)" />
     <radialGradient
        xlink:href="#linearGradient3820-7-2"
-       id="radialGradient4192-6"
+       id="radialGradient3300-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient4192-6-2"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
        cx="99.189415"
@@ -109,45 +130,45 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
      id="g4198-4"
-     transform="matrix(0.70833333,0,0,0.71428273,1.33333,0.78460484)"
-     style="stroke-width:1.40587306">
+     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
+     style="stroke-width:1.40587">
     <path
        d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587306" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8-5);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587306"
+       style="opacity:0.4;fill:url(#radialGradient4192-6-2);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
        d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path2555-3"
-     d="M 24.000003,3.4999982 C 12.68881,3.4999982 3.5,12.688804 3.5,23.999997 3.5,35.311193 12.68881,44.500003 24.000003,44.5 35.311192,44.5 44.50001,35.311193 44.5,23.999997 44.5,12.688804 35.311192,3.4999982 24.000003,3.4999982 Z" />
+     d="M 24.000002,3.5000002 C 12.68881,3.5000002 3.5,12.688806 3.5,23.999998 3.5,35.311195 12.68881,44.500002 24.000002,44.5 35.311193,44.5 44.50001,35.311195 44.5,23.999998 44.5,12.688806 35.311193,3.5000002 24.000002,3.5000002 Z" />
   <path
-     style="opacity:0.3;color:#000000;fill:none;stroke:url(#linearGradient3540);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655-4"
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 C 13.230598,43.499998 4.5,34.769109 4.5,23.999308 4.5,13.229906 13.230598,4.4999998 24.000247,4.4999998 34.76891,4.4999998 43.5,13.229906 43.5,23.999308 l 0,0 z" />
+     d="m 43.500006,23.999307 c 0,10.769901 -8.731092,19.500691 -19.499757,19.500691 -10.769654,0 -19.5002541,-8.730891 -19.5002541,-19.500691 0,-10.7694 8.7306001,-19.4993068 19.5002541,-19.4993068 10.768665,0 19.499757,8.7299058 19.499757,19.4993068 z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path2555-6-0"
-     d="M 24.000003,3.4999976 C 12.68881,3.4999976 3.5,12.688804 3.5,23.999998 3.5,35.311192 12.68881,44.500003 24.000003,44.5 35.311191,44.5 44.500011,35.311192 44.5,23.999998 44.5,12.688804 35.311191,3.4999976 24.000003,3.4999976 z" />
+     d="M 24.000001,3.4999991 C 12.68881,3.4999991 3.4999999,12.688805 3.4999999,24 c 0,11.311193 9.1888101,20.500003 20.5000011,20.500001 C 35.311191,44.500001 44.500009,35.311193 44.5,24 44.5,12.688805 35.311191,3.4999991 24.000001,3.4999991 Z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path4741"
-     d="m 23,12.001953 c -3.859165,0 -6.998047,3.138882 -6.998047,6.998047 l 0,3 A 0.9972344,0.9972344 0 0 0 17,22.998047 l 3,0 A 0.9972344,0.9972344 0 0 0 20.998047,22 l 0,-3.335938 c 0,-0.941422 0.724593,-1.666015 1.666015,-1.666015 l 2.671876,0 c 0.941421,0 1.666015,0.724593 1.666015,1.666015 l 0,3.335938 A 0.9972344,0.9972344 0 0 0 28,22.998047 l 3,0 A 0.9972344,0.9972344 0 0 0 31.998047,22 l 0,-3 c 0,-3.859165 -3.138882,-6.998047 -6.998047,-6.998047 l -2,0 z m -7,11 A 0.9972344,0.9972344 0 0 0 15.001953,24 l 0,2 a 0.9972344,0.9972344 0 0 0 0.136719,0.5 0.9972344,0.9972344 0 0 0 -0.136719,0.5 l 0,2 a 0.9972344,0.9972344 0 0 0 0.136719,0.5 0.9972344,0.9972344 0 0 0 -0.136719,0.5 l 0,2 a 0.9972344,0.9972344 0 0 0 0.136719,0.5 0.9972344,0.9972344 0 0 0 -0.136719,0.5 l 0,1 c 0,1.643165 1.354882,2.998047 2.998047,2.998047 l 12,0 c 1.643165,0 2.998047,-1.354882 2.998047,-2.998047 l 0,-1 A 0.9972344,0.9972344 0 0 0 32.861328,32.5 0.9972344,0.9972344 0 0 0 32.998047,32 l 0,-2 A 0.9972344,0.9972344 0 0 0 32.861328,29.5 0.9972344,0.9972344 0 0 0 32.998047,29 l 0,-2 A 0.9972344,0.9972344 0 0 0 32.861328,26.5 0.9972344,0.9972344 0 0 0 32.998047,26 l 0,-2 A 0.9972344,0.9972344 0 0 0 32,23.001953 l -16,0 z" />
+     style="color:#000000;fill:#206b00;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none;fill-opacity:0.15000001"
+     d="m 23,11 c -3.860697,0 -7,3.139303 -7,7 v 4 c -1.644701,0 -3,1.355299 -3,3 v 8 c 0,1.644701 1.355299,3 3,3 h 16 c 1.644701,0 3,-1.355299 3,-3 v -8 c 0,-1.644701 -1.355299,-3 -3,-3 v -4 c 0,-3.860697 -3.139305,-7 -7,-7 z m -0.335938,5 h 2.671875 C 26.27582,16 27,16.724182 27,17.664062 V 22 H 21 V 17.664062 C 21,16.724182 21.72418,16 22.664062,16 Z"
+     id="path938"
+     sodipodi:nodetypes="sscsssssscssssssccss" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.4137931;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0"
-     d="m 23,13 c -3.324,0 -6,2.676 -6,6 l 0,3 3,0 0,-3.335938 C 20,17.187787 21.187787,16 22.664062,16 l 2.671876,0 C 26.812213,16 28,17.187787 28,18.664062 L 28,22 l 3,0 0,-3 c 0,-3.324 -2.676,-6 -6,-6 l -2,0 z m -7,11 0,2 3,0 0,1 -3,0 0,2 3,0 0,1 -3,0 0,2 3,0 0,1 -3,0 0,1 c 0,1.108 0.892,2 2,2 l 12,0 c 1.108,0 2,-0.892 2,-2 l 0,-1 -3,0 0,-1 3,0 0,-2 -3,0 0,-1 3,0 0,-2 -3,0 0,-1 3,0 0,-2 -16,0 z"
-     id="rect4382-3" />
+     id="path936"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#206b00;fill-opacity:0.30000001;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 23,12 c -3.323997,0 -6,2.676003 -6,6 v 5 h -1 c -1.107999,0 -2,0.892001 -2,2 v 8 c 0,1.107999 0.892001,2 2,2 h 16 c 1.107999,0 2,-0.892001 2,-2 v -8 c 0,-1.107999 -0.892001,-2 -2,-2 h -1 v -5 c 0,-3.323997 -2.676005,-6 -6,-6 z m -0.335938,3 h 2.671876 C 26.812212,15 28,16.18779 28,17.664062 V 23 H 20 V 17.664062 C 20,16.18779 21.187788,15 22.664062,15 Z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="M 23 12 C 19.676 12 17 14.676 17 18 L 17 21 L 20 21 L 20 17.664062 C 20 16.187787 21.187787 15 22.664062 15 L 25.335938 15 C 26.812213 15 28 16.187787 28 17.664062 L 28 21 L 31 21 L 31 18 C 31 14.676 28.324 12 25 12 L 23 12 z M 16 23 L 16 25 L 19 25 L 19 26 L 16 26 L 16 28 L 19 28 L 19 29 L 16 29 L 16 31 L 19 31 L 19 32 L 16 32 L 16 33 C 16 34.108 16.892 35 18 35 L 30 35 C 31.108 35 32 34.108 32 33 L 32 32 L 29 32 L 29 31 L 32 31 L 32 29 L 29 29 L 29 28 L 32 28 L 32 26 L 29 26 L 29 25 L 32 25 L 32 23 L 16 23 z "
-     id="rect4382" />
+     id="rect4382-7"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 23 11 C 19.676003 11 17 13.676003 17 17 L 17 22 L 16 22 C 14.892001 22 14 22.892001 14 24 L 14 32 C 14 33.107999 14.892001 34 16 34 L 32 34 C 33.107999 34 34 33.107999 34 32 L 34 24 C 34 22.892001 33.107999 22 32 22 L 31 22 L 31 17 C 31 13.676003 28.323995 11 25 11 L 23 11 z M 22.664062 14 L 25.335938 14 C 26.812212 14 28 15.18779 28 16.664062 L 28 22 L 20 22 L 20 16.664062 C 20 15.18779 21.187788 14 22.664062 14 z " />
 </svg>

--- a/actions/48/system-log-out.svg
+++ b/actions/48/system-log-out.svg
@@ -1,17 +1,84 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4031"
-   height="48"
+   version="1.2"
    width="48"
-   version="1.1">
+   height="48"
+   id="svg2"
+   sodipodi:docname="system-log-out.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1278"
+     inkscape:window-height="957"
+     id="namedview27"
+     showgrid="false"
+     inkscape:zoom="11.681993"
+     inkscape:cx="16.264348"
+     inkscape:cy="17.034765"
+     inkscape:window-x="253"
+     inkscape:window-y="41"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4033">
+     id="defs4">
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015-3"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3820-7-2">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3822-2-6" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3824-1-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="rotate(90,23.999998,24)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="43.523811"
+       y1="23.999998"
+       x1="4.6204333"
+       id="linearGradient887"
+       xlink:href="#linearGradient885" />
     <linearGradient
        id="linearGradient885">
       <stop
@@ -24,26 +91,7 @@
          style="stop-color:#f37329;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4011">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4013" />
-      <stop
-         offset="0.507761"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4015" />
-      <stop
-         offset="0.83456558"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4017" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4019" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.7279009)"
+       gradientTransform="matrix(1.0540543,0,0,1.0540541,-51.611015,-2.7279023)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
        id="linearGradient3019"
@@ -52,93 +100,75 @@
        y1="6.2375584"
        x1="71.204407" />
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3300-8-6"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3300-8"
-       xlink:href="#linearGradient3820-7-2" />
-    <linearGradient
-       id="linearGradient3820-7-2">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop3822-2-6" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop3824-1-2" />
-    </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
        cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient4192-6-7"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4192-6"
-       xlink:href="#linearGradient3820-7-2" />
-    <linearGradient
-       gradientTransform="rotate(90,24,23.999999)"
-       gradientUnits="userSpaceOnUse"
-       y2="23.999999"
-       x2="44.5"
-       y1="23.999999"
-       x1="3.4999996"
-       id="linearGradient887"
-       xlink:href="#linearGradient885" />
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
   </defs>
   <metadata
-     id="metadata4036">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke-width:1.40587306"
-     transform="matrix(0.70833333,0,0,0.71428273,1.33333,0.78460484)"
-     id="g4198-4">
+     id="g4198-4"
+     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
+     style="stroke-width:1.40587">
     <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587306"
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8-6);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
+       style="opacity:0.4;fill:url(#radialGradient4192-6-7);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587306" />
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path2555"
-     d="m 44.500001,24.000002 c 0,-11.311193 -9.188806,-20.5000031 -20.5,-20.5000031 -11.311194,0 -20.5000051,9.1888101 -20.5000021,20.5000031 0,11.311188 9.1888081,20.500008 20.5000021,20.499997 11.311194,0 20.5,-9.188809 20.5,-20.499997 z" />
+     d="M 44.5,24.000003 C 44.5,12.688812 35.311195,3.500001 24,3.500001 c -11.311191,0 -20.5000043,9.188811 -20.5000002,20.500002 0,11.311187 9.1888092,20.500009 20.5000002,20.499996 11.311195,0 20.5,-9.188809 20.5,-20.499996 z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 -10.769649,0 -19.5002474,-8.730889 -19.5002474,-19.50069 0,-10.769402 8.7305984,-19.4993078 19.5002474,-19.4993078 C 34.76891,4.5000002 43.5,13.229906 43.5,23.999308 l 0,0 z" />
+     d="m 43.500009,23.999308 c 0,10.769901 -8.731092,19.500693 -19.499759,19.500693 -10.769649,0 -19.5002506,-8.730891 -19.5002506,-19.500693 0,-10.769402 8.7306016,-19.4993086 19.5002506,-19.4993086 10.768667,0 19.499759,8.7299066 19.499759,19.4993086 z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path2555-6"
-     d="m 24.000003,3.499998 c -11.311193,0 -20.5000034,9.188806 -20.5000034,20.5 0,11.311194 9.1888104,20.500005 20.5000034,20.500002 11.311188,0 20.500008,-9.188808 20.499997,-20.500002 0,-11.311194 -9.188809,-20.5 -20.499997,-20.5 z" />
+     d="m 24.000003,3.4999994 c -11.311192,0 -20.5000028,9.1888066 -20.5000028,20.4999956 0,11.311198 9.1888108,20.500006 20.5000028,20.500006 11.311189,0 20.500008,-9.188808 20.499997,-20.500006 C 44.5,12.688806 35.311192,3.4999994 24.000003,3.4999994 Z" />
   <path
-     d="M 25.388672,14 C 24.077575,14 23,15.092657 23,16.400391 V 21 H 12.388672 C 11.077888,21 10,22.092545 10,23.400391 v 4.199218 C 10,28.907455 11.077888,30 12.388672,30 H 23 v 4.599609 C 23,35.907457 24.07789,37 25.388672,37 c 0.707341,0 1.354376,-0.316661 1.789062,-0.810547 l -0.04687,0.05078 9.19336,-9.070312 a 1.0001,1.0001 0 0 0 0.02734,-0.02734 C 36.751823,26.715237 37,26.13019 37,25.5 37,24.86981 36.751818,24.284761 36.351562,23.857422 a 1.0001,1.0001 0 0 0 -0.02734,-0.02734 l -9.19336,-9.070312 0.04687,0.05078 C 26.743048,14.316661 26.096013,14 25.388672,14 Z"
-     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#ae2109;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1"
-     id="path873-5-3-6-5" />
+     style="color:#000000;fill:#a62100;-inkscape-stroke:none;fill-opacity:0.15000001"
+     d="m 25.548828,15 c -1.3798,0 -2.558594,1.111877 -2.558594,2.5 V 22 h -9.43164 -0.002 C 12.176532,21.999728 11,23.112525 11,24.5 v 3 c 0,1.388123 1.17684,2.5 2.556641,2.5 h 9.433593 v 4.5 c 0,1.388125 1.178794,2.5 2.558594,2.5 0.744076,0 1.427449,-0.314414 1.898438,-0.826172 l -0.04297,0.04492 8.873047,-8.498047 0.01172,-0.01172 C 36.721815,27.267147 37,26.650811 37,25.980469 37,25.310103 36.721781,24.693776 36.289062,24.251953 l -0.01172,-0.01172 -8.875,-8.458984 0.04492,0.04492 C 26.976288,15.314453 26.292924,15 25.548828,15 Z"
+     id="path911"
+     sodipodi:nodetypes="ssccsssscssccccsccccs" />
   <path
-     id="path873-5-3-6"
-     style="fill:#ae2109;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stop-color:#000000;font-variation-settings:normal;opacity:0.3;vector-effect:none;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-opacity:1"
-     d="M 25.38891,15 C 24.619454,15 24,15.624762 24,16.4 v 5.599999 H 12.388911 C 11.619454,21.999999 11,22.6244 11,23.399999 v 4.200002 c 0,0.775599 0.619454,1.4 1.388911,1.4 H 24 V 34.6 c 0,0.775601 0.619454,1.4 1.38891,1.4 0.414707,0 0.784905,-0.181645 1.038971,-0.470312 l 9.192338,-9.069923 C 35.855061,26.209034 36,25.872035 36,25.499999 36,25.127963 35.855061,24.790966 35.620219,24.540233 l -9.192338,-9.06992 C 26.173815,15.181646 25.803617,15 25.38891,15 Z" />
+     id="path24690"
+     style="font-variation-settings:normal;vector-effect:none;fill:#a62100;fill-opacity:0.30000001;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="M 25.547866,36 C 24.68543,36 23.991122,35.330708 23.991122,34.499344 V 29.000328 H 13.556744 C 12.694306,29.000328 12,28.331036 12,27.499672 v -2.999344 c 0,-0.831364 0.694306,-1.501476 1.556744,-1.500656 h 10.434378 v -5.49902 C 23.991122,16.669292 24.68543,16 25.547866,16 c 0.46482,0 0.87975,0.19472 1.16452,0.504124 l 8.86194,8.44757 C 35.837546,25.220452 36,25.58168 36,25.980464 c 0,0.398784 -0.16244,0.76001 -0.425674,1.02877 l -8.86194,8.48664 C 26.427616,35.805294 26.012686,36 25.547866,36 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
-     d="M 25.38891,14 C 24.619454,14 24,14.624762 24,15.4 v 5.599999 H 12.388911 C 11.619454,20.999999 11,21.6244 11,22.399999 v 4.200002 c 0,0.775599 0.619454,1.4 1.388911,1.4 H 24 V 33.6 c 0,0.775601 0.619454,1.4 1.38891,1.4 0.414707,0 0.784905,-0.181645 1.038971,-0.470312 l 9.192338,-9.069923 C 35.855061,25.209034 36,24.872035 36,24.499999 36,24.127963 35.855061,23.790966 35.620219,23.540233 l -9.192338,-9.06992 C 26.173815,14.181646 25.803617,14 25.38891,14 Z"
-     style="fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path873-5-3" />
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="M 25.547866,34 C 24.68543,34 23.991122,33.330708 23.991122,32.499344 V 27.000328 H 13.556744 C 12.694306,27.000328 12,26.331036 12,25.499672 v -2.999344 c 0,-0.831364 0.694306,-1.501476 1.556744,-1.500656 h 10.434378 v -5.49902 C 23.991122,14.669292 24.68543,14 25.547866,14 c 0.46482,0 0.87975,0.19472 1.16452,0.504124 l 8.86194,8.44757 C 35.837546,23.220452 36,23.58168 36,23.980464 c 0,0.398784 -0.16244,0.76001 -0.425674,1.02877 l -8.86194,8.48664 C 26.427616,33.805294 26.012686,34 25.547866,34 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
 </svg>

--- a/actions/48/system-reboot.svg
+++ b/actions/48/system-reboot.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
+   version="1.2"
    width="48"
    height="48"
-   id="svg4031"
+   id="svg2"
    sodipodi:docname="system-reboot.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,19 +23,23 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="758"
-     inkscape:window-height="526"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
      id="namedview27"
      showgrid="false"
-     inkscape:zoom="4.9166667"
-     inkscape:cx="24"
-     inkscape:cy="24"
-     inkscape:window-x="0"
-     inkscape:window-y="60"
+     inkscape:zoom="16.520833"
+     inkscape:cx="18.643128"
+     inkscape:cy="21.366961"
+     inkscape:window-x="802"
+     inkscape:window-y="47"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4031" />
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4033">
+     id="defs4">
     <linearGradient
        id="linearGradient4011">
       <stop
@@ -43,11 +47,11 @@
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.507761" />
       <stop
-         id="stop4017"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456558" />
       <stop
@@ -56,33 +60,33 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3019"
+       gradientTransform="rotate(90,23.999999,24)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="44.5"
+       y1="23.999998"
+       x1="3.4999995"
+       id="linearGradient887"
+       xlink:href="#linearGradient947-5" />
+    <linearGradient
+       gradientTransform="matrix(1.0540543,0,0,1.0540541,-51.611015,-2.7279023)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.7279009)" />
+       id="linearGradient3019"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
     <linearGradient
-       gradientTransform="matrix(1.5712555,0,0,1.1746645,-3179.5055,-3763.7759)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient947"
-       id="linearGradient11527-6-5"
-       y2="3241.9966"
-       x2="2035.1652"
-       y1="3208.0737"
-       x1="2035.1652" />
-    <linearGradient
-       id="linearGradient947">
+       id="linearGradient947-5">
       <stop
-         id="stop943"
+         offset="0"
          style="stop-color:#64baff;stop-opacity:1"
-         offset="0" />
+         id="stop943-6" />
       <stop
-         id="stop945"
+         offset="1"
          style="stop-color:#3689e6;stop-opacity:1"
-         offset="1" />
+         id="stop945-2" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3820-7-2"
@@ -117,54 +121,67 @@
        r="62.769119" />
   </defs>
   <metadata
-     id="metadata4036">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
      id="g4198-4"
-     transform="matrix(0.70833333,0,0,0.71428273,1.33333,0.78460484)"
-     style="stroke-width:1.40587306">
+     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
+     style="stroke-width:1.40587">
     <path
-       inkscape:connector-curvature="0"
        d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587306" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587306"
+       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
        d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
-     d="m 24.000001,3.499999 c -11.311198,0 -20.5000012,9.188802 -20.5000012,20.499999 0,11.311198 9.1888032,20.500001 20.5000012,20.500001 11.311196,0 20.500018,-9.188803 20.499999,-20.500001 C 44.5,12.688801 35.311197,3.499999 24.000001,3.499999 Z"
-     id="path2555-7-8-5-0-9"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.98999999;fill:url(#linearGradient11527-6-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
+     id="path2555"
+     d="M 44.5,24.000004 C 44.5,12.688811 35.311195,3.5 24,3.5 12.688809,3.5 3.4999957,12.688811 3.4999998,24.000004 3.4999998,35.311191 12.688809,44.500011 24,44.5 c 11.311195,0 20.5,-9.188809 20.5,-20.499996 z" />
   <path
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 -10.769649,0 -19.5002474,-8.730889 -19.5002474,-19.50069 0,-10.769402 8.7305984,-19.4993078 19.5002474,-19.4993078 C 34.76891,4.5000002 43.5,13.229906 43.5,23.999308 l 0,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 43.500009,23.999308 c 0,10.769901 -8.731092,19.500693 -19.499759,19.500693 -10.769649,0 -19.5002506,-8.730891 -19.5002506,-19.500693 0,-10.769402 8.7306016,-19.4993086 19.5002506,-19.4993086 10.768667,0 19.499759,8.7299066 19.499759,19.4993086 z" />
   <path
-     d="m 24.000003,3.499998 c -11.311193,0 -20.5000034,9.188806 -20.5000034,20.5 0,11.311194 9.1888104,20.500005 20.5000034,20.500002 11.311188,0 20.500008,-9.188808 20.499997,-20.500002 0,-11.311194 -9.188809,-20.5 -20.499997,-20.5 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path2555-6"
-     style="opacity:0.5;color:#000000;fill:none;stroke:#002e99;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     d="m 24.000003,3.4999975 c -11.311191,0 -20.5000029,9.1888055 -20.5000029,20.4999975 0,11.311199 9.1888119,20.500007 20.5000029,20.500007 11.311189,0 20.500008,-9.188808 20.499997,-20.500007 C 44.5,12.688803 35.311192,3.4999975 24.000003,3.4999975 Z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path4164"
-     d="m 24,11.570312 0,3.433594 c -5.688807,0 -10.300781,4.610022 -10.300781,10.298828 0,5.688808 4.611974,10.300782 10.300781,10.300782 5.688807,0 10.300781,-4.611974 10.300781,-10.300782 l -3.433593,0 c 0,3.792538 -3.07465,6.867188 -6.867188,6.867188 -3.792537,0 -6.867188,-3.07465 -6.867188,-6.867188 0,-3.792538 3.074651,-6.867187 6.867188,-6.867187 l 0,3.433594 8.583984,-5.148438 L 24,11.570312 Z" />
+     style="color:#000000;fill:#002e99;-inkscape-stroke:none;fill-opacity:0.15000001"
+     d="M 26.166016,9.5 C 25.071791,9.5 24,10.293121 24,11.474609 v 1.601563 c -3.619363,0.04284 -7.161794,1.456873 -9.716797,4.203125 -3.782142,4.065246 -4.6163976,10.074602 -2.068359,15 2.546656,4.922732 7.918794,7.755376 13.449218,7.134765 5.531135,-0.620691 10.13477,-4.579291 11.494141,-9.949218 0.403478,-1.594711 -0.5774,-3.240928 -2.171875,-3.644532 h -0.002 c -1.594625,-0.402278 -3.239854,0.579065 -3.642578,2.173829 -0.742366,2.929452 -3.245922,5.109182 -6.345703,5.457031 -3.099067,0.347771 -6.055602,-1.230075 -7.451172,-3.927735 -1.397533,-2.701454 -0.958684,-5.910298 1.130859,-8.15625 1.389971,-1.494014 3.3377,-2.168567 5.324219,-2.21289 v 3.371094 C 24,23.706879 25.071795,24.5 26.166016,24.5 c 0.591406,0 1.144922,-0.209799 1.558593,-0.599609 l -0.04687,0.04102 6.654297,-5.52539 0.01172,-0.01172 C 34.723648,18.067879 35,17.556963 35,16.986328 c 0,-0.570617 -0.279092,-1.08204 -0.65625,-1.416015 l -0.01172,-0.01172 -6.65625,-5.501953 0.04883,0.04297 C 27.31095,9.7098232 26.75746,9.5 26.166016,9.5 Z"
+     id="path919"
+     sodipodi:nodetypes="sscsssccccsssccsccccsccccs" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.05;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path4164-3"
-     d="m 23.939453,10.568359 a 1.0031133,1.0031133 0 0 0 -0.943359,1.001953 l 0,2.632813 c -5.73816,0.534074 -10.300781,5.224532 -10.300782,11.099609 0,6.23091 5.073779,11.304688 11.304688,11.304688 6.230909,0 11.304688,-5.073778 11.304688,-11.304688 a 1.0031133,1.0031133 0 0 0 -1.003907,-1.003906 l -3.433593,0 a 1.0031133,1.0031133 0 0 0 -1.003907,1.003906 c 0,3.250436 -2.612845,5.863282 -5.863281,5.863282 -3.250435,0 -5.863281,-2.612846 -5.863281,-5.863282 0,-2.893768 2.111195,-5.172637 4.859375,-5.662109 l 0,2.228516 a 1.0031133,1.0031133 0 0 0 1.519531,0.859375 l 8.583984,-5.148438 a 1.0031133,1.0031133 0 0 0 0,-1.71875 l -8.583984,-5.15039 a 1.0031133,1.0031133 0 0 0 -0.576172,-0.142579 z" />
+     id="path45206"
+     style="color:#000000;fill:#002e99;fill-opacity:0.30000001;fill-rule:evenodd;stroke-width:1.99973;stroke-linecap:round;-inkscape-stroke:none"
+     d="m 27.033551,11 c -0.574461,0 -1.035028,0.403541 -1.035028,0.902372 v 2.601644 c -5.156051,-0.0369 -12.397798,4.138282 -13.979272,9.078379 -1.845389,5.764497 1.858439,12.512853 7.706609,14.656785 5.848172,2.143935 12.416075,-0.38012 15.076262,-5.828305 0.477425,-0.981241 0.05265,-2.175333 -0.949101,-2.668054 -1.002398,-0.494078 -2.203941,-0.09874 -2.68326,0.882839 -1.759817,3.604184 -6.196249,5.322364 -10.112034,3.88684 -3.915786,-1.435521 -5.911052,-6.669245 -4.69864,-10.4565 1.633149,-5.101515 5.812813,-5.566979 9.639436,-5.567485 v 4.109299 c 0,0.498834 0.460565,0.902371 1.035028,0.902373 0.309614,0 0.587552,-0.115144 0.777248,-0.300792 l 5.901616,-5.094189 c 0.175338,-0.161265 0.285121,-0.377928 0.285121,-0.617207 0,-0.239276 -0.109787,-0.455948 -0.285121,-0.617205 L 27.810799,11.300789 C 27.621117,11.115142 27.343165,11 27.033551,11 Z"
+     sodipodi:nodetypes="sscsscccsscssccsccs" />
   <path
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     d="m 24,10.569079 0,3.433497 c -5.688807,0 -10.300491,4.611689 -10.300491,10.300495 0,5.688808 4.611684,10.300492 10.300491,10.300492 5.688807,0 10.300492,-4.611684 10.300492,-10.300492 l -3.433497,0 c 0,3.792538 -3.074457,6.866995 -6.866995,6.866995 -3.792537,0 -6.866994,-3.074457 -6.866994,-6.866995 0,-3.792538 3.074457,-6.866995 6.866994,-6.866995 l 0,3.433498 8.583743,-5.150246 L 24,10.569079 Z"
-     id="path2984" />
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 26.166946,22.499999 c -0.646351,0 -1.166695,-0.43504 -1.166695,-0.975427 V 10.475424 C 25.000251,9.9350403 25.520595,9.5 26.166946,9.5 c 0.348358,0 0.659324,0.1265766 0.872745,0.3276803 L 33.68123,15.319 c 0.19728,0.174692 0.319021,0.409091 0.319021,0.668301 0,0.259209 -0.121748,0.494006 -0.319021,0.6687 l -6.641539,5.516316 c -0.213435,0.201123 -0.524387,0.327682 -0.872745,0.327682 z"
+     sodipodi:nodetypes="sccsccsccs" />
+  <path
+     style="fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+     id="path54251"
+     sodipodi:type="arc"
+     sodipodi:cx="24.152536"
+     sodipodi:cy="25.248646"
+     sodipodi:rx="10.406855"
+     sodipodi:ry="10.249931"
+     sodipodi:start="0.2443461"
+     sodipodi:end="5.0963614"
+     sodipodi:arc-type="arc"
+     d="m 34.250263,27.728329 a 10.406855,10.249931 0 0 1 -8.919637,7.70436 10.406855,10.249931 0 0 1 -10.450665,-5.530672 10.406855,10.249931 0 0 1 1.599837,-11.578124 10.406855,10.249931 0 0 1 11.571215,-2.578818"
+     sodipodi:open="true" />
 </svg>

--- a/actions/48/system-shutdown.svg
+++ b/actions/48/system-shutdown.svg
@@ -1,77 +1,107 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg4031">
+   id="svg3041"
+   sodipodi:docname="system-shutdown.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1488"
+     inkscape:window-height="754"
+     id="namedview35"
+     showgrid="false"
+     inkscape:zoom="11.681993"
+     inkscape:cx="15.793538"
+     inkscape:cy="24.011314"
+     inkscape:window-x="590"
+     inkscape:window-y="211"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3041"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4033">
+     id="defs3043">
     <linearGradient
-       id="linearGradient4011-8">
+       id="linearGradient26009">
       <stop
+         id="stop26005"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4013-9" />
+         style="stop-color:#ed5353;stop-opacity:1" />
       <stop
-         offset="0.507761"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4015-2" />
-      <stop
-         offset="0.83456558"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4017-28" />
-      <stop
+         id="stop26007"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4019-23" />
+         style="stop-color:#c6262e;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4011-8"
-       id="linearGradient3540"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611004,-2.7279013)"
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8838">
+      <stop
+         id="stop8840"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8842"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
        x1="71.204407"
        y1="6.2375584"
        x2="71.204407"
-       y2="44.340794" />
-    <radialGradient
-       gradientTransform="matrix(0,6.7155205,-7.1042197,-1.8878129e-7,84.029119,-23.48282)"
+       y2="44.340794"
+       id="linearGradient3089"
+       xlink:href="#linearGradient4011"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       id="radialGradient3092"
-       fy="8.4497671"
-       fx="0.96534902"
-       r="19.99999"
-       cy="8.4497671"
-       cx="0.96534902" />
+       gradientTransform="matrix(1.054054,0,0,1.0540541,-51.610998,-2.727901)" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         offset="0"
-         style="stop-color:#919caf;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-3" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#68758e;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#485a6c;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#444c5c;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-0" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient26009"
+       id="linearGradient905"
+       gradientUnits="userSpaceOnUse"
+       x1="10.007311"
+       y1="10.467905"
+       x2="10.433324"
+       y2="29.606293"
+       gradientTransform="matrix(1.9527128,0,0,1.9527128,0.56744514,-15.054259)" />
     <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient3300-8"
+       xlink:href="#linearGradient8838"
+       id="radialGradient3300-8-9"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
        cx="99.189415"
@@ -79,20 +109,9 @@
        fx="99.189415"
        fy="185.29727"
        r="62.769119" />
-    <linearGradient
-       id="linearGradient3820-7-2">
-      <stop
-         id="stop3822-2-6"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3824-1-2"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient4192-6"
+       xlink:href="#linearGradient8838"
+       id="radialGradient4192-6-2"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
        cx="99.189415"
@@ -102,53 +121,76 @@
        r="62.769119" />
   </defs>
   <metadata
-     id="metadata4036">
+     id="metadata3046">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
      id="g4198-4"
-     transform="matrix(0.70833333,0,0,0.71428273,1.33333,0.78460484)"
-     style="stroke-width:1.40587306">
+     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
+     style="stroke-width:1.40587">
     <path
        d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587306" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8-9);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587306"
+       style="opacity:0.4;fill:url(#radialGradient4192-6-2);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
        d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
-     d="M 24.000003,3.4999982 C 12.68881,3.4999982 3.5,12.688804 3.5,23.999997 3.5,35.311193 12.68881,44.500003 24.000003,44.5 35.311192,44.5 44.50001,35.311193 44.5,23.999997 44.5,12.688804 35.311192,3.4999982 24.000003,3.4999982 Z"
-     id="path2555-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+     d="M 24.000002,3.5 C 12.68881,3.5 3.5,12.688806 3.5,23.999998 3.5,35.311192 12.68881,44.500006 24.000002,44.5 35.311192,44.5 44.500012,35.311192 44.5,23.999998 44.5,12.688806 35.311192,3.5 24.000002,3.5 Z"
+     id="path2555"
+     style="fill:url(#linearGradient905);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 C 13.230598,43.499998 4.5,34.769109 4.5,23.999308 4.5,13.229906 13.230598,4.4999998 24.000247,4.4999998 34.76891,4.4999998 43.5,13.229906 43.5,23.999308 l 0,0 z"
-     id="path8655-4"
-     style="opacity:0.3;color:#000000;fill:none;stroke:url(#linearGradient3540);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 24.000001,3.4999989 c -11.311191,0 -20.5000013,9.1888071 -20.5000013,20.5000001 0,11.311194 9.1888103,20.500005 20.5000013,20.500002 11.311188,0 20.500011,-9.188808 20.499999,-20.500002 C 44.5,12.688806 35.311189,3.4999989 24.000001,3.4999989 Z"
+     id="path2555-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate" />
   <path
-     d="M 24.000003,3.4999976 C 12.68881,3.4999976 3.5,12.688804 3.5,23.999998 3.5,35.311192 12.68881,44.500003 24.000003,44.5 35.311191,44.5 44.500011,35.311192 44.5,23.999998 44.5,12.688804 35.311191,3.4999976 24.000003,3.4999976 z"
-     id="path2555-6-0"
-     style="opacity:0.5;color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     d="m 43.5,23.999309 c 0,10.769903 -8.73109,19.500694 -19.499753,19.500694 -10.769649,0 -19.5002469,-8.730892 -19.5002469,-19.500694 0,-10.769403 8.7305979,-19.4993089 19.5002469,-19.4993089 C 34.76891,4.5000001 43.5,13.229906 43.5,23.999309 Z"
+     id="path8655"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path4235"
-     d="m 24,8.9941406 c -1.64777,0 -3.005859,1.3580894 -3.005859,3.0058594 l 0,12 c 0,1.64777 1.358089,3.005859 3.005859,3.005859 1.64777,0 3.005859,-1.358089 3.005859,-3.005859 l 0,-12 C 27.005859,10.35223 25.64777,8.9941406 24,8.9941406 Z m -6.375,4.8750004 c -0.578529,0 -1.010347,0.206577 -1.304688,0.345703 a 1.0058156,1.0058156 0 0 0 -0.08789,0.04687 l -0.625,0.375 a 1.0058156,1.0058156 0 0 0 -0.03711,0.02344 c -3.160252,2.084462 -5.401086,5.297913 -6.1874995,9.050782 -1.368e-4,1.34e-4 -0.00391,0.0039 -0.00391,0.0039 -3.96e-5,5.4e-5 -0.1816299,0.419862 -0.1816406,0.419922 a 1.0058156,1.0058156 0 0 0 -0.00195,0.0098 c -0.071077,0.421695 -0.033573,0.539749 -0.00391,0.335938 l 0.00195,-0.0039 C 9.1012675,25.090839 8.9941406,25.755625 8.9941406,26.5 c 0,8.019503 6.7497564,14.505859 15.0058594,14.505859 8.256103,0 15.005859,-6.486356 15.005859,-14.505859 0,-0.634029 -0.05616,-1.237369 -0.132812,-1.818359 a 1.0058156,1.0058156 0 0 0 -0.002,-0.002 c -0.04887,-0.364897 -0.130153,-0.537005 -0.13086,-0.541016 -0.694779,-3.944024 -3.026633,-7.312489 -6.310546,-9.478516 a 1.0058156,1.0058156 0 0 0 -0.03711,-0.02344 l -0.625,-0.375 a 1.0058156,1.0058156 0 0 0 -0.08789,-0.04687 C 31.385347,14.075718 30.953529,13.869141 30.375,13.869141 c -1.682629,0 -3.068359,1.38573 -3.068359,3.068359 0,1.0049 0.502123,1.853769 1.185547,2.40625 0.197266,0.159491 0.433436,0.327268 0.740234,0.457031 l -0.164063,-0.08789 c 1.738502,1.156837 3.021945,2.882266 3.589844,4.875 0.115724,0.406962 0.152912,0.45998 0.05859,0.113281 0.18458,0.678087 0.277344,1.367369 0.277344,2.111328 0,4.761945 -3.993242,8.619141 -8.994141,8.619141 -5.000899,0 -8.994141,-3.857196 -8.994141,-8.619141 0,-0.743957 0.09276,-1.433238 0.277344,-2.111328 a 1.0058156,1.0058156 0 0 0 0,-0.002 c -0.09089,0.336766 -0.05993,0.304439 0.05859,-0.111328 0.567899,-1.992734 1.851342,-3.718163 3.589844,-4.875 l -0.164063,0.08789 c 0.306799,-0.129766 0.542987,-0.297566 0.740234,-0.457031 0.683424,-0.552481 1.185547,-1.40135 1.185547,-2.40625 0,-1.682629 -1.38573,-3.068359 -3.068359,-3.068359 z"
-     transform="translate(-1.406e-4,-0.999859)" />
+     style="color:#000000;fill:#7a0000;fill-opacity:0.15;stroke-width:1;stroke-linecap:round;stroke-miterlimit:0;-inkscape-stroke:none"
+     d="m 29.304687,14.109189 c -0.764952,0.21105 -1.413518,0.713516 -1.802734,1.393135 -0.805208,1.406775 -0.288896,3.21623 1.144531,4.00694 2.197998,1.21071 3.415056,2.649963 3.996094,4.146829 0.581038,1.496864 0.535709,3.095989 0.0098,4.666139 -1.039811,3.104151 -4.061011,5.790997 -8.732456,5.790997 -4.682408,0 -7.582126,-2.779042 -8.591797,-6.022866 -0.509099,-1.635609 -0.529236,-3.27515 0.03516,-4.735126 0.564392,-1.459976 1.704376,-2.781195 3.722656,-3.790401 h 0.002 c 1.464708,-0.733244 2.055088,-2.519616 1.308593,-3.957116 v -0.002 C 19.649142,14.168689 17.828422,13.589447 16.363281,14.321858 9.942895,17.532258 7.8595646,24.252184 9.5898438,29.811143 11.314096,35.35074 16.685483,40 23.919922,40 c 7.116799,0 12.597732,-4.363228 14.43164,-9.838178 1.842215,-5.499744 -0.254374,-12.19784 -6.765625,-15.784391 -0.693265,-0.38187 -1.513825,-0.479066 -2.279296,-0.26828 z"
+     id="path3208"
+     sodipodi:nodetypes="cccscssscccccsssscc" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.41379309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3782-7"
-     d="m 17.624859,13.875141 c -0.31487,0 -0.608048,0.12382 -0.875,0.25 l -0.625,0.375 c -3.067692,2.02341 -5.22986,5.15026 -5.875,8.8125 -6.88e-4,0.004 -0.06182,-0.0038 -0.0625,0 -0.017,0.10086 0.0148,0.210824 0,0.3125 -0.0926,0.617666 -0.1874996,1.229142 -0.1874996,1.875 0,7.455844 6.2680136,13.5 13.9999996,13.5 7.731986,0 14,-6.044156 14,-13.5 0,-0.573518 -0.05176,-1.132366 -0.125,-1.6875 -0.02312,-0.17264 -0.095,-0.329736 -0.125,-0.5 -0.64514,-3.66224 -2.807308,-6.78909 -5.875,-8.8125 l -0.625,-0.375 c -0.266952,-0.12618 -0.56013,-0.25 -0.875,-0.25 -1.138892,0 -2.0625,0.923608 -2.0625,2.0625 0,0.648164 0.344864,1.246962 0.8125,1.625 0.14862,0.12016 0.321496,0.237 0.5,0.3125 1.932542,1.285956 3.364682,3.208196 4,5.4375 0.012,0.04254 0.0509,0.08236 0.0625,0.125 0.207862,0.763616 0.3125,1.546374 0.3125,2.375 0,5.325604 -4.477152,9.625 -10,9.625 -5.522848,0 -10,-4.299396 -10,-9.625 0,-0.828626 0.10464,-1.611384 0.3125,-2.375 0.012,-0.04446 0.0499,-0.0808 0.0625,-0.125 0.635318,-2.229304 2.067458,-4.151544 4,-5.4375 0.1785,-0.0755 0.35137,-0.19234 0.5,-0.3125 0.467636,-0.378038 0.8125,-0.976836 0.8125,-1.625 0,-1.138892 -0.923608,-2.0625 -2.0625,-2.0625 z m 6.375,-4.875 c 1.108,0 2,0.892 2,2 l 0,12 c 0,1.108 -0.892,2 -2,2 -1.108,0 -2,-0.892 -2,-2 l 0,-12 c 0,-1.108 0.892,-2 2,-2 z" />
+     d="M 17.724335,17 C 7.3186583,22.17387 12.024077,37 23.920271,37 35.692542,37 40.968686,22.944141 30.116205,17"
+     id="path3013"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:#7a0000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;marker:none" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3782"
-     d="m 17.624859,12.875141 c -0.31487,0 -0.608048,0.12382 -0.875,0.25 l -0.625,0.375 c -3.067692,2.02341 -5.22986,5.15026 -5.875,8.8125 -6.88e-4,0.004 -0.06182,-0.0038 -0.0625,0 -0.017,0.10086 0.0148,0.210824 0,0.3125 -0.0926,0.617666 -0.1874996,1.229142 -0.1874996,1.875 0,7.455844 6.2680136,13.5 13.9999996,13.5 7.731986,0 14,-6.044156 14,-13.5 0,-0.573518 -0.05176,-1.132366 -0.125,-1.6875 -0.02312,-0.17264 -0.095,-0.329736 -0.125,-0.5 -0.64514,-3.66224 -2.807308,-6.78909 -5.875,-8.8125 l -0.625,-0.375 c -0.266952,-0.12618 -0.56013,-0.25 -0.875,-0.25 -1.138892,0 -2.0625,0.923608 -2.0625,2.0625 0,0.648164 0.344864,1.246962 0.8125,1.625 0.14862,0.12016 0.321496,0.237 0.5,0.3125 1.932542,1.285956 3.364682,3.208196 4,5.4375 0.012,0.04254 0.0509,0.08236 0.0625,0.125 0.207862,0.763616 0.3125,1.546374 0.3125,2.375 0,5.325604 -4.477152,9.625 -10,9.625 -5.522848,0 -10,-4.299396 -10,-9.625 0,-0.828626 0.10464,-1.611384 0.3125,-2.375 0.012,-0.04446 0.0499,-0.0808 0.0625,-0.125 0.635318,-2.229304 2.067458,-4.151544 4,-5.4375 0.1785,-0.0755 0.35137,-0.19234 0.5,-0.3125 0.467636,-0.378038 0.8125,-0.976836 0.8125,-1.625 0,-1.138892 -0.923608,-2.0625 -2.0625,-2.0625 z m 6.375,-4.875 c 1.108,0 2,0.892 2,2 l 0,12 c 0,1.108 -0.892,2 -2,2 -1.108,0 -2,-0.892 -2,-2 l 0,-12 c 0,-1.108 0.892,-2 2,-2 z" />
+     style="color:#000000;opacity:1;fill:#7a0000;stroke-linecap:round;stroke-miterlimit:0;-inkscape-stroke:none;fill-opacity:0.15000001"
+     d="m 24,10 c -1.645008,0 -3,1.354992 -3,3 v 11 c 0,1.645008 1.354992,3 3,3 1.645008,0 3,-1.354992 3,-3 V 13 c 0,-1.645008 -1.354992,-3 -3,-3 z"
+     id="path3222"
+     sodipodi:nodetypes="sssssss" />
+  <path
+     d="M 24,24 V 13"
+     id="path3015"
+     style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:#7a0000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31;marker:none"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path3341"
+     d="M 23.977184,22 V 11"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+     id="path27328"
+     sodipodi:type="arc"
+     sodipodi:cx="24"
+     sodipodi:cy="24.45616"
+     sodipodi:rx="12.000794"
+     sodipodi:ry="11.543839"
+     sodipodi:start="5.3232542"
+     sodipodi:end="4.1015237"
+     sodipodi:arc-type="arc"
+     d="M 30.883373,15 A 12.000794,11.543839 0 0 1 35.445361,27.927459 12.000794,11.543839 0 0 1 24,35.999999 12.000794,11.543839 0 0 1 12.554639,27.927459 12.000794,11.543839 0 0 1 17.116627,15"
+     sodipodi:open="true" />
 </svg>


### PR DESCRIPTION
We did these in elementary-xfce, was wondering if you all would be interested in them?

The dark icons were a little close to disabled-button looking and adding color helps with that and makes them easier to see on dark backgrounds. Also reboot uses rounded arrow.

Questions:

1) Only 32px and 48px exist, do you all want 24px and 16px added?
2) ~`system-restart` and `system-suspend` are non-FDO names, remove these or think about it in another PR?~ Nevermind, after checking the code base these are uses in elementary.
3) We also did suspend and hibernate, and switch user if you all want them (none are FDO, but are commonly used) (also, suspend was a different design than current, didn't want to change it without asking):

![session-prop](https://github.com/elementary/icons/assets/1984060/a919be41-3c68-4cda-b3c3-c5af635f444f)