### PR TITLE
Add missing mint-green path boolean operation Inkscape icons

### DIFF
--- a/actions/16/path-cut.svg
+++ b/actions/16/path-cut.svg
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg7435"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="path-cut.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="true"
+     showgrid="true"
+     inkscape:zoom="10.495517"
+     inkscape:cx="-1.2862635"
+     inkscape:cy="-2.2390512"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435">
+    <inkscape:grid
+       id="grid2"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.5"
+       spacingy="0.5"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="2"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs7437">
+    <linearGradient
+       id="linearGradient1847">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1839" />
+      <stop
+         offset="0.49771357"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1841" />
+      <stop
+         offset="0.74999994"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1843" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1845" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient963">
+      <stop
+         id="stop955"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop957"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop959"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop961"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         style="stop-color:#43d6b5;stop-opacity:1"
+         offset="0"
+         id="stop866" />
+      <stop
+         style="stop-color:#28bca3;stop-opacity:1"
+         offset="1"
+         id="stop868" />
+    </linearGradient>
+    <linearGradient
+       y2="47.013336"
+       y1=".985206"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(.48571543 0 0 .45629666 -34.78968 -5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="-61.562508"
+       x2="51.798126"
+       y1="-98.562508"
+       x1="51.798126"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,-0.689191,23.310812)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1697-2"
+       xlink:href="#linearGradient1847" />
+    <linearGradient
+       y2="-21.229681"
+       x2="26.950296"
+       y1="-42.231876"
+       x1="26.950296"
+       gradientTransform="matrix(0.52631574,0,0,0.52631574,-1.315788,22.684197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1695-1"
+       xlink:href="#linearGradient874" />
+    <linearGradient
+       y2="40.193295"
+       x2="23.99999"
+       y1="7.818294"
+       x1="23.99999"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,0.312062,5.309558)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1693-4"
+       xlink:href="#linearGradient963" />
+    <linearGradient
+       y2="21.282824"
+       x2="14.600296"
+       y1="2.6556277"
+       x1="14.600296"
+       gradientTransform="matrix(0.52631574,0,0,0.52631574,-0.815788,4.184197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1691-7"
+       xlink:href="#linearGradient870" />
+  </defs>
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="vector-effect:none;fill:url(#linearGradient1695-1);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-5"
+     d="M 15.5,6 A 5.5000005,5.5000019 0 1 1 4.499999,6 5.5000005,5.5000019 0 1 1 15.5,6 Z" />
+  <path
+     style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1697-2);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path8339-9"
+     d="m 14.499993,5.999999 a 4.4999993,4.4999996 0 1 1 -8.999998,0 4.4999993,4.4999996 0 1 1 8.999998,0 z" />
+  <path
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-7"
+     d="M 15.5,6 A 5.5000005,5.5000019 0 1 1 4.499999,6 5.5000005,5.5000019 0 1 1 15.5,6 Z" />
+  <path
+     id="rect5505-21-8-1-25-1"
+     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#28bca3;stroke-linejoin:round;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="M 1.5 5 C 0.67764862 5 0 5.6776486 0 6.5 L 0 14.5 C 0 15.322351 0.67764862 16 1.5 16 L 9.5 16 C 10.322351 16 11 15.322351 11 14.5 L 11 12.927734 C 10.673203 12.975058 10.339309 13 10 13 L 10 14.5 C 10 14.785649 9.7856486 15 9.5 15 L 1.5 15 C 1.2143514 15 1 14.785649 1 14.5 L 1 6.5 C 1 6.2143514 1.2143514 6 1.5 6 L 3 6 C 3 5.6606911 3.0249422 5.3267967 3.0722656 5 L 1.5 5 z M 6.1230469 5 C 6.0424186 5.3190852 6 5.654067 6 6 L 9.5 6 C 9.7856486 6 10 6.2143514 10 6.5 L 10 10 C 10.345933 10 10.680915 9.9575814 11 9.8769531 L 11 6.5 C 11 5.6776486 10.322351 5 9.5 5 L 6.1230469 5 z " />
+</svg>

