### PR TITLE
Redesign changes-allow

### DIFF
--- a/status/16/changes-allow.svg
+++ b/status/16/changes-allow.svg
@@ -1,0 +1,321 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg4099"
+   height="16"
+   width="16"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4101">
+    <linearGradient
+       gradientTransform="matrix(0.66666666,0,0,0.46666666,-3.1666666,0.46666564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5475-8"
+       id="linearGradient4144"
+       y2="14"
+       x2="24"
+       y1="29"
+       x1="24" />
+    <linearGradient
+       id="linearGradient5475-8">
+      <stop
+         offset="0"
+         style="stop-color:#d88f22;stop-opacity:1"
+         id="stop5477-0" />
+      <stop
+         offset="1"
+         style="stop-color:#d88f22;stop-opacity:0"
+         id="stop5479-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.66666666,0,0,0.46666666,-12.166666,0.46666564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5475-8"
+       id="linearGradient3976"
+       y2="14"
+       x2="24"
+       y1="29"
+       x1="24" />
+    <linearGradient
+       gradientTransform="matrix(0.66666664,0,0,0.46667556,-1.1666667,-20.533589)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3966-0-4"
+       id="linearGradient3065"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       id="linearGradient3966-0-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3968-8-0" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3970-7-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.66666664,0,0,0.46667556,5.8333347,-20.533589)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3966-0-4-2"
+       id="linearGradient3062"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       id="linearGradient3966-0-4-2">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3968-8-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3970-7-4-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-0.93357748,0,0,1,23.379997,-15)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3865-4-8"
+       id="linearGradient4158"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
+    <linearGradient
+       id="linearGradient3865-4-8">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3867-110-9" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3869-96-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-0.93357745,0,0,1,23.379997,-22)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6057-35-7"
+       id="linearGradient3951"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
+    <linearGradient
+       id="linearGradient6057-35-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6059-0-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6061-4-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-1.0003052)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3957"
+       id="linearGradient3963"
+       y2="16.000305"
+       x2="10.314445"
+       y1="7.0003052"
+       x1="10.314445" />
+    <linearGradient
+       id="linearGradient3957">
+      <stop
+         offset="0"
+         style="stop-color:#b19c7d;stop-opacity:1"
+         id="stop3959" />
+      <stop
+         offset="1"
+         style="stop-color:#a08358;stop-opacity:1"
+         id="stop3961" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.47368427,0,0,0.42857142,0.4210521,1.2857141)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5443"
+       id="linearGradient3059"
+       y2="27.924538"
+       x2="21.771429"
+       y1="14.871428"
+       x1="21.771429" />
+    <linearGradient
+       id="linearGradient5443">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop5445" />
+      <stop
+         offset="0.03252051"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop5447" />
+      <stop
+         offset="0.98558509"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop5449" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop5451" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,0.80952382,-1.1390521,0,20.94881,-6.3693335)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5409"
+       id="radialGradient3074"
+       fy="11.597148"
+       fx="16.777113"
+       r="10.5"
+       cy="11.368058"
+       cx="16.823883" />
+    <linearGradient
+       id="linearGradient5409">
+      <stop
+         offset="0"
+         style="stop-color:#f2e0c4;stop-opacity:1"
+         id="stop5411" />
+      <stop
+         offset="0.76470584"
+         style="stop-color:#e5af5b;stop-opacity:1"
+         id="stop5559" />
+      <stop
+         offset="1"
+         style="stop-color:#af6900;stop-opacity:1"
+         id="stop5413" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10591-0">
+      <stop
+         offset="0"
+         style="stop-color:#cad0c6;stop-opacity:1"
+         id="stop10593-1" />
+      <stop
+         offset="0.5"
+         style="stop-color:#eaece9;stop-opacity:1"
+         id="stop10599-3" />
+      <stop
+         offset="1"
+         style="stop-color:#c5cbc0;stop-opacity:1"
+         id="stop10595-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.2606375,0,0,0.3148868,-4.273236,-1.0472711)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient10591-0"
+       id="linearGradient4097"
+       y2="17.470011"
+       x2="27.192274"
+       y1="2.9136841"
+       x1="10.650842" />
+  </defs>
+  <metadata
+     id="metadata4104">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(2)">
+    <path
+       style="opacity:0.4;fill:url(#linearGradient4097);fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path2086-4"
+       d="M -1.5,6.501 V 4.1251475 c 0,-2.4782011 1.3702785,-3.65551858 3.4872865,-3.62456998 2.1285247,0.030949 3.5133857,1.11721418 3.5133857,3.62456998 V 7.5005049 H 4.0695902 V 4.754922 c 0,-0.6297745 0.148159,-2.6676754 -2.0673917,-2.6676754 -2.1972832,0 -2.0371829,2.0504603 -2.0286629,2.6651649 V 6.501 Z" />
+    <path
+       style="opacity:0.6;fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4161"
+       d="m -0.7999998,5.0008658 c 0,0 -0.5898303,-3.5 2.8,-3.5 3.38983,0 2.8,3.5 2.8,3.5" />
+    <path
+       style="opacity:0.4;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2086-3"
+       d="M -1.5,6.501 V 4.1251479 c 0,-2.4782011 1.3702785,-3.65551858 3.4872865,-3.62456998 2.1285247,0.030949 3.5133857,1.11721418 3.5133857,3.62456998 V 7.5005053 H 3.5000002 V 4.7549224 c 0,-0.6297745 0.1514618,-2.2540566 -1.4978017,-2.2540566 -1.6492635,0 -1.5107183,1.6368415 -1.5021983,2.2515461 V 6.501 Z" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect3186-2"
+       y="6.4999995"
+       x="2.5"
+       ry="1"
+       rx="1"
+       height="8"
+       width="11" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3059);stroke-width:1px;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3186-3"
+       y="7.500001"
+       x="3.5"
+       height="6"
+       width="9" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3963);stroke-width:1px;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3186"
+       y="6.5"
+       x="2.5"
+       ry="1"
+       rx="1"
+       height="8"
+       width="11" />
+    <path
+       style="opacity:0.2;fill:none;stroke:url(#linearGradient3951);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3863-3-5"
+       d="m 3.5,7.5 9,-3.79e-4 m -9,2.0003788 9,-3.79e-4 M 3.5,11.5 l 9,-3.79e-4" />
+    <path
+       style="opacity:0.05;fill:none;stroke:url(#linearGradient4158);stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4156"
+       d="m 3.5,12.5 h 9 m -9,-6 h 9 m -9,2 h 9 m -9,2 h 9" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect5453-4-4"
+       transform="scale(1,-1)"
+       y="-14.000134"
+       x="11"
+       ry="1"
+       rx="2"
+       height="7.000133"
+       width="1" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect5453-4"
+       transform="scale(1,-1)"
+       y="-14.000134"
+       x="4"
+       ry="1"
+       rx="2"
+       height="7.000133"
+       width="1" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3976);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect3333"
+       y="7"
+       x="3"
+       ry="0.49999997"
+       rx="1.6"
+       height="7"
+       width="1" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient4144);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect5453-6"
+       y="7"
+       x="12"
+       ry="0.49999997"
+       rx="1.6"
+       height="7"
+       width="1" />
+  </g>
+</svg>

