### PR TITLE
Add symlinks for Inkscape lock/unlock icons

### DIFF
--- a/actions/16/object-locked.svg
+++ b/actions/16/object-locked.svg
@@ -1,0 +1,1 @@
+../../status/16/locked.svg

--- a/actions/16/object-unlocked.svg
+++ b/actions/16/object-unlocked.svg
@@ -1,0 +1,1 @@
+../../status/16/changes-allow.svg

--- a/actions/24/object-locked.svg
+++ b/actions/24/object-locked.svg
@@ -1,0 +1,1 @@
+../../status/24/locked.svg

--- a/actions/24/object-unlocked.svg
+++ b/actions/24/object-unlocked.svg
@@ -1,0 +1,1 @@
+../../status/24/changes-allow.svg

--- a/actions/32/object-locked.svg
+++ b/actions/32/object-locked.svg
@@ -1,0 +1,1 @@
+../../status/32/locked.svg

--- a/actions/32/object-unlocked.svg
+++ b/actions/32/object-unlocked.svg
@@ -1,0 +1,1 @@
+../../status/32/changes-allow.svg

--- a/actions/48/object-locked.svg
+++ b/actions/48/object-locked.svg
@@ -1,0 +1,1 @@
+../../status/48/locked.svg

--- a/actions/48/object-unlocked.svg
+++ b/actions/48/object-unlocked.svg
@@ -1,0 +1,1 @@
+../../status/48/changes-allow.svg


### PR DESCRIPTION
As requested, I’m splitting #1369 into three pull requests. This first pull request adds the symlinks necessary for the Inkscape lock/unlock icons.