--- a/actions/16/path-flatten.svg
+++ b/actions/16/path-flatten.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg7435"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="path-flatten.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="19.279897"
+     inkscape:cx="5.472021"
+     inkscape:cy="12.785338"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="-1"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7435">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.5"
+       spacingy="0.5"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="2"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs7437">
+    <linearGradient
+       id="linearGradient963">
+      <stop
+         id="stop1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1847">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1839" />
+      <stop
+         offset="0.49771357"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1841" />
+      <stop
+         offset="0.74999994"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1843" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1845" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient963-1">
+      <stop
+         id="stop955"
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0" />
+      <stop
+         id="stop957"
+         style="stop-color:#ffffff;stop-opacity:0.40000001;"
+         offset="0" />
+      <stop
+         id="stop959"
+         style="stop-color:#ffffff;stop-opacity:0.60000002;"
+         offset="1" />
+      <stop
+         id="stop961"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         style="stop-color:#43d6b5;stop-opacity:1"
+         offset="0"
+         id="stop866" />
+      <stop
+         style="stop-color:#28bca3;stop-opacity:1"
+         offset="1"
+         id="stop868" />
+    </linearGradient>
+    <linearGradient
+       y2="47.013336"
+       y1=".985206"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(.48571543 0 0 .45629666 -34.78968 -5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="-61.562508"
+       x2="51.798126"
+       y1="-98.562508"
+       x1="51.798126"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,-0.689191,23.310812)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1697-2"
+       xlink:href="#linearGradient1847" />
+    <linearGradient
+       y2="-21.229681"
+       x2="26.950296"
+       y1="-42.231876"
+       x1="26.950296"
+       gradientTransform="matrix(0.52631574,0,0,0.52631574,-1.315788,22.684197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1695-1"
+       xlink:href="#linearGradient870" />
+    <linearGradient
+       y2="40.193295"
+       x2="23.99999"
+       y1="7.818294"
+       x1="23.99999"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,0.312062,5.309558)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1693-4"
+       xlink:href="#linearGradient963" />
+    <linearGradient
+       y2="21.282824"
+       x2="14.600296"
+       y1="2.6556277"
+       x1="14.600296"
+       gradientTransform="matrix(0.52631574,0,0,0.52631574,-0.815788,4.184197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1691-7"
+       xlink:href="#linearGradient870" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient963-1"
+       id="linearGradient4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,0.312062,5.309558)"
+       x1="23.99999"
+       y1="7.818294"
+       x2="23.99999"
+       y2="40.193295" />
+  </defs>
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="rect5505-21-8-4-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1691-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="M 1.5 5.5 C 0.946 5.5 0.5 5.946 0.5 6.5 L 0.5 14.5 C 0.5 15.054 0.946 15.5 1.5 15.5 L 9.5 15.5 C 10.054 15.5 10.5 15.054 10.5 14.5 L 10.5 11.476562 A 5.5000005 5.5000005 0 0 1 10 11.5 A 5.5000005 5.5000005 0 0 1 4.5 6 A 5.5000005 5.5000005 0 0 1 4.5234375 5.5 L 1.5 5.5 z " />
+  <path
+     id="rect6741-9-5-1"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient1693-4);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 1.5019531 6.4980469 L 1.5019531 14.498047 L 9.5019531 14.498047 L 9.5019531 12.480469 A 6.5 6.5 0 0 1 3.5195312 6.4980469 L 1.5019531 6.4980469 z " />
+  <path
+     id="path1"
+     style="opacity:1;fill:none;stroke:url(#linearGradient4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 9.5019531,12.480469 C 6.3053175,12.234618 3.7653824,9.6946825 3.5195312,6.4980469"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="display:inline;opacity:1;vector-effect:none;fill:url(#linearGradient1695-1);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-5"
+     d="M 15.5,6 A 5.5000005,5.5000019 0 1 1 4.499999,6 5.5000005,5.5000019 0 1 1 15.5,6 Z" />
+  <path
+     style="display:inline;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1697-2);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path8339-9"
+     d="m 14.499993,5.999999 a 4.4999993,4.4999996 0 1 1 -8.999998,0 4.4999993,4.4999996 0 1 1 8.999998,0 z" />
+  <path
+     id="path8335-7"
+     style="display:inline;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#007367;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 15.5,6 A 5.5000005,5.5000019 0 1 1 4.499999,6 5.5000005,5.5000019 0 1 1 15.5,6 Z M 1.5,5.5 c -0.554,0 -1,0.446 -1,1 v 8 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 11.476562 A 5.5000005,5.5000005 0 0 1 10,11.5 5.5000005,5.5000005 0 0 1 4.5,6 5.5000005,5.5000005 0 0 1 4.5234375,5.5 Z" />
+</svg>

--- a/actions/16/path-fracture.svg
+++ b/actions/16/path-fracture.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg7435"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="path-fracture.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="16.968634"
+     inkscape:cx="12.876699"
+     inkscape:cy="14.46787"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435" />
+  <defs
+     id="defs7437">
+    <linearGradient
+       id="linearGradient2690">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop2682" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop2684" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop2686" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop2688" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1847">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1839" />
+      <stop
+         offset="0.49771357"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1841" />
+      <stop
+         offset="0.74999994"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1843" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1845" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient963">
+      <stop
+         id="stop955"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop957"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop959"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop961"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         style="stop-color:#43d6b5;stop-opacity:1"
+         offset="0"
+         id="stop866" />
+      <stop
+         style="stop-color:#28bca3;stop-opacity:1"
+         offset="1"
+         id="stop868" />
+    </linearGradient>
+    <linearGradient
+       y2="47.013336"
+       y1=".985206"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(.48571543 0 0 .45629666 -34.78968 -5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="-61.562508"
+       x2="51.798126"
+       y1="-98.562508"
+       x1="51.798126"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,-0.689191,23.310812)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1697-3"
+       xlink:href="#linearGradient1847" />
+    <linearGradient
+       y2="-21.229681"
+       x2="26.950296"
+       y1="-42.231876"
+       x1="26.950296"
+       gradientTransform="matrix(0.52631574,0,0,0.52631574,-1.315788,22.684197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1695-9"
+       xlink:href="#linearGradient874" />
+    <linearGradient
+       y2="40.193295"
+       x2="23.99999"
+       y1="7.818294"
+       x1="23.99999"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,0.312062,5.309558)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1693-0"
+       xlink:href="#linearGradient963" />
+    <linearGradient
+       y2="21.282824"
+       x2="14.600296"
+       y1="2.6556277"
+       x1="14.600296"
+       gradientTransform="matrix(0.52631574,0,0,0.52631574,-0.815788,4.184197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1691-8"
+       xlink:href="#linearGradient874" />
+    <linearGradient
+       y2="21.282824"
+       x2="14.600296"
+       y1="2.6556277"
+       x1="14.600296"
+       gradientTransform="matrix(0.52631574,0,0,0.52631574,13.858345,3.8895357)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1691-8-2"
+       xlink:href="#linearGradient870" />
+    <linearGradient
+       y2="26.318295"
+       x2="23.99999"
+       y1="7.818294"
+       x1="23.99999"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,0.312062,5.309558)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2521"
+       xlink:href="#linearGradient2690" />
+  </defs>
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="10"
+     height="10"
+     rx="1"
+     ry="1"
+     x="0.5"
+     y="5.5"
+     id="rect5505-21-8-4-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1691-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+  <rect
+     width="8"
+     height="8"
+     x="1.5012512"
+     y="6.498745"
+     id="rect6741-9-5-5"
+     style="opacity:1;fill:none;stroke:url(#linearGradient1693-0);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="opacity:1;vector-effect:none;fill:url(#linearGradient1695-9);fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-9"
+     d="M 15.5,6 A 5.5000005,5.5000019 0 1 1 4.499999,6 5.5000005,5.5000019 0 1 1 15.5,6 Z" />
+  <path
+     style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1697-3);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path8339-6"
+     d="m 14.499993,5.999999 a 4.4999993,4.4999996 0 1 1 -8.999998,0 4.4999993,4.4999996 0 1 1 8.999998,0 z" />
+  <path
+     id="rect5505-21-8-4-8-5-8"
+     d="m 5.528129,6.498047 c 0.141277,1.237881 0.819621,2.478208 1.886532,3.170206 0.622588,0.405988 1.354411,0.707945 2.087292,0.794801 l -0.002,-3.965007 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2521);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="rect5505-21-8-1-25-0-4"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 10.160156,0.501953 A 5.5000005,5.5000019 0 0 0 4.525391,5.5 H 1.5 c -0.554,0 -1,0.446 -1,1 v 8 c 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 V 11.472656 A 5.5000005,5.5000019 0 0 0 15.5,6 5.5000005,5.5000019 0 0 0 10.160156,0.501953 Z M 4.525391,5.5 A 5.5000005,5.5000019 0 0 0 4.5,6 a 5.5000005,5.5000019 0 0 0 6,5.472656 V 6.5 c 0,-0.554 -0.446,-1 -1,-1 z" />
+</svg>