--- a/status/24/changes-allow.svg
+++ b/status/24/changes-allow.svg
@@ -1,243 +1,223 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="24"
+   id="svg5833"
    height="24"
-   id="svg5833">
+   width="24"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs5835">
     <linearGradient
        id="linearGradient1181">
       <stop
-         offset="0"
+         id="stop1177"
          style="stop-color:#7d511a;stop-opacity:0.1"
-         id="stop1177" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop1179"
          style="stop-color:#b69464;stop-opacity:0.02941176"
-         id="stop1179" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient1125">
       <stop
-         id="stop1121"
+         style="stop-color:#f0dab6;stop-opacity:1"
          offset="0"
-         style="stop-color:#f0dab6;stop-opacity:1" />
+         id="stop1121" />
       <stop
-         id="stop1123"
+         style="stop-color:#dfa751;stop-opacity:1"
          offset="1"
-         style="stop-color:#dfa751;stop-opacity:1" />
+         id="stop1123" />
     </linearGradient>
     <linearGradient
        id="linearGradient5443">
       <stop
-         id="stop5445"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop5445" />
       <stop
-         id="stop5447"
+         offset="0.00000002"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.00000002" />
+         id="stop5447" />
       <stop
-         id="stop5449"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
+         id="stop5449" />
       <stop
-         id="stop5451"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop5451" />
     </linearGradient>
     <linearGradient
        id="linearGradient3966-0-4-2">
       <stop
-         id="stop3968-8-0-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0-1" />
       <stop
-         id="stop3970-7-4-2"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3966-0-4">
-      <stop
-         id="stop3968-8-0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3970-7-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4-2" />
     </linearGradient>
     <linearGradient
        id="linearGradient5475">
       <stop
-         id="stop5477"
+         offset="0"
          style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
+         id="stop5477" />
       <stop
-         id="stop5479"
+         offset="1"
          style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
+         id="stop5479" />
     </linearGradient>
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309">
       <stop
-         id="stop2889"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
-    <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
-       y2="14"
-       id="linearGradient3065"
-       xlink:href="#linearGradient3966-0-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666669,0,0,0.66666664,-0.16666671,-30.333334)" />
     <linearGradient
        id="linearGradient10591-3-5">
       <stop
-         id="stop10593-9-2"
+         offset="0"
          style="stop-color:#cad0c6;stop-opacity:1"
-         offset="0" />
+         id="stop10593-9-2" />
       <stop
-         id="stop10599-4-4"
+         offset="0.5"
          style="stop-color:#eaece9;stop-opacity:1"
-         offset="0.5" />
+         id="stop10599-4-4" />
       <stop
-         id="stop10595-6-6"
+         offset="1"
          style="stop-color:#c5cbc0;stop-opacity:1"
-         offset="1" />
+         id="stop10595-6-6" />
     </linearGradient>
     <linearGradient
-       x1="21.846153"
-       y1="15.277778"
-       x2="21.846153"
-       y2="27.722221"
-       id="linearGradient3059-6"
+       gradientTransform="matrix(0.68421053,0,0,0.64285716,4.052627,2.1785708)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5443"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.68421053,0,0,0.64285716,1.052627,2.1785708)" />
+       id="linearGradient3059-6"
+       y2="27.722221"
+       x2="21.846153"
+       y1="15.277778"
+       x1="21.846153" />
     <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient3087-3"
+       gradientTransform="matrix(0.48214367,0,0,0.32142905,3.428567,7.8928328)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3702-501-757"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48214367,0,0,0.32142905,0.428567,7.8928328)" />
+       id="linearGradient3087-3"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
     <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
+       gradientTransform="matrix(0.90170441,0,0,0.45000068,-12.755353,-41.450027)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309"
        id="radialGradient3090-2"
-       xlink:href="#linearGradient3688-464-309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.90170441,0,0,0.45000068,-9.755353,-41.450027)" />
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
        fy="43.5"
-       id="radialGradient3093-9"
-       xlink:href="#linearGradient3688-464-309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.90170441,0,0,0.45000068,14.244677,2.2999678)" />
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <radialGradient
-       cx="18.031223"
-       cy="6.2806997"
-       r="3.1819806"
-       fx="18.031223"
-       fy="6.2806997"
+       gradientTransform="matrix(0.90170441,0,0,0.45000068,17.244677,2.2999678)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3093-9"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(0.46988398,0,0,0.47066524,-5.5494135,-1.0831916)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3966-0-4-2"
        id="radialGradient3079-6"
-       xlink:href="#linearGradient3966-0-4-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46988398,0,0,0.47066524,0.450582,-1.0836652)" />
+       fy="6.2806997"
+       fx="18.031223"
+       r="3.1819806"
+       cy="6.2806997"
+       cx="18.031223" />
     <linearGradient
-       x1="11.276111"
-       y1="8.9632645"
-       x2="31.420702"
-       y2="17.461874"
-       id="linearGradient3560-2-9"
+       gradientTransform="matrix(0.41893991,0,0,0.47066524,-4.1633865,-1.2186976)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient10591-3-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.41893991,0,0,0.47066524,1.836609,-1.2191712)" />
+       id="linearGradient3560-2-9"
+       y2="17.461874"
+       x2="31.420702"
+       y1="8.9632645"
+       x1="11.276111" />
     <linearGradient
-       gradientTransform="translate(23.759995)"
-       gradientUnits="userSpaceOnUse"
-       y2="21.417143"
-       x2="-11.442858"
-       y1="10.514286"
-       x1="-11.442858"
+       xlink:href="#linearGradient1125"
        id="linearGradient1127"
