### PR TITLE
metainfo: Correct position of translate tag

### DIFF
--- a/data/icons.metainfo.xml.in
+++ b/data/icons.metainfo.xml.in
@@ -29,8 +29,8 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
-    <release version="8.2.0" date="2025-10-31" urgency="medium" translate="no">
-      <description>
+    <release version="8.2.0" date="2025-10-31" urgency="medium">
+      <description translate="no">
         <p>Additions:</p>
         <ul>
           <li>`start-here`</li>
@@ -64,8 +64,8 @@
       </issues>
     </release>
 
-    <release version="8.1.0" date="2024-10-23" urgency="medium" translate="no">
-      <description>
+    <release version="8.1.0" date="2024-10-23" urgency="medium">
+      <description translate="no">
         <p>Additions:</p>
         <ul>
           <li>import and export actions at 16px</li>
@@ -91,8 +91,8 @@
       </issues>
     </release>
 
-    <release version="8.0.0" date="2024-05-06" urgency="medium" translate="no">
-      <description>
+    <release version="8.0.0" date="2024-05-06" urgency="medium">
+      <description translate="no">
         <p>Additions:</p>
         <ul>
           <li>`preferences-desktop-wallpaper` is now a unique icon from `preferences-desktop` and features a colorful paint roller design</li>
@@ -134,8 +134,8 @@
       </issues>
     </release>
 
-    <release version="7.3.1" date="2023-08-08" urgency="medium" translate="no">
-      <description>
+    <release version="7.3.1" date="2023-08-08" urgency="medium">
+      <description translate="no">
         <p>Removals:</p>
         <ul>
           <li>non-fd.o "bluetooth-*", "microphone-sensitivity-*", and "night-light" symbolic panel icons</li>
@@ -154,8 +154,8 @@
       </issues>
     </release>
 
-    <release version="7.3.0" date="2023-05-02" urgency="medium" translate="no">
-      <description>
+    <release version="7.3.0" date="2023-05-02" urgency="medium">
+      <description translate="no">
         <p>Additions:</p>
         <ul>
           <li>"list-drag-handle-symbolic" as used in draggable list box rows</li>


### PR DESCRIPTION
Fixes #1397

Works confirmed:

```diff
ryo@fedora-host:~/work/elementary/icons (ryonakano/metainfo-fix-translate-tag-pos)$ ninja -C builddir/ extra-pot
ninja: Entering directory `builddir/'
[0/1] Running external command extra-pot
ryo@fedora-host:~/work/elementary/icons (ryonakano/metainfo-fix-translate-tag-pos *)$ git diff | head -n 50
diff --git a/po/extra.pot b/po/extra.pot
index 029aa8fd..ce9601a3 100644
--- a/po/extra.pot
+++ b/po/extra.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-31 04:43+0000\n"
+"POT-Creation-Date: 2026-06-06 23:15+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,277 +31,6 @@ msgid ""
 "its desktop environment: Pantheon."
 msgstr ""

-#: data/icons.metainfo.xml.in:34 data/icons.metainfo.xml.in:69
-#: data/icons.metainfo.xml.in:96 data/icons.metainfo.xml.in:159
-msgid "Additions:"
-msgstr ""
-
-#: data/icons.metainfo.xml.in:36
-msgid "`start-here`"
-msgstr ""
-
-#: data/icons.metainfo.xml.in:37
-msgid "Tool icons for Inkscape"
-msgstr ""
-
-#: data/icons.metainfo.xml.in:38
-msgid "Add Adwaita as a fallback for icon names"
-msgstr ""
-
-#: data/icons.metainfo.xml.in:39
-msgid ""
-"16px `accessories-character-map`, `document-properties`, `preferences-system`"
-msgstr ""
-
-#: data/icons.metainfo.xml.in:40
-msgid "24px `list-add-symbolic`"
-msgstr ""
-
-#: data/icons.metainfo.xml.in:42 data/icons.metainfo.xml.in:76
-#: data/icons.metainfo.xml.in:108 data/icons.metainfo.xml.in:144
-#: data/icons.metainfo.xml.in:172
-msgid "Updated families:"
-msgstr ""
-
-#: data/icons.metainfo.xml.in:44
ryo@fedora-host:~/work/elementary/icons (ryonakano/metainfo-fix-translate-tag-pos *)$
```