### PR TITLE
Add more dnd-* symlinks

### DIFF
--- a/cursors/meson.build
+++ b/cursors/meson.build
@@ -227,6 +227,10 @@ links += [[
 links += [[
     'grabbing',
     [
+        'dnd-ask',
+        'dnd-copy',
+        'dnd-link',
+        'dnd-move',
         'dnd-none',
         'fleur'
     ]

--- a/cursors/meson.build
+++ b/cursors/meson.build
@@ -180,6 +180,7 @@ links += [[
 links += [[
     'copy',
     [
+        'dnd-copy',
         '6407b0e94181790501fd1e167b474872',
         '1081e37283d90000800003c07f3ef6bf'
     ]
@@ -228,7 +229,6 @@ links += [[
     'grabbing',
     [
         'dnd-ask',
-        'dnd-copy',
         'dnd-link',
         'dnd-move',
         'dnd-none',


### PR DESCRIPTION
Fixes #1326

Added more drag symlinks and fixed almost all of these cases, but it looks like the window one might be an upstream mutter issue that was fixed more recently than our version of Mutter https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/3624

- [x] move icons in the dock
- [x] move tabs in firefox
- [x] drag selected text