--- a/actions/16/path-split.svg
+++ b/actions/16/path-split.svg
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg7435"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="path-split.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     showguides="true"
+     inkscape:zoom="18.345852"
+     inkscape:cx="11.364967"
+     inkscape:cy="8.4760303"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.5"
+       spacingy="0.5"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="2"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs7437">
+    <linearGradient
+       id="linearGradient1847">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1839" />
+      <stop
+         offset="0.49771357"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1841" />
+      <stop
+         offset="0.74999994"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1843" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1845" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient963">
+      <stop
+         id="stop955"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop957"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop959"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop961"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="-61.562508"
+       x2="51.798126"
+       y1="-98.562508"
+       x1="51.798126"
+       gradientTransform="matrix(0.14412325,0,0,0.14412613,4.3753386,16.038135)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1697-2"
+       xlink:href="#linearGradient1847" />
+    <linearGradient
+       y2="-21.229681"
+       x2="26.950296"
+       y1="-42.231876"
+       x1="26.950296"
+       gradientTransform="matrix(0.38088868,0,0,0.38088868,3.3306065,16.554449)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1695-1"
+       xlink:href="#linearGradient874" />
+    <linearGradient
+       y2="40.193295"
+       x2="23.99999"
+       y1="7.818294"
+       x1="23.99999"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,4.8108108,-6.189187)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1693-4"
+       xlink:href="#linearGradient963" />
+    <linearGradient
+       y2="47.013336"
+       y1=".985206"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(.48571543 0 0 .45629666 -34.78968 -5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="21.282824"
+       x2="14.600296"
+       y1="2.6556277"
+       x1="14.600296"
+       gradientTransform="matrix(0.52631574,0,0,0.52631574,-0.815788,4.184197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient878"
+       xlink:href="#linearGradient874" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient874"
+       id="linearGradient2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.38088868,0,0,0.38088868,-3.6693917,23.553269)"
+       x1="26.950296"
+       y1="-42.231876"
+       x2="26.950296"
+       y2="-21.229681" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1847"
+       id="linearGradient3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.14412325,0,0,0.14412613,-2.6246597,23.036955)"
+       x1="51.798126"
+       y1="-98.562508"
+       x2="51.798126"
+       y2="-61.562508" />
+  </defs>
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="opacity:1;vector-effect:none;fill:url(#linearGradient1695-1);fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-5"
+     d="m 15.5,4.4802866 a 3.9802875,3.9802886 0 1 1 -7.9605749,0 3.9802875,3.9802886 0 1 1 7.9605749,0 z" />
+  <path
+     style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1697-2);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path8339-9"
+     d="m 14.499993,4.4990357 a 2.9995647,2.9996248 0 1 1 -5.9991285,0 2.9995647,2.9996248 0 1 1 5.9991285,0 z" />
+  <path
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-7"
+     d="m 15.5,4.4999053 a 4.0000007,4.0000122 0 1 1 -8.000001,0 4.0000007,4.0000122 0 1 1 8.000001,0 z" />
+  <path
+     style="vector-effect:none;fill:url(#linearGradient2);fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-5-8"
+     d="m 8.5000013,11.479106 a 3.9802875,3.9802886 0 1 1 -7.96057504,0 3.9802875,3.9802886 0 1 1 7.96057504,0 z" />
+  <path
+     style="vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path8339-9-6"
+     d="m 7.4999943,11.497855 a 2.9995647,2.9996248 0 1 1 -5.999129,0 2.9995647,2.9996248 0 1 1 5.999129,0 z" />
+  <path
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-7-5"
+     d="m 8.5000013,11.498725 a 4.0000007,4.0000122 0 1 1 -8.00000104,0 4.0000007,4.0000122 0 1 1 8.00000104,0 z" />
+</svg>

