### PR TITLE
Remove visual artifact from 16px edit-paste icon

### DIFF
--- a/actions/16/edit-paste.svg
+++ b/actions/16/edit-paste.svg
@@ -12,27 +12,6 @@
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3377">
-    <radialGradient
-       cx="24.837126"
-       cy="36.421127"
-       r="15.644737"
-       fx="24.837126"
-       fy="36.421127"
-       id="radialGradient4123"
-       xlink:href="#linearGradient8662-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.25568731,0,0,-0.17604034,13.353337,18.657486)" />
-    <linearGradient
-       id="linearGradient8662-6">
-      <stop
-         id="stop8664-2"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8666-6"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        x1="23.99999"
        y1="7.5555444"
@@ -232,8 +211,4 @@
      style="fill:none;stroke:url(#linearGradient3069);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect6741-1-2"
      d="m 13.5,14.5 -7,0 0,-9 7,0 z" />
-  <path
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.14117647;fill:url(#radialGradient4123);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
-     id="path3501"
-     d="m 3.0026383,12.245895 a 4.0001609,2.7541062 0 1 1 8.0003217,0 4.0001609,2.7541062 0 0 1 -8.0003217,0 z" />
 </svg>


### PR DESCRIPTION
The paste icon had this weird shadow I assume was unintentional: <img src="https://raw.githubusercontent.com/elementary/icons/refs/heads/main/actions/16/edit-paste.svg" width="128">