### PR TITLE
Prep palette file for Inkscape

### DIFF
--- a/data/elementary.gpl
+++ b/data/elementary.gpl
@@ -1,7 +1,7 @@
 GIMP Palette
 Name: elementary
 Columns:  5
-#
+# <https://elementary.io/brand#color>
 255 140 130 Strawberry 100
 237 83 83 Strawberry 300
 198 38 46 Strawberry 500

--- a/data/elementary.gpl
+++ b/data/elementary.gpl
@@ -3,79 +3,79 @@ Name: elementary
 Columns:  5
 # <https://elementary.io/brand#color>
 255 140 130 Strawberry 100
-237 83 83 Strawberry 300
-198 38 46 Strawberry 500
-161 7 5 Strawberry 700
-122 0 0 Strawberry 900
+237  83  83 Strawberry 300
+198  38  46 Strawberry 500
+161   7   5 Strawberry 700
+122   0   0 Strawberry 900
 
 255 194 125 Orange 100
-255 161 84 Orange 300
-243 115 41 Orange 500
-204 59 2 Orange 700
-166 33 0 Orange 900
+255 161  84 Orange 300
+243 115  41 Orange 500
+204  59   2 Orange 700
+166  33   0 Orange 900
 
 255 243 148 Banana 100
 255 225 107 Banana 300
-249 196 64 Banana 500
-212 142 21 Banana 700
-173 95 0 Banana 900
+249 196  64 Banana 500
+212 142  21 Banana 700
+173  95   0 Banana 900
 
 209 255 130 Lime 100
-155 219 77 Lime 300
-104 183 35 Lime 500
-58 145 4 Lime 700
-32 107 0 Lime 900
+155 219  77 Lime 300
+104 183  35 Lime 500
+ 58 145   4 Lime 700
+ 32 107   0 Lime 900
 
 137 255 221 Mint 100
-67 214 181 Mint 300
-40 188 163 Mint 500
-14 154 131 Mint 700
-0 115 103 Mint 900
+ 67 214 181 Mint 300
+ 40 188 163 Mint 500
+ 14 154 131 Mint 700
+  0 115 103 Mint 900
 
 140 213 255 Blueberry 100
 100 186 255 Blueberry 300
-54 137 230 Blueberry 500
-13 82 191 Blueberry 700
-0 46 153 Blueberry 900
+ 54 137 230 Blueberry 500
+ 13  82 191 Blueberry 700
+  0  46 153 Blueberry 900
 
 228 198 250 Grape 100
 205 158 247 Grape 300
 165 109 226 Grape 500
-114 57 179 Grape 700
-69 41 129 Grape 900
+114  57 179 Grape 700
+ 69  41 129 Grape 900
 
 254 154 184 Bubblegum 100
 244 103 157 Bubblegum 300
-222 62 128 Bubblegum 500
-188 36 93 Bubblegum 700
-145 14 56 Bubblegum 900
+222  62 128 Bubblegum 500
+188  36  93 Bubblegum 700
+145  14  56 Bubblegum 900
 
 239 223 196 Latte 100
 231 197 145 Latte 300
-207 162 94 Latte 500
-182 128 46 Latte 700
-128 75 0 Latte 900
+207 162  94 Latte 500
+182 128  46 Latte 700
+128  75   0 Latte 900
 
 163 144 124 Cocoa 100
-138 113 94 Cocoa 300
-113 83 68 Cocoa 500
-87 57 45 Cocoa 700
-61 33 27 Cocoa 900
+138 113  94 Cocoa 300
+113  83  68 Cocoa 500
+ 87  57  45 Cocoa 700
+ 61  33  27 Cocoa 900
 
 250 250 250 Silver 100
 212 212 212 Silver 300
 171 172 174 Silver 500
 126 128 135 Silver 700
-85 87 97 Silver 900
+ 85  87  97 Silver 900
 
 149 163 171 Slate 100
 102 120 133 Slate 300
-72 90 108 Slate 500
-39 52 69 Slate 700
-14 20 31 Slate 900
+ 72  90 108 Slate 500
+ 39  52  69 Slate 700
+ 14  20  31 Slate 900
 
 102 102 102 Black 100
-77 77 77 Black 300
-51 51 51 Black 500
-26 26 26 Black 700
-0 0 0 Black 900
+ 77  77  77 Black 300
+ 51  51  51 Black 500
+ 26  26  26 Black 700
+  0   0   0 Black 900


### PR DESCRIPTION
I proposed getting the palette shipped with [Inkscape](https://gitlab.com/inkscape/inkscape/-/tree/master/share/palettes?ref_type=heads) in #984 as a longer term solution, and this is a follow-up to make sure we're all prim and proper before pursuing any such merge requests.