--- a/actions/24/path-cut.svg
+++ b/actions/24/path-cut.svg
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg7435"
+   sodipodi:docname="path-cut.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="18.058328"
+     inkscape:cx="14.591606"
+     inkscape:cy="20.461474"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435" />
+  <defs
+     id="defs7437">
+    <linearGradient
+       id="linearGradient939">
+      <stop
+         id="stop931"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop933"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop935"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop937"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1847">
+      <stop
+         id="stop1839"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1841"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.49999997" />
+      <stop
+         id="stop1843"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.74999994" />
+      <stop
+         id="stop1845"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1847"
+       id="linearGradient1697-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31231236,0,0,0.31231203,-0.43993651,34.002483)"
+       x1="51.798126"
+       y1="-99.267654"
+       x2="51.798126"
+       y2="-60.844543" />
+    <linearGradient
+       xlink:href="#linearGradient874"
+       id="linearGradient1695-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71770322,0,0,0.71753731,-0.43061789,31.745917)"
+       x1="26.950296"
+       y1="-42.231876"
+       x2="26.950296"
+       y2="-21.229681" />
+    <linearGradient
+       xlink:href="#linearGradient939"
+       id="linearGradient1693-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32432433,0,0,0.32432433,0.7162159,7.7162204)"
+       x1="23.99999"
+       y1="7.0416536"
+       x2="23.99999"
+       y2="40.958321" />
+    <linearGradient
+       id="linearGradient874"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop870" />
+      <stop
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop872" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient870"
+       id="linearGradient878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73684202,0,0,0.73684202,-0.3421032,6.6578757)"
+       x1="14.600296"
+       y1="2.6556277"
+       x2="14.600296"
+       y2="21.282824" />
+    <linearGradient
+       gradientTransform="matrix(0.02485212,0,0,0.0082353,-0.48225013,18.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,9.761206,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,7.238793,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         style="stop-color:#43d6b5;stop-opacity:1"
+         offset="0"
+         id="stop866" />
+      <stop
+         style="stop-color:#28bca3;stop-opacity:1"
+         offset="1"
+         id="stop868" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 23,10.000796 a 8.0000001,7.9991057 0 1 1 -16,0 8.0000001,7.9991057 0 1 1 16,0 z"
+     id="path8335-9-5-5-3"
+     style="opacity:0.05;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     d="m 22.5,10.000796 a 7.5000002,7.4982683 0 1 1 -14.9999999,0 7.5000002,7.4982683 0 1 1 14.9999999,0 z"
+     id="path8335-9-5-5"
+     style="opacity:0.07;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     d="m 22.5,9 a 7.5000002,7.4982683 0 1 1 -15,0 7.5000002,7.4982683 0 1 1 15,0 z"
+     id="path8335-9-5"
+     style="opacity:1;vector-effect:none;fill:url(#linearGradient1695-1);fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     d="m 21.499999,8.997998 a 6.4999998,6.4999935 0 1 1 -12.9999991,0 6.4999998,6.4999935 0 1 1 12.9999991,0 z"
+     id="path8339-9"
+     style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1697-2);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 22.5,9.000001 a 7.5000002,7.5000021 0 1 1 -15,0 7.5000002,7.5000021 0 1 1 15,0 z"
+     id="path8335-7"
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     id="rect5505-21-8-1-25-1"
+     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#28bca3;stroke-linecap:round;stroke-linejoin:round;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="M 3 8 C 1.9006486 8 1 8.9006486 1 10 L 1 21 C 1 22.099351 1.9006486 23 3 23 L 14 23 C 15.099351 23 16 22.099351 16 21 L 16 17.947266 C 15.671547 17.983938 15.337881 18.001953 15 18.001953 L 15 21 C 15 21.562649 14.562649 22 14 22 L 3 22 C 2.4373514 22 2 21.562649 2 21 L 2 10 C 2 9.4373514 2.4373514 9 3 9 L 6 9 C 5.999922 8.6621226 6.0180905 8.3284568 6.0546875 8 L 3 8 z M 9.0820312 8 C 9.0283472 8.3249648 8.9999213 8.6590154 9 9 L 14 9 C 14.562649 9 15 9.4373514 15 10 L 15 15.001953 C 15.340997 15.001953 15.675047 14.973696 16 14.919922 L 16 10 C 16 8.9006486 15.099351 8 14 8 L 9.0820312 8 z " />
+</svg>