-       xlink:href="#linearGradient1125" />
+       x1="-11.442858"
+       y1="10.514286"
+       x2="-11.442858"
+       y2="21.417143"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(26.759995)" />
     <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
-       y2="27.5"
-       id="linearGradient3888-76-7-37"
+       gradientTransform="matrix(-0.93357899,0,0,0.75000126,29.494454,-9.250054)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3966-0-4-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.93357899,0,0,0.75000126,26.494454,-9.250054)" />
-    <linearGradient
-       x1="9.3452244"
-       y1="27.5"
-       x2="22.792734"
+       id="linearGradient3888-76-7-37"
        y2="27.5"
-       id="linearGradient3927-6-54"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
+    <linearGradient
+       gradientTransform="matrix(-0.87866114,0,0,0.69999996,29.033468,-5.749999)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient1181"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.87866114,0,0,0.69999996,26.033468,-5.749999)" />
+       id="linearGradient3927-6-54"
+       y2="27.5"
+       x2="22.792734"
+       y1="27.5"
+       x1="9.3452244" />
     <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
-       y2="14"
+       gradientTransform="matrix(0.66666666,0,0,0.66666664,3.833333,1.6666665)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5475"
        id="linearGradient3071-3"
-       xlink:href="#linearGradient5475"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666666,0,0,0.66666664,0.833333,1.6666665)" />
-    <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
        y2="14"
-       id="linearGradient3071-3-6"
-       xlink:href="#linearGradient5475"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       gradientTransform="matrix(0.66666666,0,0,0.66666664,14.833333,1.6666665)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666666,0,0,0.66666664,11.833333,1.6666665)" />
+       xlink:href="#linearGradient5475"
+       id="linearGradient3071-3-6"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
   </defs>
   <metadata
      id="metadata5838">
@@ -247,104 +227,100 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="g1236">
-    <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3560-2-9);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.9999994;marker:none;enable-background:accumulate"
-       id="rect3174-8-4"
-       d="m 12.391093,0.49952564 c -2.9911224,0 -4.8728642,2.41512776 -4.8728642,5.40624996 v 1.5935179 l 2,-0.03644 V 5.9995296 c 0,-1.939 1.0276142,-3.5 2.9666142,-3.5 1.939,0 3.015151,1.561 3.015151,3.5 v 6.5617884 l 2,-0.06179 V 5.9057776 c 0,-2.9911202 -1.93028,-5.40624796 -4.921401,-5.40624796 z" />
-    <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.9999994;marker:none;enable-background:accumulate"
-       id="rect3174-8-5-7"
-       d="m 12.391093,0.17537934 c -2.9911224,0 -4.8728642,2.41512776 -4.8728642,5.40624996 v 1.5935172 l 2,-0.03644 V 5.6753833 c 0,-1.939 1.0276142,-3.5 2.9666142,-3.5 1.939,0 3.015151,1.561 3.015151,3.5 v 6.5617877 l 2,-0.06179 V 5.5816313 c 0,-2.9911202 -1.93028,-5.40624796 -4.921401,-5.40624796 z" />
-    <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#555761;stroke-width:0.9999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="rect3174-84"
-       d="m 12.391093,0.49952594 c -2.9911224,0 -4.8728642,2.41512776 -4.8728642,5.40624996 v 1.5935176 l 2,-0.03644 V 5.9995259 c 0,-1.939 1.0276142,-3.5 2.9666142,-3.5 1.939,0 3.015151,1.561 3.015151,3.5 v 6.5617881 l 2,-0.06179 V 5.9057739 c 0,-2.9911202 -1.93028,-5.40624796 -4.921401,-5.40624796 z" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#radialGradient3079-6);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-       id="path6055-5"
-       d="m 11.921407,1.872441 c 2.07e-4,0.827275 -1.154107,1.498024 -1.9800092,1.498024 -0.8259,0 -1.495368,-0.670749 -1.495161,-1.498024 -2.07e-4,-0.827274 0.669261,-1.49802296 1.495161,-1.49802296 0.8259022,0 1.9802162,0.67074896 1.9800092,1.49802296 z" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-       id="path6065-0"
-       d="m 10.590798,1.872441 c 9e-5,0.359315 -0.290682,0.650644 -0.6494002,0.650644 -0.358717,0 -0.649489,-0.291329 -0.649399,-0.650644 -9e-5,-0.359312 0.290682,-0.650643 0.649399,-0.650643 0.3587182,0 0.6494902,0.291331 0.6494002,0.650643 z" />
-  </g>
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3560-2-9);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;marker:none;enable-background:accumulate"
+     id="rect3174-8-4"
+     d="m 5.9062495,0.4999992 c -2.991122,0 -5.40625,2.4151278 -5.40625,5.40625 v 3.6119706 l 2,-0.03644 V 6.0000032 c 0,-1.939 1.561,-3.5 3.5,-3.5 1.939,0 3.499999,1.561 3.499999,3.5 v 4.5617888 l 2.0000005,-0.06179 V 5.9062512 c 0,-2.9911202 -2.4151285,-5.406248 -5.4062495,-5.406248 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;marker:none;enable-background:accumulate"
+     id="rect3174-8-5-7"
+     d="m 5.9062495,0.1758529 c -2.991122,0 -5.40625,2.4151278 -5.40625,5.40625 v 3.9361169 l 2,-0.01822 V 5.6758569 c 0,-1.939 1.561,-3.5 3.5,-3.5 1.939,0 3.499999,1.561 3.499999,3.5 V 11.5 L 11.499999,11.43821 V 5.5821049 c 0,-2.9911202 -2.4151285,-5.406248 -5.4062495,-5.406248 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#555761;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3174-84"
+     d="m 5.9062495,0.4999995 c -2.991122,0 -5.40625,2.4151278 -5.40625,5.40625 v 3.6119703 l 2,-0.01822 V 5.9999995 c 0,-1.939 1.561,-3.5 3.5,-3.5 1.939,0 3.499999,1.561 3.499999,3.5 V 11.5 L 11.499999,11.43821 V 5.9062475 c 0,-2.9911202 -2.4151285,-5.406248 -5.4062495,-5.406248 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#radialGradient3079-6);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="path6055-5"
+     d="m 4.4183305,1.8729146 c 2.07e-4,0.827275 -0.66926,1.498024 -1.495162,1.498024 -0.8259,0 -1.495368,-0.670749 -1.495161,-1.498024 -2.07e-4,-0.827274 0.669261,-1.498023 1.495161,-1.498023 0.825902,0 1.495369,0.670749 1.495162,1.498023 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="path6065-0"
+     d="m 3.5725685,1.8729146 c 9e-5,0.359315 -0.290682,0.650644 -0.6494,0.650644 -0.358717,0 -0.649489,-0.291329 -0.649399,-0.650644 -9e-5,-0.359312 0.290682,-0.650643 0.649399,-0.650643 0.358718,0 0.64949,0.291331 0.6494,0.650643 z" />
   <rect
