### PR TITLE
Apps: redesign default icon

### DIFF
--- a/apps/48/application-default-icon.svg
+++ b/apps/48/application-default-icon.svg
@@ -1,15 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg6649">
+   id="svg6649"
+   sodipodi:docname="application-default-icon.svg"
+   inkscape:export-filename="/home/dani/default-icon.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1"
+     inkscape:cx="23.5"
+     inkscape:cy="24"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6649" />
   <defs
      id="defs6651">
     <linearGradient
@@ -103,18 +128,27 @@
        x2="16.767664"
        y2="29.896721"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.444444,0,0,1.444444,0.888913,1.888891)" />
+       gradientTransform="matrix(1.407407,0,0,1.407407,1.4814901,2.4814882)" />
     <linearGradient
        id="linearGradient870">
       <stop
          id="stop866"
          offset="0"
-         style="stop-color:#cd9ef7;stop-opacity:1" />
+         style="stop-color:#d4d4d4;stop-opacity:1" />
       <stop
          id="stop868"
          offset="1"
-         style="stop-color:#a56de2;stop-opacity:1" />
+         style="stop-color:#abacae;stop-opacity:1" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient870"
+       id="linearGradient930-9-2-3"
+       x1="16.767664"
+       y1="2.7676599"
+       x2="16.767664"
+       y2="29.896721"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.444444,0,0,1.444444,0.888913,1.888891)" />
   </defs>
   <metadata
      id="metadata6654">
@@ -124,41 +158,41 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <rect
-     style="opacity:0.6;fill:url(#radialGradient3013-6);fill-opacity:1;stroke:none;stroke-width:0.862764"
+  <path
      id="rect2801-3-7"
