### PR TITLE
Actions: add 24px list-add-symbolic

### DIFF
--- a/actions/24/list-add-symbolic.svg
+++ b/actions/24/list-add-symbolic.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="list-add-symbolic.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="35.312489"
+     inkscape:cx="12.007083"
+     inkscape:cy="12.007083"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     color="#bebebe"
+     transform="matrix(1.5,0,0,1.5,-439.50001,-175.50001)"
+     id="g1"
+     style="fill:#555761;stroke-width:0.666667">
+    <path
+       d="m 299.66667,119.50001 v 4.16666 h -4.16666 c -0.27615,0 -0.5,0.22386 -0.5,0.5 v 1.66667 c 0,0.27614 0.22385,0.5 0.5,0.5 h 4.16666 v 4.16667 c 0,0.27614 0.22386,0.5 0.5,0.5 h 1.66667 c 0.27614,0 0.5,-0.22386 0.5,-0.5 v -4.16667 h 4.16667 c 0.27614,0 0.5,-0.22386 0.5,-0.5 v -1.66667 c 0,-0.27614 -0.22386,-0.5 -0.5,-0.5 h -4.16667 v -4.16666 c 0,-0.27615 -0.22386,-0.5 -0.5,-0.5 h -1.66667 c -0.27614,0 -0.5,0.22385 -0.5,0.5 z"
+       fill="#666"
+       overflow="visible"
+       style="fill:#555761;stroke-width:0.544331;marker:none"
+       id="path1"
+       sodipodi:nodetypes="scsssscsssscsssscssss" />
+  </g>
+</svg>


### PR DESCRIPTION
Needed so we don't have blurry add icon in https://github.com/elementary/dock/pull/364