-     style="opacity:0.3;fill:url(#radialGradient3093-9);fill-opacity:1;stroke:none"
+     width="2.2500038"
+     height="2.2500033"
+     x="21.750027"
+     y="20.749996"
      id="rect2801-3"
-     y="20.749996"
-     x="18.750027"
-     height="2.2500033"
-     width="2.2500038" />
+     style="opacity:0.3;fill:url(#radialGradient3093-9);fill-opacity:1;stroke:none" />
   <rect
-     style="opacity:0.3;fill:url(#radialGradient3090-2);fill-opacity:1;stroke:none"
-     id="rect3696-6"
-     transform="scale(-1)"
+     width="2.2500038"
+     height="2.2500033"
+     x="-8.2500038"
      y="-23"
-     x="-5.2500038"
-     height="2.2500033"
-     width="2.2500038" />
+     transform="scale(-1)"
+     id="rect3696-6"
+     style="opacity:0.3;fill:url(#radialGradient3090-2);fill-opacity:1;stroke:none" />
   <rect
-     style="opacity:0.3;fill:url(#linearGradient3087-3);fill-opacity:1;stroke:none"
-     id="rect3700-1"
-     y="20.749996"
-     x="5.2500038"
+     width="13.500024"
      height="2.2500036"
-     width="13.500024" />
+     x="8.2500038"
+     y="20.749996"
+     id="rect3700-1"
+     style="opacity:0.3;fill:url(#linearGradient3087-3);fill-opacity:1;stroke:none" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1127);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="rect3186-2-0"
-     y="10.5"
-     x="4.4999943"
-     ry="0.99999994"
+     width="15"
+     height="11"
      rx="0.99999994"
-     height="11"
-     width="15" />
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7d511a;stroke-width:1px;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect3186-5"
-     y="10.5"
-     x="4.4999943"
      ry="0.99999994"
-     rx="1"
+     x="7.4999943"
+     y="10.5"
+     id="rect3186-2-0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1127);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate" />
+  <rect
+     width="15"
      height="11"
-     width="15" />
+     rx="1"
+     ry="0.99999994"
+     x="7.4999943"
+     y="10.5"
+     id="rect3186-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7d511a;stroke-width:1px;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;stroke:url(#linearGradient3888-76-7-37);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 8.999994,11.5 h 12 m -12,2 h 12 m -12,2 h 12 m -12,2 h 12 m -12,2 h 12"
      id="path3863-6-1-2"
-     d="m 5.999994,11.5 h 12 m -12,2 h 12 m -12,2 h 12 m -12,2 h 12 m -12,2 h 12" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;stroke:url(#linearGradient3888-76-7-37);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:1;fill:none;stroke:url(#linearGradient3927-6-54);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 8.999994,12.5 h 12 m -12,2 h 12 m -12,2 h 12 m -12,2 h 12 m -12,2 h 12"
      id="path3863-6-4"
-     d="m 5.999994,12.5 h 12 m -12,2 h 12 m -12,2 h 12 m -12,2 h 12 m -12,2 h 12" />
+     style="fill:none;stroke:url(#linearGradient3927-6-54);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3071-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+     width="1"
+     height="10"
+     rx="2"
+     ry="1"
+     x="9"
+     y="11"
      id="rect5453-8"
-     y="11"
-     x="6"
-     ry="1"
-     rx="2"
-     height="10"
-     width="1" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3071-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3071-3-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+     width="1"
+     height="10"
+     rx="2"
+     ry="1"
+     x="20"
+     y="11"
      id="rect5453-8-4"
-     y="11"
-     x="17"
-     ry="1"
-     rx="2"
-     height="10"
-     width="1" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3071-3-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate" />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3059-6);stroke-width:0.99999988px;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect3186-3-1"
-     y="11.5"
-     x="5.4999943"
+     width="13"
      height="9"
-     width="13" />
+     x="8.4999943"
+     y="11.5"
+     id="rect3186-3-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3059-6);stroke-width:1px;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate" />
 </svg>

--- a/status/32/changes-allow.svg
+++ b/status/32/changes-allow.svg
@@ -1,274 +1,274 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="32"
+   id="svg5833"
    height="32"
-   id="svg5833">
+   width="32"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs5835">
     <linearGradient
        id="linearGradient1390">
       <stop
-         id="stop1382"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop1382" />
       <stop
-         id="stop1384"
+         offset="0.57210702"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.57210702" />
+         id="stop1384" />
       <stop
-         id="stop1386"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
+         id="stop1386" />
       <stop
-         id="stop1388"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop1388" />
     </linearGradient>
     <linearGradient
        id="linearGradient1336">
       <stop
-         offset="0"
+         id="stop1330"
          style="stop-color:#abacae;stop-opacity:1"
-         id="stop1330" />
+         offset="0" />
       <stop
-         offset="0.5"
+         id="stop1332"
          style="stop-color:#fafafa;stop-opacity:1"
-         id="stop1332" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop1334"
          style="stop-color:#abacae;stop-opacity:1"
-         id="stop1334" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient1177">
       <stop
-         offset="0"
+         id="stop1169"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop1169" />
+         offset="0" />
       <stop
-         offset="0.00000001"
+         id="stop1171"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop1171" />
+         offset="0.00000001" />
       <stop
-         offset="1"
+         id="stop1173"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop1173" />
+         offset="1" />
       <stop
-         offset="1"
+         id="stop1175"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop1175" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3966-0-4-2">
       <stop
-         id="stop3968-8-0-1"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3968-8-0-1" />
       <stop
-         id="stop3970-7-4-2"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop3970-7-4-2" />
     </linearGradient>
     <linearGradient
        id="linearGradient5475">
       <stop
-         id="stop5477"
+         offset="0"
          style="stop-color:#d88f22;stop-opacity:1"
-         offset="0" />
+         id="stop5477" />
       <stop
-         id="stop5479"
+         offset="1"
          style="stop-color:#d88f22;stop-opacity:0"
-         offset="1" />
+         id="stop5479" />
     </linearGradient>
     <linearGradient
        id="linearGradient6057">
       <stop
-         id="stop6059"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop6059" />
       <stop
-         id="stop6061"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop6061" />
     </linearGradient>
     <linearGradient
-       spreadMethod="reflect"
-       x1="10.650842"
-       y1="2.9136841"
-       x2="27.192274"
-       y2="17.470011"
-       id="linearGradient2503"
-       xlink:href="#linearGradient1336"
+       gradientTransform="matrix(0.5585856,0,0,0.6275526,-5.443463,-1.0836028)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5585856,0,0,0.6275526,2.5797896,-0.96235182)" />
+       xlink:href="#linearGradient1336"
+       id="linearGradient2503"
+       y2="17.470011"
+       x2="27.192274"
+       y1="2.9136841"
+       x1="10.650842"
+       spreadMethod="reflect" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309">
       <stop
-         id="stop2889"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
-       cx="18.031223"
-       cy="6.2806997"
-       r="3.1819806"
-       fx="18.031223"
-       fy="6.2806997"
-       id="radialGradient3079"
+       gradientTransform="matrix(0.6265109,0,0,0.6275526,-7.4224716,0.1012114)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient6057"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6265109,0,0,0.6275526,0.6007813,0.22246237)" />
+       id="radialGradient3079"
+       fy="6.2806997"
+       fx="18.031223"
+       r="3.1819806"
+       cy="6.2806997"
+       cx="18.031223" />
     <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient3087"