--- a/actions/24/path-flatten.svg
+++ b/actions/24/path-flatten.svg
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg7435"
+   sodipodi:docname="path-flatten.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="20.172943"
+     inkscape:cx="13.062051"
+     inkscape:cy="9.6416274"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.5"
+       spacingy="0.5"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="2"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs7437">
+    <linearGradient
+       id="linearGradient939">
+      <stop
+         id="stop1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient939-1">
+      <stop
+         id="stop931"
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0" />
+      <stop
+         id="stop933"
+         style="stop-color:#ffffff;stop-opacity:0.40000001;"
+         offset="0" />
+      <stop
+         id="stop935"
+         style="stop-color:#ffffff;stop-opacity:0.60000002;"
+         offset="1" />
+      <stop
+         id="stop937"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1847">
+      <stop
+         id="stop1839"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1841"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.49999997" />
+      <stop
+         id="stop1843"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.74999994" />
+      <stop
+         id="stop1845"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1847"
+       id="linearGradient1697-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31231236,0,0,0.31231203,-0.43993651,34.002483)"
+       x1="51.798126"
+       y1="-99.267654"
+       x2="51.798126"
+       y2="-60.844543" />
+    <linearGradient
+       xlink:href="#linearGradient870"
+       id="linearGradient1695-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71770322,0,0,0.71753731,-0.43061789,31.745917)"
+       x1="26.950296"
+       y1="-42.231876"
+       x2="26.950296"
+       y2="-21.229681" />
+    <linearGradient
+       xlink:href="#linearGradient939"
+       id="linearGradient1693-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32432433,0,0,0.32432433,0.7162159,7.7162204)"
+       x1="23.99999"
+       y1="7.0416536"
+       x2="23.99999"
+       y2="40.958321" />
+    <linearGradient
+       id="linearGradient874"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       gradientUnits="userSpaceOnUse"
+       x1="25.132275"
+       x2="25.132275"
+       y1="0.98520601"
+       y2="47.013336">
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0"
+         stop-color="#f4f4f4"
+         id="stop870" />
+      <stop
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1"
+         stop-color="#dbdbdb"
+         id="stop872" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient870"
+       id="linearGradient878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73684202,0,0,0.73684202,-0.3421032,6.6578757)"
+       x1="14.600296"
+       y1="2.6556277"
+       x2="14.600296"
+       y2="21.282824" />
+    <linearGradient
+       gradientTransform="matrix(0.02485212,0,0,0.0082353,-0.48225013,18.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,9.761206,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,7.238793,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         style="stop-color:#43d6b5;stop-opacity:1"
+         offset="0"
+         id="stop866" />
+      <stop
+         style="stop-color:#28bca3;stop-opacity:1"
+         offset="1"
+         id="stop868" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient939-1"
+       id="linearGradient4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32432433,0,0,0.32432433,0.7162159,7.7162204)"
+       x1="23.99999"
+       y1="7.0416536"
+       x2="23.99999"
+       y2="40.958321" />
+  </defs>
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 23,10.000796 a 8.0000001,7.9991057 0 1 1 -16,0 8.0000001,7.9991057 0 1 1 16,0 z"
+     id="path8335-9-5-5-3"
+     style="opacity:0.05;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     d="m 22.5,10.000796 a 7.5000002,7.4982683 0 1 1 -14.9999999,0 7.5000002,7.4982683 0 1 1 14.9999999,0 z"
+     id="path8335-9-5-5"
+     style="opacity:0.07;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;marker:none"
+     id="rect2879"
+     y="22"
+     x="2.499999"
+     height="2"
+     width="12" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2881"
+     d="m 2.5,22.000085 c 0,0 0,1.999891 0,1.999891 C 1.879527,24.003776 1,23.551901 1,22.999901 1,22.447902 1.6924,22.000085 2.5,22.000085 Z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2883"
+     d="m 14.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <path
+     id="rect5505-21-8-4-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient878);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+     d="M 3 8.5 C 2.169 8.5 1.5 9.169 1.5 10 L 1.5 21 C 1.5 21.831 2.169 22.5 3 22.5 L 14 22.5 C 14.831 22.5 15.5 21.831 15.5 21 L 15.5 16.484375 A 7.5000002 7.5000021 0 0 1 7.5 9 A 7.5000002 7.5000021 0 0 1 7.515625 8.5 L 3 8.5 z " />
+  <path
+     id="rect6741-9-5-1"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient1693-4);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 3.25 9.5 C 2.8345 9.5 2.5 9.8345 2.5 10.25 L 2.5 20.75 C 2.5 21.1655 2.8345 21.5 3.25 21.5 L 13.75 21.5 C 14.1655 21.5 14.5 21.1655 14.5 20.75 L 14.5 17.488281 A 8.500001 8.4999737 0 0 1 6.5136719 9.5 L 3.25 9.5 z " />
+  <path
+     id="rect5505-21-8-1-25-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#007367;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;fill-opacity:1"
+     d="M 3 8.5 C 2.169 8.5 1.5 9.169 1.5 10 L 1.5 21 C 1.5 21.831 2.169 22.5 3 22.5 L 14 22.5 C 14.831 22.5 15.5 21.831 15.5 21 L 15.5 16.484375 A 7.5000002 7.5000021 0 0 1 7.5 9 A 7.5000002 7.5000021 0 0 1 7.515625 8.5 L 3 8.5 z " />
+  <path
+     d="m 22.5,9 a 7.5000002,7.4982683 0 1 1 -15,0 7.5000002,7.4982683 0 1 1 15,0 z"
+     id="path8335-9-5"
+     style="opacity:1;vector-effect:none;fill:url(#linearGradient1695-1);fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     d="m 21.499999,8.997998 a 6.4999998,6.4999935 0 1 1 -12.9999991,0 6.4999998,6.4999935 0 1 1 12.9999991,0 z"
+     id="path8339-9"
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1697-2);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 22.5,9.000001 a 7.5000002,7.5000021 0 1 1 -15,0 7.5000002,7.5000021 0 1 1 15,0 z"
+     id="path8335-7"
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#007367;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     id="path1"
+     style="opacity:1;fill:none;stroke:url(#linearGradient4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 14.5,17.488281 C 10.197701,17.23521 6.7656784,13.802348 6.5136719,9.5"
+     sodipodi:nodetypes="cc" />
+</svg>

