### PR TITLE
Actions: Add color mail-send-receive

### DIFF
--- a/actions/16/mail-send-receive.svg
+++ b/actions/16/mail-send-receive.svg
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="mail-send-receive.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10667"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="6.8279998"
+     inkscape:cy="3.049398"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="956"
+     inkscape:window-y="61"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <linearGradient
+       id="linearGradient78">
+      <stop
+         style="stop-color:#d1ff82;stop-opacity:1"
+         offset="0"
+         id="stop74" />
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop76" />
+    </linearGradient>
+    <linearGradient
+       y2="52.88578"
+       x2="33.060375"
+       y1="52.88578"
+       x1="21.235779"
+       gradientTransform="matrix(0,0.54188661,0.46916342,0,-20.115418,-7.9189116)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940-5"
+       xlink:href="#linearGradient1597-6" />
+    <linearGradient
+       id="linearGradient1597-6">
+      <stop
+         id="stop1589-2"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1591-9"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.49999997" />
+      <stop
+         id="stop1593-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1595-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="10.24962"
+       x2="20.895462"
+       y1="10.24962"
+       x1="2.5057657"
+       gradientTransform="matrix(0,0.61157583,-0.6008607,0,17.611227,1.9708373)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient72-3"
+       xlink:href="#linearGradient78" />
+    <linearGradient
+       y2="57.037033"
+       x2="18.686367"
+       y1="57.037033"
+       x1="25.631071"
+       gradientTransform="matrix(0,-0.39056144,0.43562686,0,-12.519347,21.010503)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940"
+       xlink:href="#linearGradient1356" />
+    <linearGradient
+       id="linearGradient1356">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1348" />
+      <stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1350" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1352" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1354" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1597"
+       id="linearGradient940-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.66975928,0.49699178,0,-15.864986,28.525584)"
+       x1="33.634502"
+       y1="54.470387"
+       x2="27.660069"
+       y2="54.470387" />
+    <linearGradient
+       id="linearGradient1597">
+      <stop
+         id="stop1589"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1591"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00000024" />
+      <stop
+         id="stop1593"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1595"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="0"
+         id="stop866" />
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="1"
+         id="stop868" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient870"
+       id="linearGradient1556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66883157,0,0,0.67307731,16.389718,-17.597913)"
+       x1="-17.392385"
+       y1="25.405151"
+       x2="-17.392385"
+       y2="47.681522" />
+  </defs>
+  <path
+     id="path873-5-5-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient72-3);fill-opacity:1;stroke:#206b00;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     d="m 11.499023,14.249998 c -0.08084,0 -0.150827,-0.03231 -0.208984,-0.08789 L 7.6013133,10.064336 C 7.5390943,10.004896 7.4997512,9.9214594 7.4997512,9.8221484 c 0,-0.184523 0.130217,-0.322266 0.304688,-0.322266 h 2.3964838 c 0.162838,1.16e-4 0.298829,-0.145914 0.298829,-0.324218 V 4.8066417 c 0,-0.1748181 0.129025,-0.306641 0.300781,-0.306641 h 1.398663 c 0.171754,0 0.300781,0.1318229 0.300781,0.306641 v 4.4002727 c 0.01503,0.16368 0.145595,0.293077 0.298828,0.292968 h 2.400412 c 0.174469,0 0.300781,0.137743 0.300781,0.322266 0,0.1845766 -0.07628,0.1785566 -0.103516,0.2421876 l -3.686521,4.097771 c -0.05467,0.05559 -0.129519,0.08789 -0.210938,0.08789 z"
+     sodipodi:nodetypes="sccsscsssssccssccs" />
+  <path
+     d="M 10.499752,10.499995 H 9.34 L 11.499977,12.91 13.66,10.499995 h -1.160001"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path873-5-5-2"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="m 12.5,10.499996 c -0.410995,0 -0.999402,-0.6055892 -0.999504,-1.1198542 l -9.95e-4,-3.8801425 h 7.48e-4 l -9.95e-4,3.8801425 c -6.3e-5,0.465044 -0.502511,1.1198542 -0.999503,1.1198542"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path873-5-5-2-6"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     d="m 4.4990234,1.7499992 c -0.080838,0 -0.1508278,0.03231 -0.2089844,0.08789 L 0.60156125,5.9356641 c -0.062219,0.059439 -0.101562,0.1428761 -0.101562,0.2421875 0,0.1845228 0.130217,0.3222656 0.304688,0.3222656 H 3.2011704 C 3.3640083,6.5000012 3.4999985,6.646031 3.4999985,6.8243359 V 11.19368 c 0,0.174818 0.1290258,0.306641 0.3007812,0.306641 h 1.3984156 c 0.1717556,0 0.3007813,-0.131823 0.3007812,-0.306641 V 6.7930859 C 5.5150045,6.6294056 5.6455714,6.5000084 5.7988047,6.5001172 H 8.199452 c 0.174469,0 0.300781,-0.1377426 0.300781,-0.3222656 0,-0.1845764 -0.07628,-0.1785565 -0.103516,-0.2421875 L 4.7099609,1.8378902 c -0.054667,-0.05559 -0.1295192,-0.08789 -0.2109375,-0.087891 z"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:url(#linearGradient1556);fill-opacity:1;stroke:#7239b3;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path873-5-5"
+     sodipodi:nodetypes="sccsscsssscccssccs" />
+  <path
+     d="M 4.4999766,3.09 2.34,5.5 H 3.5 c 0.5584978,2.081e-4 0.9994068,0.7738764 0.9995326,1.2200757 L 4.5004644,10.5 H 4.499767 L 4.500699,6.7200757 C 4.500808,6.2738764 5.0074402,5.500223 5.6060146,5.5 H 6.66 Z"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940-5);stroke-width:0.999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000;stop-opacity:1"
+     id="path873-5-5-2-3"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/actions/24/mail-send-receive.svg
+++ b/actions/24/mail-send-receive.svg
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="mail-send-receive.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10667"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16.000001"
+     inkscape:cx="11.718749"
+     inkscape:cy="7.3124995"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="632"
+     inkscape:window-y="14"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <linearGradient
+       id="linearGradient1356">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1348" />
+      <stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1350" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1352" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1354" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="0"
+         id="stop866" />
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="1"
+         id="stop868" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1356"
+       id="linearGradient4081"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.39056144,0.43562686,0,-6.519347,26.010508)"
+       x1="25.631071"
+       y1="57.037033"
+       x2="12.286115"
+       y2="57.037033" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1597-3"
+       id="linearGradient4079"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.66975928,0.49699178,0,-9.864985,33.525589)"
+       x1="36.61731"
+       y1="53.037033"
+       x2="27.66007"
+       y2="53.037033" />
+    <linearGradient
+       id="linearGradient1597-3">
+      <stop
+         id="stop1589-5"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1591-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00000012" />
+      <stop
+         id="stop1593-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1595-9"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1046"
+       id="linearGradient1556-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,34.776675,50.245449)"
+       x1="-17.673822"
+       y1="42.245449"
+       x2="-17.673822"
+       y2="29.409298" />
+    <linearGradient
+       id="linearGradient1046">
+      <stop
+         id="stop1042"
+         offset="0"
+         style="stop-color:#9bdb4d;stop-opacity:1" />
+      <stop
+         id="stop1044"
+         offset="1"
+         style="stop-color:#68b723;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8662-8">
+      <stop
+         id="stop8664-1"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8666-5"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient870"
+       id="linearGradient1556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(24.776676,-26.245456)"
+       x1="-17.392385"
+       y1="25.29842"
+       x2="-17.392385"
+       y2="47.231144" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient47817"
+       id="linearGradient47751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5372019,0,0,-0.57681717,-30.050103,44.031181)"
+       x1="70.441086"
+       y1="67.749962"
+       x2="70.441086"
+       y2="50.323315" />
+    <linearGradient
+       id="linearGradient47817">
+      <stop
+         id="stop47809"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop47811"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.40414637" />
+      <stop
+         id="stop47813"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop47815"
+         style="stop-color:#ffffff;stop-opacity:0.38999999;"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.52995454,0,0,-0.35307735,22.512547,21.835677)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8662-8"
+       id="radialGradient3862-3"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8662-8"
+       id="radialGradient12365"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.52995454,0,0,-0.35307735,22.512547,21.835677)"
+       cx="24.837126"
+       cy="36.421127"
+       fx="24.837126"
+       fy="36.421127"
+       r="15.644737" />
+  </defs>
+  <g
+     id="g12363"
+     transform="matrix(-0.78398268,0,0,0.9051732,14.330238,4.8749888)"
+     style="stroke-width:1.18709">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient12365);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.18709;marker:none"
+       id="path12361"
+       d="m 1.059,8.976195 a 8.2909995,5.5238047 0 1 1 16.581999,0 8.2909995,5.5238047 0 0 1 -16.581999,0 z" />
+  </g>
+  <g
+     id="layer1"
+     transform="matrix(-0.78398268,0,0,0.9051732,24.330238,9.874989)"
+     style="stroke-width:1.18709">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient3862-3);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.18709;marker:none"
+       id="path3501-0"
+       d="m 1.059,8.976195 a 8.2909995,5.5238047 0 1 1 16.581999,0 8.2909995,5.5238047 0 0 1 -16.581999,0 z" />
+  </g>
+  <path
+     id="path873-5-5-4"
+     style="font-variation-settings:normal;fill:url(#linearGradient1556-1);fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     d="m 22.500001,14.870809 c 0,0.129184 -0.10128,0.228749 -0.126255,0.285156 -0.0054,0.0048 -0.01065,0.01041 -0.01578,0.01553 l -5.103413,6.224035 c -0.06681,0.0657 -0.155042,0.104463 -0.254553,0.104463 -0.0988,0 -0.183919,-0.03876 -0.255,-0.104463 l -5.105872,-6.224036 c -0.0051,-0.0051 -0.01037,-0.01072 -0.01577,-0.01553 C 11.547298,15.085724 11.5,14.988176 11.5,14.870807 c 0,-0.218072 0.158254,-0.370816 0.371495,-0.370816 h 3.263029 c 0.199024,1.37e-4 0.365761,-0.18217 0.365761,-0.392893 V 7.861385 C 15.500285,7.654781 15.657554,7.5 15.867478,7.5 h 2.265766 c 0.209925,0 0.367193,0.154781 0.367193,0.361385 v 6.281009 c 0.01837,0.19344 0.177038,0.357729 0.364322,0.3576 h 3.268048 c 0.190944,0 0.367194,0.223285 0.367194,0.370815 z"
+     sodipodi:nodetypes="scccscccsscsssssccss" />
+  <path
+     d="M 15.500001,15.5 H 13.205 L 16.999999,20.125 20.795,15.5 h -2.294875"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4081);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4075"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="m 18.499876,15.5 c -0.410995,0 -0.99965,-0.735733 -0.999752,-1.249998 0,0 -0.02402,-4.092125 -2.48e-4,-5.750002 h -0.999378 l -9.95e-4,5.750002 C 16.499441,14.715045 15.996992,15.5 15.5,15.5"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4079);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4077"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     id="path873-5-5-4-0"
+     style="font-variation-settings:normal;fill:url(#linearGradient1556);fill-opacity:1;stroke:#7239b3;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     d="m 12.500002,9.129184 c 0,-0.129184 -0.10128,-0.228749 -0.126255,-0.285156 -0.0054,-0.0048 -0.01065,-0.01041 -0.01578,-0.01553 L 7.2545537,2.604463 C 7.1877437,2.538763 7.0995117,2.5 7.0000007,2.5 c -0.0988,0 -0.183919,0.03876 -0.255,0.104463 L 1.639128,8.828499 c -0.0051,0.0051 -0.01037,0.01072 -0.01577,0.01553 C 1.547298,8.914269 1.5,9.011817 1.5,9.129186 c 0,0.218072 0.158254,0.370816 0.3714954,0.370816 h 3.2630293 c 0.199024,-1.37e-4 0.365761,0.18217 0.365761,0.3928935 v 6.2457155 c 0,0.206604 0.157269,0.361385 0.367193,0.361385 h 2.265766 c 0.209925,0 0.367193,-0.154781 0.367193,-0.361385 V 9.857599 c 0.01837,-0.19344 0.177038,-0.357729 0.364322,-0.3576 h 3.2680483 c 0.190944,0 0.367194,-0.223285 0.367194,-0.370815 z"
+     sodipodi:nodetypes="scccscccsscsssssccss" />
+  <path
+     id="path4075-9"
+     style="font-variation-settings:normal;opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient47751);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="M 7.0000007,3.875 3.2050788,8.5 h 2.2949219 c 0.496992,0 0.999938,0.784957 1,1.25 v 5.750004 h 1 c -0.02377,-1.657876 0,-5.750004 0,-5.750004 1.02e-4,-0.514264 0.589005,-1.25 1,-1.25 h 2.2949223 z"
+     sodipodi:nodetypes="ccsccccscc" />
+</svg>