+       gradientTransform="matrix(0.64285714,0,0,0.42857134,4.571429,10.857146)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3702-501-757"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64285714,0,0,0.42857134,0.5714286,10.857146)" />
+       id="linearGradient3087"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
     <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3090"
+       gradientTransform="matrix(1.2022705,0,0,0.59999988,-17.007122,-55.599994)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3688-464-309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2022705,0,0,0.59999988,-13.007122,-55.599994)" />
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
+       id="radialGradient3090"
        fy="43.5"
-       id="radialGradient3093"
-       xlink:href="#linearGradient3688-166-749"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(1.2022705,0,0,0.59999988,22.992878,3.4000047)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2022705,0,0,0.59999988,18.992878,3.4000047)" />
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
        id="linearGradient1181">
       <stop
-         offset="0"
+         id="stop1177"
          style="stop-color:#7d511a;stop-opacity:0.1"
-         id="stop1177" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop1179"
          style="stop-color:#b69464;stop-opacity:0.02941176"
-         id="stop1179" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient1125">
       <stop
-         id="stop1121"
+         style="stop-color:#f0dab6;stop-opacity:1"
          offset="0"
-         style="stop-color:#f0dab6;stop-opacity:1" />
+         id="stop1121" />
       <stop
-         id="stop1123"
+         style="stop-color:#dfa751;stop-opacity:1"
          offset="1"
-         style="stop-color:#dfa751;stop-opacity:1" />
+         id="stop1123" />
     </linearGradient>
     <linearGradient
-       x1="8.6428576"
-       y1="27.5"
-       x2="23.299999"
-       y2="27.5"
-       id="linearGradient3888-76-9"
+       gradientTransform="matrix(-1.2447699,0,0,1,39.523611,-11)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3966-0-4-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.2447699,0,0,1,35.523611,-11)" />
-    <linearGradient
-       x1="9.1428566"
-       y1="27.5"
-       x2="22.799999"
+       id="linearGradient3888-76-9"
        y2="27.5"
-       id="linearGradient3927-6-2"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
+    <linearGradient
+       gradientTransform="matrix(-1.2447699,0,0,1,39.523611,-10)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient1181"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.2447699,0,0,1,35.523611,-10)" />
+       id="linearGradient3927-6-2"
+       y2="27.5"
+       x2="22.799999"
+       y1="27.5"
+       x1="9.1428566" />
     <linearGradient
-       x1="21.771429"
-       y1="15.038462"
-       x2="21.771429"
-       y2="27.961538"
-       id="linearGradient3059-5"
+       gradientTransform="matrix(1,0,0,0.92857143,4.0000004,2.035714)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient1177"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.92857143,0,2.035714)" />
+       id="linearGradient3059-5"
+       y2="27.961538"
+       x2="21.771429"
+       y1="15.038462"
+       x1="21.771429" />
     <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
-       y2="14"
+       gradientTransform="matrix(0.66666666,0,0,0.93333333,5.8333344,1.9333322)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5475"
        id="linearGradient3071-5"
-       xlink:href="#linearGradient5475"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666666,0,0,0.93333333,1.833334,1.9333322)" />
-    <linearGradient
-       x1="9"
-       y1="29"
-       x2="9"
        y2="14"
-       id="linearGradient3071-5-3"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       gradientTransform="matrix(0.66666666,0,0,0.93333333,22.833334,1.933332)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5475"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66666666,0,0,0.93333333,18.833334,1.933332)" />
+       id="linearGradient3071-5-3"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
     <linearGradient
-       gradientTransform="translate(28.476345,4.047689)"
-       gradientUnits="userSpaceOnUse"
-       y2="25.323393"
-       x2="-11.442858"
-       y1="10.514286"
-       x1="-11.442858"
+       xlink:href="#linearGradient1125"
        id="linearGradient1127-2"
-       xlink:href="#linearGradient1125" />
-    <linearGradient
-       y2="14.201538"
-       x2="21.977144"
-       y1="1.623077"
-       x1="21.977144"
-       gradientTransform="matrix(1,0,0,0.92857143,0,1.0357141)"
+       x1="-11.442858"
+       y1="10.514286"
+       x2="-11.442858"
+       y2="25.323393"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(32.476345,4.047689)" />
+    <linearGradient
+       xlink:href="#linearGradient1390"
        id="linearGradient1380"
-       xlink:href="#linearGradient1390" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.92857143,-8.0232526,0.9144631)"
+       x1="21.977144"
+       y1="1.623077"
+       x2="21.977144"
+       y2="14.201538" />
   </defs>
   <metadata
      id="metadata5838">