--- a/actions/24/path-fracture.svg
+++ b/actions/24/path-fracture.svg
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg7435"
+   sodipodi:docname="path-fracture.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="20.204848"
+     inkscape:cx="9.1314716"
+     inkscape:cy="14.42723"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435" />
+  <defs
+     id="defs7437">
+    <linearGradient
+       id="linearGradient939">
+      <stop
+         id="stop931"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop933"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop935"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop937"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1847">
+      <stop
+         id="stop1839"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1841"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.49999997" />
+      <stop
+         id="stop1843"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.74999994" />
+      <stop
+         id="stop1845"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         id="stop866"
+         offset="0"
+         style="stop-color:#43d6b5;stop-opacity:1" />
+      <stop
+         id="stop868"
+         offset="1"
+         style="stop-color:#28bca3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027-3"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02485212,0,0,0.0082353,-0.4822501,18.980547)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024-3"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,9.761206,18.980564)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021-2"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,7.238793,18.980564)" />
+    <linearGradient
+       y2="21.282824"
+       x2="14.600296"
+       y1="2.6556277"
+       x1="14.600296"
+       gradientTransform="matrix(0.73684202,0,0,0.73684202,-0.3421032,6.6578756)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient878"
+       xlink:href="#linearGradient874" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop875"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="40.958321"
+       x2="23.99999"
+       y1="7.0416536"
+       x1="23.99999"
+       gradientTransform="matrix(0.32432433,0,0,0.32432433,0.7162159,7.7162203)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1693-4-1"
+       xlink:href="#linearGradient939" />
+    <linearGradient
+       y2="-21.229681"
+       x2="26.950296"
+       y1="-42.231876"
+       x1="26.950296"
+       gradientTransform="matrix(0.71770322,0,0,0.71753731,-0.4306179,31.745917)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1695-1"
+       xlink:href="#linearGradient874" />
+    <linearGradient
+       y2="-60.844543"
+       x2="51.798126"
+       y1="-99.267654"
+       x1="51.798126"
+       gradientTransform="matrix(0.31231236,0,0,0.31231203,-0.4399365,34.002483)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1697-2-3"
+       xlink:href="#linearGradient1847" />
+    <linearGradient
+       y2="22.145414"
+       x2="-25.561935"
+       y1="-7.7227783"
+       x1="-25.561935"
+       gradientTransform="matrix(0.73684202,0,0,0.73684202,33.657897,6.6578761)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1035"
+       xlink:href="#linearGradient870" />
+    <linearGradient
+       y2="40.958321"
+       x2="23.99999"
+       y1="7.0416536"
+       x1="23.99999"
+       gradientTransform="matrix(0.32432433,0,0,0.32432433,0.7162159,7.7160305)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1693-4-1-0"
+       xlink:href="#linearGradient939" />
+  </defs>
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="12"
+     height="2"
+     x="2.499999"
+     y="22"
+     id="rect2879-6"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3027-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;marker:none" />
+  <path
+     d="m 2.5,22.000085 c 0,0 0,1.999891 0,1.999891 C 1.879527,24.003776 1,23.551901 1,22.999901 1,22.447902 1.6924,22.000085 2.5,22.000085 Z"
+     id="path2881-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3024-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 14.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z"
+     id="path2883-8"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3021-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <rect
+     width="14"
+     height="14"
+     rx="1.5"
+     ry="1.5"
+     x="1.5"
+     y="8.5"
+     id="rect5505-21-8-4-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient878);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+  <rect
+     width="12"
+     height="12"
+     x="2.5"
+     y="9.5"
+     id="rect6741-9-5-1-7"
+     style="opacity:1;fill:none;stroke:url(#linearGradient1693-4-1);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="0.75"
+     ry="0.75" />
+  <path
+     style="opacity:0.05;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-5-5-3-2"
+     d="m 23,10.000796 a 8.0000001,7.9991057 0 1 1 -16,0 8.0000001,7.9991057 0 1 1 16,0 z" />
+  <path
+     style="opacity:0.07000002;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-5-5-0"
+     d="m 22.5,10.000796 a 7.5000002,7.4982683 0 1 1 -14.9999999,0 7.5000002,7.4982683 0 1 1 14.9999999,0 z" />
+  <path
+     style="opacity:1;vector-effect:none;fill:url(#linearGradient1695-1);fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-5"
+     d="m 22.5,8.9999999 a 7.5000002,7.4982683 0 1 1 -15,0 7.5000002,7.4982683 0 1 1 15,0 z" />
+  <path
+     style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1697-2-3);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path8339-9-2"
+     d="m 21.499999,8.9979979 a 6.4999998,6.4999935 0 1 1 -12.9999991,0 6.4999998,6.4999935 0 1 1 12.9999991,0 z" />
+  <path
+     id="rect6741-9-5-1-7-6"
+     d="M 8.5273438 9.5 A 6.4999998 6.4999935 0 0 0 14.5 15.470703 L 14.5 10.25 C 14.5 9.8345 14.1655 9.5 13.75 9.5 L 8.5273438 9.5 z "
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient1693-4-1-0);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     id="rect5505-21-8-1-25-1-9"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 15.216797,1.5019531 A 7.5000002,7.5000021 0 0 0 7.5253906,8.5 H 3 C 2.169,8.5 1.5,9.169 1.5,10 v 11 c 0,0.831 0.669,1.5 1.5,1.5 h 11 c 0.831,0 1.5,-0.669 1.5,-1.5 V 16.482422 A 7.5000002,7.5000021 0 0 0 22.5,9 7.5000002,7.5000021 0 0 0 15.216797,1.5019531 Z M 7.5253906,8.5 A 7.5000002,7.5000021 0 0 0 7.5,9 a 7.5000002,7.5000021 0 0 0 8,7.484375 V 10 C 15.5,9.169 14.831,8.5 14,8.5 Z" />
+</svg>

