### PR TITLE
Use Adwaita as a fallback icon theme

### DIFF
--- a/index.theme.in
+++ b/index.theme.in
@@ -1,6 +1,7 @@
 [Icon Theme]
 Name=elementary
 Comment=Smooth modern theme designed to be intuitive.
+Inherits=Adwaita
 
 Example=directory-x-normal
 


### PR DESCRIPTION
Currently, if no fitting icon is found in elementary icon theme, gtk falls back to `hicolor`, as per the fd.o spec. With this PR, it will first try to find missing icon in Adwaita (which is present in elementary OS) before resorting to displaying a missing icon image. This issue mainly affects GNOME Circle apps that heavily rely on Adwaita, and while it is recommended to bundle all non-fd.o icons, not all apps do so (unfortunately).

Before/after examples (Apostrophe and Ptyxis):

<img width="559" height="87" alt="Screenshot from 2025-08-11 22 07 16" src="https://github.com/user-attachments/assets/7fe4850c-fa2b-4576-aa8c-9517ec018796" />
<img width="565" height="90" alt="Screenshot from 2025-08-11 22 06 50" src="https://github.com/user-attachments/assets/2f2e5859-8af4-4ecf-a556-8bd7bf69e690" />

<img width="257" height="51" alt="Screenshot from 2025-08-11 22 27 56" src="https://github.com/user-attachments/assets/ccfbcce9-de53-4298-977a-a3fdfa3b6585" />
<img width="241" height="49" alt="Screenshot from 2025-08-11 22 28 12" src="https://github.com/user-attachments/assets/71a86803-8a7f-4c09-801f-dea6fba4c05a" />
