### PR TITLE
Remove broken symlinks

### DIFF
--- a/apps/16/calendar.svg
+++ b/apps/16/calendar.svg
@@ -1,1 +1,0 @@
-office-calendar.svg

--- a/mimes/symbolic/text-calendar-symbolic.svg
+++ b/mimes/symbolic/text-calendar-symbolic.svg
@@ -1,1 +1,0 @@
-../../apps/symbolic/office-calendar-symbolic.svg

--- a/mimes/symbolic/vcalendar-symbolic.svg
+++ b/mimes/symbolic/vcalendar-symbolic.svg
@@ -1,1 +1,0 @@
-text-calendar-symbolic.svg


### PR DESCRIPTION
Follow-up for https://github.com/elementary/icons/pull/1435.

NixOS packaging requires no broken symlinks...

```
error: builder for '/nix/store/z3amj0jhnqif2w85zl57gk2wpbwy1p0x-elementary-icon-theme-9.0.0.drv' failed with exit code 1;
       > ERROR: noBrokenSymlinks: the symlink /nix/store/cnn29vlw3w97gnmk4bycg2rahld787kr-elementary-icon-theme-9.0.0/share/icons/elementary/apps/16/calendar.svg points to a missing target: /nix/store/cnn29vlw3w97gnmk4bycg2rahld787kr-elementary-icon-theme-9.0.0/share/icons/elementary/apps/16/office-calendar.svg
       > ERROR: noBrokenSymlinks: the symlink /nix/store/cnn29vlw3w97gnmk4bycg2rahld787kr-elementary-icon-theme-9.0.0/share/icons/elementary/mimes/symbolic/text-calendar-symbolic.svg points to a missing target: /nix/store/cnn29vlw3w97gnmk4bycg2rahld787kr-elementary-icon-theme-9.0.0/share/icons/elementary/apps/symbolic/office-calendar-symbolic.svg
       > ERROR: noBrokenSymlinks: the symlink /nix/store/cnn29vlw3w97gnmk4bycg2rahld787kr-elementary-icon-theme-9.0.0/share/icons/elementary/mimes/symbolic/vcalendar-symbolic.svg points to a missing target: /nix/store/cnn29vlw3w97gnmk4bycg2rahld787kr-elementary-icon-theme-9.0.0/share/icons/elementary/mimes/symbolic/text-calendar-symbolic.svg
       > ERROR: noBrokenSymlinks: found 3 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
       For full logs, run:
         nix log /nix/store/z3amj0jhnqif2w85zl57gk2wpbwy1p0x-elementary-icon-theme-9.0.0.drv
```