--- a/actions/24/path-split.svg
+++ b/actions/24/path-split.svg
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg7435"
+   height="24"
+   width="24"
+   version="1.1"
+   sodipodi:docname="path-split.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     showguides="true"
+     inkscape:zoom="16.390685"
+     inkscape:cx="13.574784"
+     inkscape:cy="23.702488"
+     inkscape:window-width="1344"
+     inkscape:window-height="770"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7435">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.5"
+       spacingy="0.5"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="2"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs7437">
+    <linearGradient
+       id="linearGradient1847">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1839" />
+      <stop
+         offset="0.49771357"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1841" />
+      <stop
+         offset="0.74999994"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1843" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1845" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient963">
+      <stop
+         id="stop955"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop957"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop959"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop961"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="-61.562508"
+       x2="51.798126"
+       y1="-98.562508"
+       x1="51.798126"
+       gradientTransform="matrix(0.21617519,0,0,0.21617555,6.3136921,24.306762)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1697-2"
+       xlink:href="#linearGradient1847" />
+    <linearGradient
+       y2="-21.229681"
+       x2="26.950296"
+       y1="-42.231876"
+       x1="26.950296"
+       gradientTransform="matrix(0.52630668,0,0,0.52630668,5.6845029,23.68391)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1695-1"
+       xlink:href="#linearGradient874" />
+    <linearGradient
+       y2="40.193295"
+       x2="23.99999"
+       y1="7.818294"
+       x1="23.99999"
+       gradientTransform="matrix(0.21621622,0,0,0.21621622,4.8108108,-6.189187)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1693-4"
+       xlink:href="#linearGradient963" />
+    <linearGradient
+       y2="47.013336"
+       y1="0.98520601"
+       x2="25.132275"
+       x1="25.132275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48571543,0,0,0.45629666,-34.78968,-5.734851)"
+       id="linearGradient874">
+      <stop
+         id="stop870"
+         stop-color="#f4f4f4"
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop872"
+         stop-color="#dbdbdb"
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="21.282824"
+       x2="14.600296"
+       y1="2.6556277"
+       x1="14.600296"
+       gradientTransform="matrix(0.52631574,0,0,0.52631574,-0.815788,4.184197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient878"
+       xlink:href="#linearGradient874" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient874"
+       id="linearGradient1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.52630668,0,0,0.52630668,-4.3154898,33.683856)"
+       x1="26.950296"
+       y1="-42.231876"
+       x2="26.950296"
+       y2="-21.229681" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1847"
+       id="linearGradient2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21617519,0,0,0.21617555,-3.6863006,34.306708)"
+       x1="51.798126"
+       y1="-98.562508"
+       x2="51.798126"
+       y2="-61.562508" />
+  </defs>
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 23.5,7.4985451 a 6.5,6.4992733 0 1 1 -13,0 6.5,6.4992733 0 1 1 13,0 z"
+     id="path8335-9-5-5-3"
+     style="opacity:0.05;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     d="m 23,7.4986145 a 6,5.9986145 0 1 1 -12,0 6,5.9986145 0 1 1 12,0 z"
+     id="path8335-9-5-5"
+     style="opacity:0.07;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     d="m 13.5,17.498545 a 6.5,6.4992733 0 1 1 -13,0 6.5,6.4992733 0 1 1 13,0 z"
+     id="path8335-9-5-5-3-2"
+     style="opacity:0.05;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     d="m 13,17.498615 a 6,5.9986145 0 1 1 -12,0 6,5.9986145 0 1 1 12,0 z"
+     id="path8335-9-5-5-6"
+     style="opacity:0.07;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     style="opacity:1;vector-effect:none;fill:url(#linearGradient1695-1);fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-5"
+     d="m 22.500001,7.0000002 a 5.499906,5.4999076 0 1 1 -10.999812,0 5.499906,5.4999076 0 1 1 10.999812,0 z" />
+  <path
+     style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1697-2);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path8339-9"
+     d="m 21.499993,6.9992058 a 4.4991455,4.4991531 0 1 1 -8.998291,0 4.4991455,4.4991531 0 1 1 8.998291,0 z" />
+  <path
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-7"
+     d="m 22.499999,7.0004016 a 5.4999998,5.4999645 0 1 1 -10.999999,0 5.4999998,5.4999645 0 1 1 10.999999,0 z" />
+  <path
+     style="vector-effect:none;fill:url(#linearGradient1);fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-9-5-1"
+     d="m 12.500008,16.999946 a 5.499906,5.4999076 0 1 1 -10.999812,0 5.499906,5.4999076 0 1 1 10.999812,0 z" />
+  <path
+     style="vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient2);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path8339-9-4"
+     d="m 11.5,16.999151 a 4.4991455,4.4991531 0 1 1 -8.998291,0 4.4991455,4.4991531 0 1 1 8.998291,0 z" />
+  <path
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path8335-7-7"
+     d="m 12.500006,17.000347 a 5.4999998,5.4999645 0 1 1 -10.999999,0 5.4999998,5.4999645 0 1 1 10.999999,0 z" />
+</svg>

--- a/actions/symbolic/path-cut-symbolic.svg
+++ b/actions/symbolic/path-cut-symbolic.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg7435"
+   sodipodi:docname="path-cut-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="29.387258"
+     inkscape:cx="9.8512082"
+     inkscape:cy="7.4692235"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435">
+    <inkscape:grid
+       id="grid3"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.5"
+       spacingy="0.5"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="2"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs7437" />
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="rect5505-21-8-4-7-5-7-2-1-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+     d="M 10.173828 0.001953125 C 6.7932183 -0.096029595 3.999683 2.6179697 4 6 C 3.99852 9.3147596 6.6852433 12.001953 10 12.001953 C 13.314757 12.001953 16.001482 9.3147596 16 6 C 16.000304 2.7537646 13.4187 0.096002275 10.173828 0.001953125 z M 10.146484 1.0019531 C 12.849761 1.0812097 15.000104 3.2955606 15 6 C 15.0012 8.7622996 12.762297 11.001953 10 11.001953 C 7.2377028 11.001953 4.9987647 8.7622996 5 6 C 4.9998927 3.1811133 7.3288084 0.91937131 10.146484 1.0019531 z M 1 5 C 0.446 5 0 5.446 0 6 L 0 15 C 0 15.554 0.446 16 1 16 L 10 16 C 10.554 16 11 15.554 11 15 L 11 12.927734 A 6.9999995 7 0 0 1 10 13 L 10 14.5 C 10 14.777 9.777 15 9.5 15 L 1.5 15 C 1.223 15 1 14.777 1 14.5 L 1 6.5 C 1 6.223 1.223 6 1.5 6 L 3 6 A 6.9999995 7 0 0 1 3.0722656 5 L 1 5 z M 6.1269531 5 A 4 4.0000005 0 0 0 6 6 L 9.5 6 C 9.777 6 10 6.223001 10 6.5 L 10 10 A 4 4.0000005 0 0 0 11 9.8730469 L 11 6 C 11 5.446 10.554 5 10 5 L 6.1269531 5 z " />
+</svg>