@@ -278,101 +278,101 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     style="fill:url(#linearGradient2503);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.59206575"
+     d="M 0.4999995,14 V 9.2247511 c 0,-4.9389225 2.9367129,-7.2852538 7.4737789,-7.2235745 4.5617516,0.061679 7.5297186,2.2265479 7.5297186,7.2235745 v 5.7558059 c 0,1.226381 -3.067027,1.382467 -3.067027,0 v -4.500701 c 0,-1.2551049 0.31753,-5.3165329 -4.4307326,-5.3165329 -4.709108,0 -4.365989,4.086458 -4.347728,5.3115289 V 14 Z"
      id="path2086"
-     d="M 9.3960239,10.94492 V 9.3460021 c 0,-4.9389225 2.5811391,-7.2852538 7.1182051,-7.2235745 4.561752,0.061679 7.012521,2.2265479 7.012521,7.2235745 v 5.7558059 c 0,1.226381 -3.067027,1.382467 -3.067027,0 v -4.500701 c 0,-1.2551049 0.834728,-5.3165329 -3.913535,-5.3165329 -4.709108,0 -4.010415,4.086458 -3.992154,5.3115289 v 0.369951 l -3.1580101,-0.02114 z" />
+     style="fill:url(#linearGradient2503);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.592066" />
   <path
-     d="m 14.763857,4.1639318 c 2.76e-4,1.103031 -0.892346,1.9973608 -1.993546,1.9973608 -1.101199,0 -1.993822,-0.8943298 -1.993545,-1.9973608 -2.77e-4,-1.1030309 0.892346,-1.9973608 1.993545,-1.9973608 1.1012,0 1.993822,0.8943299 1.993546,1.9973608 z"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3079);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path6055"
-     style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3079);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+     d="m 5.8678324,4.0426808 c 2.76e-4,1.103031 -0.892346,1.9973608 -1.993546,1.9973608 -1.101199,0 -1.9938214,-0.8943298 -1.9935451,-1.9973608 C 1.880465,2.9396499 2.7730874,2.04532 3.8742864,2.04532 c 1.1012,0 1.993822,0.8943299 1.993546,1.9973608 z" />
   <path
-     d="m 13.636176,4.1639317 c 1.2e-4,0.4790843 -0.387576,0.8675225 -0.865865,0.8675225 -0.478289,0 -0.865985,-0.3884382 -0.865865,-0.8675225 -1.2e-4,-0.4790842 0.387576,-0.8675225 0.865865,-0.8675225 0.478289,0 0.865985,0.3884383 0.865865,0.8675225 z"
+     style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path6065"
-     style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+     d="m 4.7401514,4.0426807 c 1.2e-4,0.4790843 -0.387576,0.8675225 -0.865865,0.8675225 -0.478289,0 -0.865985,-0.3884382 -0.865865,-0.8675225 -1.2e-4,-0.4790842 0.387576,-0.8675225 0.865865,-0.8675225 0.478289,0 0.865985,0.3884383 0.865865,0.8675225 z" />
   <path
-     d="M 9.3960239,10.944919 V 9.3460021 c 0,-4.9389228 2.5811391,-7.2852541 7.1182051,-7.2235748 4.561752,0.061679 7.012521,2.2265479 7.012521,7.2235748 v 5.7558059 h -3.067027 v -4.500701 c 0,-1.2551049 0.540277,-5.3165332 -3.913535,-5.3165332 -4.903057,0 -4.010415,4.0864583 -3.992154,5.3115292 v 0.369951 z"
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
      id="path2086-1"
-     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#555761;stroke-width:0.9999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+     d="M 0.4999995,13.5 V 9.2247511 c 0,-4.9389228 2.9367129,-7.2852541 7.4737789,-7.2235748 4.5617516,0.061679 7.5297186,2.2265479 7.5297186,7.2235748 V 14.980557 H 12.43647 v -4.500701 c 0,-1.2551049 0.31753,-5.3165332 -4.4307326,-5.3165332 -4.709108,0 -4.365989,4.0864583 -4.347728,5.3115292 V 13.5 Z" />
   <path
-     d="m 10.372771,9.9174281 v -0.744642 c 0,-4.1853484 2.188985,-6.1736797 6.120192,-6.1214114 C 20.44556,3.1036429 22.5,4.938199 22.5,9.1727861 v 4.8775929"
+     style="vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1380);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
      id="path2086-1-4"
-     style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1380);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+     d="M 1.4767471,13 V 9.0515351 c 0,-4.1853484 2.5445583,-6.1736797 6.4757653,-6.1214114 3.9525966,0.052268 6.5242346,1.8868243 6.5242346,6.1214114 v 4.8775929" />
   <rect
-     width="3"
-     height="2.9999993"
-     x="25"
-     y="28"
+     style="opacity:0.3;fill:url(#radialGradient3093);fill-opacity:1;stroke:none"
      id="rect2801"
-     style="opacity:0.3;fill:url(#radialGradient3093);fill-opacity:1;stroke:none" />
-  <rect
-     width="3"
-     height="2.9999993"
-     x="-7"
-     y="-30.999998"
-     transform="scale(-1,-1)"
-     id="rect3696"
-     style="opacity:0.3;fill:url(#radialGradient3090);fill-opacity:1;stroke:none" />
-  <rect
-     width="18"
-     height="2.9999995"
-     x="7"
      y="28"
+     x="29"
+     height="2.9999993"
+     width="3" />
+  <rect
+     style="opacity:0.3;fill:url(#radialGradient3090);fill-opacity:1;stroke:none"
+     id="rect3696"
+     transform="scale(-1)"
+     y="-30.999998"
+     x="-11"
+     height="2.9999993"
+     width="3" />
+  <rect
+     style="opacity:0.3;fill:url(#linearGradient3087);fill-opacity:1;stroke:none"
      id="rect3700"
-     style="opacity:0.3;fill:url(#linearGradient3087);fill-opacity:1;stroke:none" />
+     y="28"
+     x="11"
+     height="2.9999995"
+     width="18" />
   <rect
-     width="21"
-     height="15"
-     rx="1"
-     ry="1"
-     x="5.5"
-     y="14.500001"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1127-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect3186-2-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1127-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-  <rect
-     width="21"
-     height="15"
-     rx="1"
-     ry="1"
-     x="5.5"
      y="14.500001"
+     x="9.5"
+     ry="1"
+     rx="1"
+     height="15"
+     width="21" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#7d511a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect3186-0"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#7d511a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     y="14.500001"
+     x="9.5"
+     ry="1"
+     rx="1"
+     height="15"
+     width="21" />
   <path