-     y="41.75"
-     x="40"
-     height="4.4999995"
-     width="5" />
-  <rect
-     style="opacity:0.6;fill:url(#radialGradient3015-1);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     style="opacity:0.2;fill:url(#radialGradient3013-6);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     d="M 42.771484 41.75 C 42.327121 42.91869 41.27675 43.783734 40 43.964844 L 40 46.25 L 45 46.25 L 45 41.75 L 42.771484 41.75 z " />
+  <path
      id="rect3696-6-3"
-     transform="scale(-1)"
-     y="-46.25"
-     x="-8"
-     height="4.4999995"
-     width="5" />
-  <rect
-     style="opacity:0.6;fill:url(#linearGradient1191);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     style="opacity:0.2;fill:url(#radialGradient3015-1);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     d="M -3 -41.75 L -3 -46.25 L -8 -46.25 L -8 -43.964844 C -6.7232502 -43.783734 -5.6728794 -42.91869 -5.2285156 -41.75 L -3 -41.75 z "
+     transform="scale(-1)" />
+  <path
      id="rect3700-4-6"
-     y="41.75"
-     x="8"
-     height="4.5"
-     width="32" />
+     style="opacity:0.2;fill:url(#linearGradient1191);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     d="M 8 43.964844 L 8 46.25 L 40 46.25 L 40 43.964844 C 39.836763 43.987999 39.669831 44 39.5 44 L 8.5 44 C 8.3301685 44 8.1632369 43.987999 8 43.964844 z " />
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient930-9-2);fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:1;stroke-opacity:0.5;marker:none;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stop-color:#000000;stop-opacity:1"
-     id="rect5505-21-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-5"
      y="5.4999952"
      x="4.5000153"
      ry="4"
      rx="4"
      height="39"
      width="39" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.6;vector-effect:none;fill:url(#linearGradient930-9-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     id="rect5505-21-1"
+     y="6"
+     x="5"
+     ry="3.5"
+     rx="3.5"
+     height="38"
+     width="38" />
   <rect
      style="opacity:0.35;fill:none;stroke:url(#linearGradient3058-5);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect6741-2"
@@ -169,26 +203,23 @@
      height="37"
      width="37" />
   <path
-     id="path1047-9-53-6-2"
-     class="warning"
-     d="m 23.940626,16.001147 c -0.553606,0.02301 -1.045427,0.355417 -1.266986,0.856336 l -2.155009,4.856298 h -5.568518 c -1.331005,0.0014 -1.95584,1.623746 -0.961551,2.496487 l 4.335467,3.787966 -2.203084,6.089198 c -0.455748,1.267138 0.953516,2.3973 2.118243,1.698729 l 5.760827,-3.472768 5.760829,3.472768 c 1.164727,0.698569 2.57399,-0.431593 2.118242,-1.698729 l -2.203085,-6.089198 4.335468,-3.787966 c 0.994288,-0.872741 0.369454,-2.495005 -0.961552,-2.496487 H 27.4814 l -2.155008,-4.856298 c -0.238843,-0.539851 -0.789054,-0.879855 -1.385766,-0.856336 z"
-     style="font-variation-settings:normal;opacity:0.3;vector-effect:none;fill:#7239b3;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1" />
+     id="path9124-3"
+     style="font-variation-settings:normal;opacity:0.07;mix-blend-mode:normal;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="m 23.933594,13.914062 c -1.722695,0.03715 -3.044102,1.307478 -4.519686,2.03171 -1.650609,1.004277 -3.400338,1.861717 -4.988979,2.958181 -1.220255,0.94988 -1.552237,2.571463 -1.424929,4.039406 0.03072,2.567488 -0.06105,5.141587 0.04492,7.705079 0.192262,1.527851 1.378012,2.679006 2.722702,3.297794 2.26687,1.274062 4.478617,2.656722 6.779251,3.864315 1.419007,0.603211 3.012219,0.147656 4.220749,-0.707951 2.23535,-1.3268 4.538469,-2.550532 6.732376,-3.940487 1.267719,-0.947868 1.637297,-2.60401 1.5,-4.107421 -0.03074,-2.566834 0.06107,-5.140301 -0.04492,-7.703126 -0.192675,-1.52741 -1.378206,-2.680299 -2.722702,-3.299747 -2.267126,-1.273003 -4.476875,-2.658191 -6.779251,-3.862362 -0.484117,-0.187401 -1.000697,-0.281113 -1.519531,-0.275391 z m 5.888672,7.570313 C 28.214844,22.41276 26.607422,23.341146 25,24.269531 c 0,-1.856771 0,-3.713541 0,-5.570312 1.607422,0.928385 3.214844,1.856771 4.822266,2.785156 z M 23,26.576172 c 0,2.240885 0,4.481771 0,6.722656 -1.940755,-1.119792 -3.88151,-2.239583 -5.822266,-3.359375 0,-2.241536 0,-4.483073 0,-6.724609 1.940756,1.120442 3.881511,2.240885 5.822266,3.361328 z" />
   <path
-     id="path1047-9-53-6-2-9"
-     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#7239b3;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1"
-     d="m 23.900391,16 c -0.92861,0.0386 -1.766714,0.596971 -2.144532,1.451172 l -1.888671,4.257812 h -4.917969 a 1.0037653,1.0037653 0 0 0 -0.002,0 c -1.073514,0.0011 -1.953926,0.700017 -2.28711,1.566407 -0.333183,0.86639 -0.141336,1.980796 0.666016,2.689453 a 1.0037653,1.0037653 0 0 0 0.002,0.002 l 3.818359,3.335937 -1.96875,5.44336 a 1.0037653,1.0037653 0 0 0 -0.002,0.002 c -0.371469,1.032814 0.03288,2.119236 0.767578,2.708984 0.734698,0.589749 1.870344,0.755315 2.810547,0.191407 a 1.0037653,1.0037653 0 0 0 0.002,-0.002 L 24,34.484375 l 5.244141,3.162109 a 1.0037653,1.0037653 0 0 0 0.002,0.002 c 0.940204,0.563906 2.07585,0.398342 2.810547,-0.191407 0.734697,-0.589748 1.139047,-1.676171 0.767578,-2.708984 a 1.0037653,1.0037653 0 0 0 -0.002,-0.002 l -1.96875,-5.44336 3.818359,-3.335937 a 1.0037653,1.0037653 0 0 0 0.002,-0.002 c 0.807339,-0.708647 0.999202,-1.823072 0.666016,-2.689453 -0.333187,-0.866381 -1.213626,-1.565211 -2.28711,-1.566407 a 1.0037653,1.0037653 0 0 0 -0.002,0 H 28.132812 L 26.244141,17.451172 C 25.837894,16.532943 24.902672,15.960573 23.902344,16 a 1.0037653,1.0037653 0 0 0 -0.002,0 z"
-     transform="translate(0,-0.99808537)" />
+     id="path9124-3-2"
+     style="font-variation-settings:normal;opacity:0.25;mix-blend-mode:normal;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="m 24,14.913 c -0.51338,0 -1.027471,0.132389 -1.488281,0.398438 l -7.023438,4.05664 C 14.566661,19.900177 14,20.880054 14,21.94425 v 8.111328 c 0,1.064196 0.566661,2.044075 1.488281,2.576172 l 7.023438,4.056641 c 0.92162,0.532098 2.054941,0.532098 2.976562,0 L 32.511719,32.63175 C 33.43334,32.099653 34,31.119774 34,30.055578 V 21.94425 c 0,-1.064196 -0.56666,-2.044073 -1.488281,-2.576172 l -7.023438,-4.05664 C 25.027471,15.045389 24.51338,14.913 24,14.913 Z m 0,2.179688 c 0.137911,0 0.275666,0.03459 0.398438,0.105468 l 7.02539,4.056641 c 0.122772,0.07088 0.22206,0.171581 0.291016,0.291015 L 24,26.000891 v 8.908203 c -0.137911,0 -0.275667,-0.03654 -0.398438,-0.107422 l -7.02539,-4.054688 C 16.330629,30.605221 16.177734,30.339106 16.177734,30.055578 V 21.94425 c 0,-0.141763 0.03847,-0.279003 0.107422,-0.398438 L 24,26.000891 Z" />
   <path
-     id="path1047-9"
-     class="warning"
-     d="m 23.940626,15.001142 c -0.553606,0.02301 -1.045427,0.355417 -1.266986,0.856336 l -2.155009,4.856298 h -5.568518 c -1.331005,0.0014 -1.95584,1.623746 -0.961551,2.496487 l 4.335467,3.787966 -2.203084,6.089198 c -0.455748,1.267138 0.953516,2.3973 2.118243,1.698729 l 5.760827,-3.472768 5.760829,3.472768 c 1.164727,0.698569 2.57399,-0.431593 2.118242,-1.698729 l -2.203085,-6.089198 4.335468,-3.787966 c 0.994288,-0.872741 0.369454,-2.495005 -0.961552,-2.496487 H 27.4814 l -2.155008,-4.856298 c -0.238843,-0.539851 -0.789054,-0.879855 -1.385766,-0.856336 z"
-     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000" />
+     id="path9124"
+     style="font-variation-settings:normal;mix-blend-mode:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 24,13.912764 c -0.51338,0 -1.027471,0.132389 -1.488281,0.398438 l -7.023438,4.05664 C 14.566661,18.899941 14,19.879818 14,20.944014 v 8.111328 c 0,1.064196 0.566661,2.044075 1.488281,2.576172 l 7.023438,4.056641 c 0.92162,0.532098 2.054941,0.532098 2.976562,0 l 7.023438,-4.056641 C 33.43334,31.099417 34,30.119538 34,29.055342 v -8.111328 c 0,-1.064196 -0.56666,-2.044073 -1.488281,-2.576172 l -7.023438,-4.05664 C 25.027471,14.045153 24.51338,13.912764 24,13.912764 Z m 0,2.179688 c 0.137911,0 0.275666,0.03459 0.398438,0.105468 l 7.02539,4.056641 c 0.122772,0.07088 0.22206,0.171581 0.291016,0.291015 L 24,25.000655 v 8.908203 c -0.137911,0 -0.275667,-0.03654 -0.398438,-0.107422 l -7.02539,-4.054688 C 16.330629,29.604985 16.177734,29.33887 16.177734,29.055342 v -8.111328 c 0,-0.141763 0.03847,-0.279003 0.107422,-0.398438 L 24,25.000655 Z" />
   <path
-     id="path1047-9-53"
-     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#7239b3;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1"
-     d="m 13.601562,21.628906 c -0.201614,0.516105 -0.112535,1.143809 0.386719,1.582032 l 4.335748,3.787291 1.9e-4,-1.000182 -4.335938,-3.787109 C 13.794596,22.04093 13.679117,21.83828 13.601562,21.628906 Z m 20.796876,0 c -0.07755,0.20937 -0.193035,0.412024 -0.386719,0.582032 l -4.335938,3.787109 2.2e-4,1.000182 4.335717,-3.787291 c 0.499253,-0.438223 0.588333,-1.065937 0.38672,-1.582032 z M 24,30.3125 18.238281,33.787109 c -0.84587,0.50733 -1.811634,0.04518 -2.107422,-0.728515 l -0.0098,0.0293 c -0.455748,1.267138 0.95246,2.397789 2.117187,1.699218 L 24,31.3125 l 5.761719,3.474609 c 1.164727,0.698569 2.572935,-0.432082 2.117187,-1.699218 l -0.0098,-0.0293 c -0.295788,0.773699 -1.261552,1.235843 -2.107422,0.728515 z" />
+     id="path9124-0"
+     style="font-variation-settings:normal;opacity:0.07;mix-blend-mode:normal;vector-effect:none;fill:#7e8087;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 25,14.699219 v 1.845703 l 3.224609,1.861328 1.597657,-0.921875 z m -7.822266,4.515625 v 1.845703 L 23,24.421875 V 22.576172 Z M 14,28.666016 v 0.388672 c 0,1.064194 0.566662,2.044075 1.488281,2.576171 l 7.023438,4.056641 c 0.921619,0.532097 2.054942,0.532097 2.976562,0 l 7.023438,-4.056641 C 33.433339,31.098763 34,30.118882 34,29.054688 v -0.355469 c -0.148895,0.167406 -0.313457,0.323413 -0.5,0.46289 -2.193905,1.389954 -4.497074,2.614608 -6.732422,3.941407 -1.208529,0.855606 -2.801697,1.310241 -4.220703,0.707031 C 20.246243,32.602955 18.034446,31.221326 15.767578,29.947266 15.106524,29.643067 14.48508,29.209038 14,28.666016 Z" />
   <path
-     id="path1047-9-53-6"
-     style="font-variation-settings:normal;opacity:0.07;vector-effect:none;fill:#7239b3;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1"
-     d="m 13.759766,21.345703 c -0.372327,0.55134 -0.368229,1.34144 0.228515,1.865235 l 4.335748,3.787291 c 0,0 -0.05904,-1.551832 -1.177545,-2.693541 z m 20.480468,0 -3.386718,2.958985 c -1.246145,1.346071 -1.177515,2.693541 -1.177515,2.693541 l 4.335718,-3.787291 c 0.596744,-0.523795 0.600842,-1.3139 0.228515,-1.865235 z M 24,29.486328 l -5.244141,3.16211 c -6.52e-4,6.5e-4 -0.0013,0.0013 -0.002,0.002 -0.810695,0.486232 -1.765392,0.428149 -2.484375,0.02539 l -0.148437,0.41211 c -0.455748,1.267138 0.95246,2.397789 2.117187,1.699218 L 24,31.3125 l 5.761719,3.474609 c 1.164727,0.698569 2.572935,-0.432082 2.117187,-1.699218 l -0.148437,-0.41211 c -0.718982,0.402758 -1.673679,0.460841 -2.484375,-0.02539 -6.5e-4,-6.52e-4 -0.0013,-0.0013 -0.002,-0.002 z" />
+     id="path9124-6"
+     style="font-variation-settings:normal;opacity:0.15;mix-blend-mode:normal;vector-effect:none;fill:#7e8087;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 24,15.091797 v 1 c 0.137911,0 0.275666,0.03459 0.398438,0.105469 l 6.55664,3.787109 0.759766,-0.439453 C 31.645888,19.425488 31.5466,19.324786 31.423828,19.253906 l -7.02539,-4.05664 C 24.275666,15.126388 24.137911,15.091797 24,15.091797 Z m -7.714844,4.453125 c -0.06895,0.119435 -0.107422,0.256675 -0.107422,0.398437 v 1 c 0,-0.141762 0.03847,-0.279002 0.107422,-0.398437 L 24,25 V 24 Z M 14,28.054688 v 1 c 0,1.064194 0.566662,2.044075 1.488281,2.576171 l 7.023438,4.056641 c 0.921619,0.532097 2.054942,0.532097 2.976562,0 l 7.023438,-4.056641 C 33.433339,31.098763 34,30.118882 34,29.054688 v -1 c 0,1.064194 -0.566661,2.044075 -1.488281,2.576171 L 25.488281,34.6875 c -0.92162,0.532097 -2.054943,0.532097 -2.976562,0 L 15.488281,30.630859 C 14.566662,30.098763 14,29.118882 14,28.054688 Z" />
 </svg>


### PR DESCRIPTION
Default icon is used as a fallback/placeholder when the actual app icon fails to load, is missing, or hasn't loaded yet. Playing with something that looks more like a placeholder. Not sure about the transparency, that might be too much for some use cases?

<img width="48" height="48" alt="default-icon" src="https://github.com/user-attachments/assets/bf76219c-fb8c-43d5-a471-5512ded6238e" />
<img width="48" height="48" alt="default-icon-dark" src="https://github.com/user-attachments/assets/f248c74c-d23a-40fe-bbe0-098f67f10834" />