--- a/actions/symbolic/mail-send-receive-symbolic.svg
+++ b/actions/symbolic/mail-send-receive-symbolic.svg
@@ -1,6 +1,49 @@
-<svg height='16' width='16' xmlns='http://www.w3.org/2000/svg'>
-    <g color='#bebebe' transform='translate(-653 -49)'>
-        
-        <path d='M657.514 50.334a.5.5 0 0 0-.414.2l-3.5 4.665a.5.5 0 0 0 .4.801h2v4.5a.5.5 0 0 0 .5.5h2a.5.5 0 0 0 .5-.5V56h2a.5.5 0 0 0 .4-.8l-3.5-4.667a.5.5 0 0 0-.386-.199zM663.5 53a.5.5 0 0 0-.5.5V58h-2a.5.5 0 0 0-.4.8l3.5 4.667a.5.5 0 0 0 .8 0l3.5-4.666A.5.5 0 0 0 668 58h-2v-4.5a.5.5 0 0 0-.5-.5z' fill='#666' font-family='sans-serif' font-weight='400' overflow='visible' style='line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal;marker:none' white-space='normal'/>
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg688"
+   sodipodi:docname="mail-send-receive-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs692" />
+  <sodipodi:namedview
+     id="namedview690"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.6785241"
+     inkscape:cx="9.5572423"
+     inkscape:cy="8.1624016"
+     inkscape:window-width="1390"
+     inkscape:window-height="1053"
+     inkscape:window-x="520"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg688" />
+  <path
+     d="m 4.4990253,1.7500545 c -0.080838,0 -0.1508278,0.03231 -0.2089844,0.08789 L 0.6015631,6.4356641 c -0.062219,0.059439 -0.101562,0.1428761 -0.101562,0.2421875 0,0.1845228 0.1302171,0.3222656 0.3046881,0.3222656 h 1.8965061 c 0.1628379,-1.16e-4 0.2988281,0.1459138 0.2988281,0.3242187 v 3.3693431 c 0,0.174818 0.1290258,0.306641 0.3007812,0.306641 h 2.3983907 c 0.1717556,0 0.3007813,-0.131823 0.3007812,-0.306641 V 7.2930859 C 6.0150045,7.1294056 6.1455714,7.0000084 6.2988047,7.0001172 h 1.9006492 c 0.174469,0 0.300781,-0.1377426 0.300781,-0.3222656 0,-0.1845764 -0.07628,-0.1785565 -0.103516,-0.2421875 L 4.7099628,1.8379455 c -0.054667,-0.05559 -0.1295192,-0.08789 -0.2109375,-0.087891 z"
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;stop-color:#000000"
+     id="path873-5-5"
+     sodipodi:nodetypes="sccsscsssscccssccs" />
+  <path
+     id="path2066"
+     style="color:#000000;fill:#555761;fill-opacity:1;fill-rule:evenodd;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 4.5,1.75 C 4.3504036,1.7496571 4.2085373,1.8162992 4.1132812,1.9316406 l -3.49804682,4.25 C 0.3457245,6.5081455 0.57856754,7.0009021 1.0019531,7 H 2 2.5 C 2.7761309,7.0000276 2.9999724,7.2238691 3,7.5 V 8 11.5 c 2.76e-5,0.276131 0.22385,0.499972 0.5,0.5 h 2 C 5.7761499,11.999972 5.9999724,11.776131 6,11.5 V 8 7.5 C 6.0000276,7.2238691 6.2238691,7.0000276 6.5,7 H 7 7.9980469 c 0.211693,4.511e-4 0.3756732,-0.1232202 0.453125,-0.2871094 0.077452,-0.1638891 0.068349,-0.3679975 -0.066406,-0.53125 l -3.4980468,-4.25 C 4.7914626,1.8162996 4.6495962,1.7496572 4.5,1.75 Z"
+     sodipodi:nodetypes="cccccccccccccccccsccc" />
+  <path
+     id="path2223"
+     style="color:#000000;fill:#555761;fill-opacity:1;fill-rule:evenodd;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 11.5,14.25 c 0.149596,3.43e-4 0.291463,-0.0663 0.386719,-0.181641 L 15.384766,9.8183594 C 15.654276,9.4918545 15.421433,8.9990979 14.998047,9 H 14 13.5 C 13.223869,8.9999724 13.000028,8.7761309 13,8.5 V 8 4.5 C 12.999972,4.223869 12.77615,4.000028 12.5,4 h -2 C 10.22385,4.000028 10.000028,4.223869 10,4.5 V 8 8.5 C 9.9999724,8.7761309 9.7761309,8.9999724 9.5,9 H 9 8.0019531 c -0.211693,-4.511e-4 -0.3756732,0.1232202 -0.453125,0.2871094 -0.077452,0.1638891 -0.068349,0.3679975 0.066406,0.53125 L 11.113281,14.068359 C 11.208537,14.1837 11.350404,14.250342 11.5,14.25 Z"
+     sodipodi:nodetypes="cccccccccccccccccsccc" />
 </svg>


### PR DESCRIPTION
Options here! I submitted here Option A. But when I went to adjust the arrow aspect ratio of the symbolic icon (which was a little narrow), realized it used longer arrow tails (Option C).

So, Option A is what I submitted, the arrow tail matches the ones used in `document-send` and `browser-download`. Option C, the arrow tail matches `go-up` and `go-down`. Options B and D are just variants.

Just let me know which one is best. Thanks!

Light:

![prop1](https://github.com/user-attachments/assets/445ae83d-25bd-445d-81a8-104e19636deb)
![prop2](https://github.com/user-attachments/assets/ef6542e2-a5f1-4f15-beaa-06066a0f6494)
![prop3](https://github.com/user-attachments/assets/f3c5f4bc-8efb-4ec8-8081-b3f6df9991a4)

Dark:

![dark-prop1](https://github.com/user-attachments/assets/09c39e7b-a0ee-4a87-9f74-6ec4aa9be700)
![dark-prop2](https://github.com/user-attachments/assets/f7db2926-be0a-428b-8a9f-f7942ad9558b)