-     d="m 7.142858,17.5 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17"
+     style="fill:none;stroke:url(#linearGradient3927-6-2);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path3863-6-6"
-     style="opacity:1;fill:none;stroke:url(#linearGradient3927-6-2);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 11.142858,17.5 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17" />
   <path
-     d="m 7.142858,16.5 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17"
+     style="opacity:0.2;fill:none;stroke:url(#linearGradient3888-76-9);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path3863-3-5-1"
-     style="opacity:0.2;fill:none;stroke:url(#linearGradient3888-76-9);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     d="m 11.142858,16.5 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17 m -17,2 h 17" />
   <rect
-     width="1"
-     height="14"
-     rx="1.6"
-     ry="0.99999994"
-     x="7"
-     y="15"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3071-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
      id="rect5453-7"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3071-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate" />
-  <rect
-     width="1"
-     height="14"
-     rx="1.6"
-     ry="0.99999994"
-     x="24"
      y="15"
-     id="rect5453-7-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3071-5-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate" />
+     x="11"
+     ry="0.99999994"
+     rx="1.6"
+     height="14"
+     width="1" />
   <rect
-     width="19"
-     height="13"
-     x="6.5"
-     y="15.500001"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3071-5-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+     id="rect5453-7-5"
+     y="15"
+     x="28"
+     ry="0.99999994"
+     rx="1.6"
+     height="14"
+     width="1" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3059-5);stroke-width:1px;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="rect3186-3-2"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient3059-5);stroke-width:1px;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     y="15.500001"
+     x="10.5"
+     height="13"
+     width="19" />
 </svg>