--- a/actions/symbolic/path-flatten-symbolic.svg
+++ b/actions/symbolic/path-flatten-symbolic.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg7435"
+   sodipodi:docname="path-flatten-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="43.328825"
+     inkscape:cx="5.1351496"
+     inkscape:cy="12.566692"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435"
+     showgrid="true">
+    <inkscape:grid
+       id="grid15"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.5"
+       spacingy="0.5"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="2"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs7437">
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect16"
+       is_visible="true"
+       lpeversion="1"
+       nodesatellites_param="F,0,0,1,0,1,0,1 @ F,0,0,1,0,1,0,1 @ F,0,0,1,0,1,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 | F,0,0,1,0,0.5,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0.5,0,1 @ F,0,0,1,0,0.5,0,1"
+       radius="0"
+       unit="px"
+       method="auto"
+       mode="F"
+       chamfer_steps="1"
+       flexible="false"
+       use_knot_distance="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
+  </defs>
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path15"
+     style="display:inline;opacity:1;fill:#555761;fill-opacity:1;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;paint-order:fill markers stroke"
+     d="M 10.5,0 A 5.5,5.5 0 0 0 5,5.5 5.5,5.5 0 0 0 10.5,11 5.5,5.5 0 0 0 16,5.5 5.5,5.5 0 0 0 10.5,0 Z m 0,1 A 4.5,4.5 0 0 1 15,5.5 4.5,4.5 0 0 1 10.5,10 4.5,4.5 0 0 1 6,5.5 4.5,4.5 0 0 1 10.5,1 Z M 1,6 A 1,1 0 0 0 0,7 v 8 a 1,1 0 0 0 1,1 h 8 a 1,1 0 0 0 1,-1 V 11.980469 C 6.8048076,11.733829 4.2661708,9.1951924 4.0195312,6 Z M 1.5,7 H 3.1523438 C 3.7537424,9.9448588 6.0551412,12.246257 9,12.847656 V 14.5 A 0.5,0.5 0 0 1 8.5,15 h -7 A 0.5,0.5 0 0 1 1,14.5 v -7 A 0.5,0.5 0 0 1 1.5,7 Z" />
+  <path
+     id="path20"
+     style="display:inline;opacity:0.25;fill:#555761;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;paint-order:fill markers stroke"
+     d="M 10.5 1 A 4.5 4.5 0 0 0 6 5.5 A 4.5 4.5 0 0 0 10.5 10 A 4.5 4.5 0 0 0 15 5.5 A 4.5 4.5 0 0 0 10.5 1 z M 1.5 7 A 0.5 0.5 0 0 0 1 7.5 L 1 14.5 A 0.5 0.5 0 0 0 1.5 15 L 8.5 15 A 0.5 0.5 0 0 0 9 14.5 L 9 12.847656 C 6.0551412 12.246257 3.7537423 9.9448588 3.1523438 7 L 1.5 7 z " />
+</svg>

--- a/actions/symbolic/path-fracture-symbolic.svg
+++ b/actions/symbolic/path-fracture-symbolic.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg7435"
+   sodipodi:docname="path-fracture-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="2.9419743"
+     inkscape:cx="2.5493084"
+     inkscape:cy="-3.229124"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435" />
+  <defs
+     id="defs7437" />
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 1,5 C 0.446,5 0,5.446 0,6 v 9 c 0,0.554 0.446,1 1,1 h 9 c 0.554,0 1,-0.446 1,-1 V 6 C 11,5.446 10.554,5 10,5 Z m 0.5,1 h 8 C 9.777,6 10,6.223001 10,6.5 v 8 C 10,14.777 9.777,15 9.5,15 h -8 C 1.223,15 1,14.777 1,14.5 v -8 C 1,6.223 1.223,6 1.5,6 Z M 10.173828,0.001954 A 6.0000006,6.0000022 0 0 0 4,6 6.0000006,6.0000022 0 1 0 16,6 6.0000006,6.0000022 0 0 0 10.173828,0.001954 Z m -0.02734,1 A 5.0000005,5.0000018 0 0 1 15,6 5.0000005,5.0000018 0 1 1 5,6 5.0000005,5.0000018 0 0 1 10.146484,1.001954 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect5505-21-8-4-7-5-7-2-7" />
+</svg>

--- a/actions/symbolic/path-split-symbolic.svg
+++ b/actions/symbolic/path-split-symbolic.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg7435"
+   sodipodi:docname="path-split-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     showguides="true"
+     inkscape:zoom="14.156332"
+     inkscape:cx="-2.0132333"
+     inkscape:cy="11.408322"
+     inkscape:window-width="1440"
+     inkscape:window-height="784"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7435">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.5"
+       spacingy="0.5"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="2"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs7437" />
+  <metadata
+     id="metadata7440">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path8335-7-6-2-0"
+     style="opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="M 11.5,0 C 9.020641,0 7,2.0206412 7,4.5 7,6.979359 9.020641,9 11.5,9 13.979359,9 16,6.979359 16,4.5 16,2.0206412 13.979359,0 11.5,0 Z m 0,1 C 13.438919,1 15,2.5610808 15,4.5 15,6.438919 13.438919,8 11.5,8 9.561081,8 8,6.438919 8,4.5 8,2.5610808 9.561081,1 11.5,1 Z m -7,6 C 2.020641,7 0,9.0206412 0,11.5 0,13.979359 2.020641,16 4.5,16 6.979359,16 9,13.979359 9,11.5 9,9.0206412 6.979359,7 4.5,7 Z m 0,1 C 6.438919,8 8,9.5610808 8,11.5 8,13.438919 6.438919,15 4.5,15 2.561081,15 1,13.438919 1,11.5 1,9.5610808 2.561081,8 4.5,8 Z"
+     sodipodi:nodetypes="ssssssssssssssssssss" />
+</svg>


### PR DESCRIPTION
This pull request includes the `path-cut`, `path-flatten`, `path-fracture`and `path-split` icons used in the Inkscape Path menu, in 16px and 24px sizes as well as a symbolic version.

In the `path-cut` icon, the square is shown only as a stroke because Inkscape deletes the fill when the "Cut Path" menu item is selected. All other icons use filled shapes only.