--- a/status/48/changes-allow.svg
+++ b/status/48/changes-allow.svg
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg4078"
+   height="48"
+   width="48"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4080">
+    <linearGradient
+       gradientTransform="matrix(-1.8671693,0,0,1.5000117,53.285829,-15.750435)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6057-35"
+       id="linearGradient3888-76"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
+    <linearGradient
+       id="linearGradient6057-35">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6059-0" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6061-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-1.8671693,0,0,1.5000117,53.285829,-14.750435)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3865-4"
+       id="linearGradient3927-6"
+       y2="27.5"
+       x2="23.299999"
+       y1="27.5"
+       x1="8.6428576" />
+    <linearGradient
+       id="linearGradient3865-4">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3867-110" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3869-96" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.5263159,0,0,1.4285714,-0.4210539,2.7857126)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5443"
+       id="linearGradient3059"
+       y2="27.924538"
+       x2="21.771429"
+       y1="14.871428"
+       x1="21.771429" />
+    <linearGradient
+       id="linearGradient5443">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop5445" />
+      <stop
+         offset="0.03252051"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop5447" />
+      <stop
+         offset="0.98558509"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop5449" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop5451" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0000078,0,0,1.4000109,29.000225,-63.600154)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3966-0-4-2"
+       id="linearGradient3062"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       id="linearGradient3966-0-4-2">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3968-8-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3970-7-4-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0000078,0,0,1.4000109,2.0000155,-63.600154)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3966-0-4"
+       id="linearGradient3065"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       id="linearGradient3966-0-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3968-8-0" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3970-7-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3333334,0,0,1.4000109,4.6666646,3.3996844)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5475"
+       id="linearGradient3068"
+       y2="14"
+       x2="24"
+       y1="29"
+       x1="24" />
+    <linearGradient
+       id="linearGradient5475">
+      <stop
+         offset="0"
+         style="stop-color:#d88f22;stop-opacity:1"
+         id="stop5477" />
+      <stop
+         offset="1"
+         style="stop-color:#d88f22;stop-opacity:0"
+         id="stop5479" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3333334,0,0,1.4000109,0.6666657,3.3996844)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5483"
+       id="linearGradient3071"
+       y2="14"
+       x2="9"
+       y1="29"
+       x1="9" />
+    <linearGradient
+       id="linearGradient5483">
+      <stop
+         offset="0"
+         style="stop-color:#d88f22;stop-opacity:1"
+         id="stop5485" />
+      <stop
+         offset="1"
+         style="stop-color:#d88f22;stop-opacity:0"
+         id="stop5487" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,2.2261905,-3.2100562,0,60.492107,-12.89067)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5409"
+       id="radialGradient3074"
+       fy="11.597148"
+       fx="16.777113"
+       r="10.5"
+       cy="11.368058"
+       cx="16.823883" />
+    <linearGradient
+       id="linearGradient5409">
+      <stop
+         offset="0"
+         style="stop-color:#f2e0c4;stop-opacity:1"
+         id="stop5411" />
+      <stop
+         offset="0.76470584"
+         style="stop-color:#e5af5b;stop-opacity:1"
+         id="stop5559" />
+      <stop
+         offset="1"
+         style="stop-color:#af6900;stop-opacity:1"
+         id="stop5413" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.96429319,0,0,0.642862,0.8571496,16.285475)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient3087"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.8034197,0,0,0.9000068,-19.510834,-83.400268)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3090"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.8034197,0,0,0.9000068,28.489539,5.099676)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6057-31"
+       id="radialGradient3328"
+       fy="6.2806997"
+       fx="18.031223"
+       r="3.1819806"
+       cy="6.2806997"
+       cx="18.031223" />
+    <linearGradient
+       id="linearGradient6057-31">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6059-15" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6061-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-0.8563683,0,0,0.9968005,45.000381,2.6467529)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6227-1"
+       id="linearGradient3326"
+       y2="13.789077"
+       x2="35.020981"
+       y1="13.789077"
+       x1="32.128025" />
+    <linearGradient
+       id="linearGradient6227-1">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop6229-8" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop6231-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.8563683,0,0,0.9968005,4.828827,2.6467529)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6227-1"
+       id="linearGradient3324"
+       y2="14.849737"
+       x2="33.004314"
+       y1="14.849737"
+       x1="35.004684" />
+    <linearGradient
+       id="linearGradient10591-4">
+      <stop
+         offset="0"
+         style="stop-color:#cad0c6;stop-opacity:1"
+         id="stop10593-3" />
+      <stop
+         offset="0.5"
+         style="stop-color:#eaece9;stop-opacity:1"
+         id="stop10599-8" />
+      <stop
+         offset="1"
+         style="stop-color:#c5cbc0;stop-opacity:1"
+         id="stop10595-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.8563683,0,0,0.9968005,3.38807,-0.3947636)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient10591-4"
+       id="linearGradient4076"
+       y2="17.470011"
+       x2="27.192274"
+       y1="2.9136841"
+       x1="10.650842" />
+  </defs>
+  <metadata
+     id="metadata4083">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(6)">
+    <g
+       id="g1"
+       transform="translate(-18,-2.0032107)">
+      <path
+         style="fill:url(#linearGradient4076);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         id="path2086-6"
+         d="M 12.5,22.986425 V 15.97896 C 12.5,8.1340066 17.002278,4.4071091 23.958059,4.5050801 30.951688,4.6030513 35.501881,8.0417145 35.501881,15.97896 v 10.813405 h -4.702062 v -8.819804 c 0,-1.993601 0.486805,-8.4447478 -6.792763,-8.4447478 -7.219539,0 -6.693503,6.4909038 -6.665508,8.4367988 v 5.055384 z" />
+      <path
+         style="opacity:0.182353;fill:url(#linearGradient3324);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         id="rect1345-3"
+         d="m 33.092992,12.327748 1.082405,0.1246 c 0.794058,2.813702 0.630331,9.479985 0.630331,9.479985 -0.05352,1.1214 -1.739498,0.52955 -1.712736,0 z" />
+      <path
+         style="opacity:0.141176;fill:url(#linearGradient3326);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         id="path6332-4"
+         d="m 17.203152,12.415853 -0.318328,0.168654 c -1.473237,1.05159 -1.861344,9.347825 -1.861344,9.347825 0.03218,0.865283 1.731606,0.434849 1.712737,0 0,0 -0.323896,-6.848657 0.466935,-9.516479 z" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.623529;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="path5675-7"
+         d="M 14.272838,20.774535 14.3929,14.102027 c 0,-9.8447736 17.949433,-10.6422411 17.949433,0.8722 v 6.853004" />
+      <g
+         id="g6067"
+         transform="matrix(0.9605048,0,0,0.9968005,0.35405,1.4871877)">
+        <path
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3328);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           id="path6055-4"
+           d="m 21.213204,6.2806997 c 4.41e-4,1.7576709 -1.42431,3.1827783 -3.181981,3.1827783 -1.75767,0 -3.182421,-1.4251074 -3.18198,-3.1827783 -4.41e-4,-1.7576709 1.42431,-3.1827783 3.18198,-3.1827783 1.757671,0 3.182422,1.4251074 3.181981,3.1827783 z" />
+        <path
+           style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           id="path6065-9"
+           transform="matrix(0.4343344,0,0,0.4343344,10.199642,3.5527756)"
+           d="m 21.213204,6.2806997 c 4.41e-4,1.7576709 -1.42431,3.1827783 -3.181981,3.1827783 -1.75767,0 -3.182421,-1.4251074 -3.18198,-3.1827783 -4.41e-4,-1.7576709 1.42431,-3.1827783 3.18198,-3.1827783 1.757671,0 3.182422,1.4251074 3.181981,3.1827783 z" />
+      </g>
+      <path
+         style="opacity:0.4;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2086-6-4"
+         d="M 12.5,22.986425 V 15.97896 C 12.5,8.1340067 17.002278,4.4071092 23.958059,4.5050802 30.951688,4.6030514 35.501881,8.0417146 35.501881,15.97896 v 10.813405 h -4.702062 v -8.819804 c 0,-1.993601 0.486805,-8.4447477 -6.792763,-8.4447477 -7.219539,0 -6.693503,6.4909037 -6.665508,8.4367987 v 5.055384 z" />
+    </g>
+    <rect
+       style="opacity:0.3;fill:url(#radialGradient3093);fill-opacity:1;stroke:none"
+       id="rect2801"
+       y="41.999954"
+       x="37.500294"
+       height="4.5000339"
+       width="4.5000348" />
+    <rect
+       style="opacity:0.3;fill:url(#radialGradient3090);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-46.499989"
+       x="-10.500081"
+       height="4.5000339"
+       width="4.5000348" />
+    <rect
+       style="opacity:0.3;fill:url(#linearGradient3087);fill-opacity:1;stroke:none"
+       id="rect3700"
+       y="41.999954"
+       x="10.500081"
+       height="4.5000343"
+       width="27.000208" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect3186-2"
+       y="22.5"
+       x="8.5"
+       ry="0.99999994"
+       rx="1"
+       height="22"
+       width="31" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3071);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect5453"
+       y="22.999838"
+       x="11"
+       ry="0.99999994"
+       rx="2"
+       height="21.000162"
+       width="2" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3068);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect5453-6"
+       y="22.999838"
+       x="35"
+       ry="0.99999994"
+       rx="2"
+       height="21.000162"
+       width="2" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3065);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect5453-4"
+       transform="scale(1,-1)"
+       y="-44"
+       x="9.7500763"
+       ry="0.99999994"
+       rx="2"
+       height="21.000162"
+       width="1.5000116" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       id="rect5453-4-4"
+       transform="scale(1,-1)"
+       y="-44"
+       x="36.750286"
+       ry="0.99999994"
+       rx="2"
+       height="21.000162"
+       width="1.5000116" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3059);stroke-width:1px;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3186-3"
+       y="23.5"
+       x="9.5"
+       height="20"
+       width="29" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:1px;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3186"
+       y="22.5"
+       x="8.5"
+       ry="0.99999994"
+       rx="1"
+       height="22"
+       width="31" />
+    <path
+       style="opacity:0.05;fill:none;stroke:url(#linearGradient3927-6);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3863-6"
+       d="M 10.714369,26.499885 H 36.214568 M 10.714369,29.499909 H 36.214568 M 10.714369,32.49993 H 36.214568 M 10.714369,35.499954 H 36.214568 M 10.714369,38.499978 H 36.214568 M 10.714369,41.5 h 25.500199" />
+    <path
+       style="opacity:0.2;fill:none;stroke:url(#linearGradient3888-76);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3863-3-5"
+       d="M 10.714369,25.499884 H 36.214568 M 10.714369,28.499908 H 36.214568 M 10.714369,31.499929 H 36.214568 M 10.714369,34.499953 H 36.214568 M 10.714369,37.499977 H 36.214568 M 10.714369,40.5 h 25.500199" />
+  </g>
+</svg>


### PR DESCRIPTION
This is the third and final pull request split from #1369. It contains the icon I submitted as `unlocked.svg`in #1369, but this time as a redesign of `changes-allow`, which I wasn’t aware already existed.

The new design has the advantage of being more visually distinct from the `locked` icon, especially at small sizes.